### PR TITLE
fix(create-app): add process to context

### DIFF
--- a/packages/create-app/src/files.ts
+++ b/packages/create-app/src/files.ts
@@ -34,7 +34,7 @@ export const localContextText = `\
 import type { CommandContext } from "@stricli/core";
 
 export interface LocalContext extends CommandContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 
@@ -53,7 +53,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/additional features/without auto-complete.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/additional features/without auto-complete.txt
@@ -200,7 +200,7 @@ export default async function(this: LocalContext, flags: SubdirCommandFlags): Pr
 import type { CommandContext } from "@stricli/core";
 
 export interface LocalContext extends CommandContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom bin command.txt
@@ -226,7 +226,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom metadata.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom metadata.txt
@@ -226,7 +226,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom name and bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom name and bin command.txt
@@ -226,7 +226,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom name.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom name.txt
@@ -226,7 +226,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/with default flags.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/with default flags.txt
@@ -226,7 +226,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/additional features/without auto-complete.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/additional features/without auto-complete.txt
@@ -200,7 +200,7 @@ export default async function(this: LocalContext, flags: SubdirCommandFlags): Pr
 import type { CommandContext } from "@stricli/core";
 
 export interface LocalContext extends CommandContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom bin command.txt
@@ -226,7 +226,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom metadata.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom metadata.txt
@@ -226,7 +226,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom name and bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom name and bin command.txt
@@ -226,7 +226,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom name.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom name.txt
@@ -226,7 +226,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/with default flags.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/with default flags.txt
@@ -226,7 +226,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/additional features/without auto-complete.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/additional features/without auto-complete.txt
@@ -122,7 +122,7 @@ void run(app, process.argv.slice(2), buildContext(process));
 import type { CommandContext } from "@stricli/core";
 
 export interface LocalContext extends CommandContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom bin command.txt
@@ -141,7 +141,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom metadata.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom metadata.txt
@@ -141,7 +141,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom name and bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom name and bin command.txt
@@ -141,7 +141,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom name.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom name.txt
@@ -141,7 +141,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/with default flags.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/with default flags.txt
@@ -141,7 +141,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/additional features/without auto-complete.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/additional features/without auto-complete.txt
@@ -122,7 +122,7 @@ await run(app, process.argv.slice(2), buildContext(process));
 import type { CommandContext } from "@stricli/core";
 
 export interface LocalContext extends CommandContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom bin command.txt
@@ -141,7 +141,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom metadata.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom metadata.txt
@@ -141,7 +141,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom name and bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom name and bin command.txt
@@ -141,7 +141,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom name.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom name.txt
@@ -141,7 +141,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/with default flags.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/with default flags.txt
@@ -141,7 +141,7 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  // readonly process: NodeJS.Process;
+  readonly process: NodeJS.Process;
   // ...
 }
 


### PR DESCRIPTION
`@stricli/create-app` template creates a context with `NodeJS.Process` on it - so we add the type that.