### PR TITLE
chore: define codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @bloomberg/stricli-devs


### PR DESCRIPTION
Set the @bloomberg/stricli-devs team as the CODEOWNERS for all files in this repo
