### PR TITLE
chore: prettierignore CHANGELOG.md

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
`nx` is generating changelog updates that Prettier doesn't like. I think we can live without these updates, so ignoring the file