### PR TITLE
docs: correct typo with --template flag in tutorial

### DIFF
--- a/docs/docs/tutorial.mdx
+++ b/docs/docs/tutorial.mdx
@@ -91,7 +91,7 @@ You should see this exact output if you generated a multi-command app. Since Str
 
 #### Single Command
 
-You can optionally choose to run `npx @stricli/create-app@latest --command-type single` to generate a single command app.
+You can optionally choose to run `npx @stricli/create-app@latest --template single` to generate a single command app.
 
 If you generated a single command app, your initial output should look like this:
 


### PR DESCRIPTION
Resolves #10 

**Describe your changes**
This flag used to be called `--command-type` but it was renamed to `--template`. This section in the tutorial wasn't updated to match.
