### PR TITLE
fix: update auto-complete template to output completions

### DIFF
--- a/packages/create-app/src/files.ts
+++ b/packages/create-app/src/files.ts
@@ -34,14 +34,14 @@ export const localContextText = `\
 import type { CommandContext } from "@stricli/core";
 
 export interface LocalContext extends CommandContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-  };
+    return {
+        process,
+    };
 }
 `;
 
@@ -53,17 +53,17 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 `;
 
@@ -71,11 +71,11 @@ export const singleCommandImplText = `\
 import type { LocalContext } from "./context";
 
 interface CommandFlags {
-  readonly count: number;
+    readonly count: number;
 }
 
 export default async function(this: LocalContext, flags: CommandFlags, name: string): Promise<void> {
-  this.process.stdout.write(\`Hello \${name}!\\n\`.repeat(flags.count));
+    this.process.stdout.write(\`Hello \${name}!\\n\`.repeat(flags.count));
 }
 `;
 
@@ -84,35 +84,35 @@ import { buildApplication, buildCommand, numberParser } from "@stricli/core";
 import { name, version, description } from "../package.json";
 
 const command = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [
-        {
-          brief: "Your name",
-          parse: String,
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [
+                {
+                    brief: "Your name",
+                    parse: String,
+                },
+            ],
         },
-      ],
+        flags: {
+            count: {
+                kind: "parsed",
+                brief: "Number of times to say hello",
+                parse: numberParser,
+            },
+        },
     },
-    flags: {
-      count: {
-        kind: "parsed",
-        brief: "Number of times to say hello",
-        parse: numberParser,
-      },
+    docs: {
+        brief: description,
     },
-  },
-  docs: {
-    brief: description,
-  },
 });
 
 export const app = buildApplication(command, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 `;
 
@@ -120,11 +120,11 @@ export const multiCommandSubdirImplText = `\
 import type { LocalContext } from "../../context";
 
 interface SubdirCommandFlags {
-  // ...
+    // ...
 }
 
 export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 `;
 
@@ -132,16 +132,16 @@ export const multiCommandSubdirCommandText = `\
 import { buildCommand } from "@stricli/core";
 
 export const subdirCommand = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
     },
-  },
-  docs: {
-    brief: "Command in subdirectory",
-  },
+    docs: {
+        brief: "Command in subdirectory",
+    },
 });
 `;
 
@@ -149,19 +149,19 @@ export const multiCommandNestedImplText = `\
 import type { LocalContext } from "../../context";
 
 interface FooCommandFlags {
-  // ...
+    // ...
 }
 
 export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 interface BarCommandFlags {
-  // ...
+    // ...
 }
 
 export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 `;
 
@@ -169,45 +169,45 @@ export const multiCommandNestedCommandsText = `\
 import { buildCommand, buildRouteMap } from "@stricli/core";
 
 export const fooCommand = buildCommand({
-  loader: async () => {
-    const { foo } = await import("./impl");
-    return foo;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
     },
-  },
-  docs: {
-    brief: "Nested foo command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
 });
 
 export const barCommand = buildCommand({
-  loader: async () => {
-    const { bar } = await import("./impl");
-    return bar;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
     },
-  },
-  docs: {
-    brief: "Nested bar command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
 });
 
 export const nestedRoutes = buildRouteMap({
-  routes: {
-    foo: fooCommand,
-    bar: barCommand,
-  },
-  docs: {
-    brief: "Nested commands",
-  },
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
 });
 `;
 
@@ -218,20 +218,20 @@ import { subdirCommand } from "./commands/subdir/command";
 import { nestedRoutes } from "./commands/nested/commands";
 
 const routes = buildRouteMap({
-  routes: {
-    subdir: subdirCommand,
-    nested: nestedRoutes,
-  },
-  docs: {
-    brief: description,
-  },
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+    },
+    docs: {
+        brief: description,
+    },
 });
 
 export const app = buildApplication(routes, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 `;
 
@@ -244,26 +244,26 @@ import { subdirCommand } from "./commands/subdir/command";
 import { nestedRoutes } from "./commands/nested/commands";
 
 const routes = buildRouteMap({
-  routes: {
-    subdir: subdirCommand,
-    nested: nestedRoutes,
-    install: buildInstallCommand("${command}", { bash: "${autcCommand}" }),
-    uninstall: buildUninstallCommand("${command}", { bash: true }),
-  },
-  docs: {
-    brief: description,
-    hideRoute: {
-      install: true,
-      uninstall: true,
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("${command}", { bash: "${autcCommand}" }),
+        uninstall: buildUninstallCommand("${command}", { bash: true }),
     },
-  },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
 });
 
 export const app = buildApplication(routes, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 `;
 }
@@ -291,9 +291,16 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
 await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(\`\${completion}\\n\`);
+    }
+} catch {
+    // ignore
+}
 `;
 
 export const binBashCompleteScriptText = `\
@@ -303,7 +310,13 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
-void proposeCompletions(app, inputs, buildContext(process));
+void proposeCompletions(app, inputs, buildContext(process)).then((completions) => {
+    for (const { completion } of completions) {
+        process.stdout.write(\`\${completion}\\n\`);
+    }
+}, () => {
+    // ignore
+});
 `;

--- a/packages/create-app/src/impl.ts
+++ b/packages/create-app/src/impl.ts
@@ -167,7 +167,7 @@ export default async function (this: LocalContext, flags: CreateProjectFlags, di
         await writeFile("src/context.ts", localContextText);
     }
 
-    await writeFile("package.json", JSON.stringify(packageJson, void 0, 2));
+    await writeFile("package.json", JSON.stringify(packageJson, void 0, 4));
 
     await writeFile(".gitignore", gitignoreText);
 
@@ -176,7 +176,7 @@ export default async function (this: LocalContext, flags: CreateProjectFlags, di
         include: srcTsconfig.include,
         exclude: srcTsconfig.exclude,
     };
-    await writeFile("src/tsconfig.json", JSON.stringify(sourceTsconfigJson, void 0, 2));
+    await writeFile("src/tsconfig.json", JSON.stringify(sourceTsconfigJson, void 0, 4));
 
     if (flags.template === "single") {
         await writeFile("src/impl.ts", singleCommandImplText);

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/additional features/without auto-complete.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/additional features/without auto-complete.txt
@@ -82,20 +82,20 @@ import { subdirCommand } from "./commands/subdir/command";
 import { nestedRoutes } from "./commands/nested/commands";
 
 const routes = buildRouteMap({
-  routes: {
-    subdir: subdirCommand,
-    nested: nestedRoutes,
-  },
-  docs: {
-    brief: description,
-  },
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+    },
+    docs: {
+        brief: description,
+    },
 });
 
 export const app = buildApplication(routes, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/cli.ts
@@ -109,133 +109,133 @@ void run(app, process.argv.slice(2), buildContext(process));
 import { buildCommand, buildRouteMap } from "@stricli/core";
 
 export const fooCommand = buildCommand({
-  loader: async () => {
-    const { foo } = await import("./impl");
-    return foo;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
     },
-  },
-  docs: {
-    brief: "Nested foo command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
 });
 
 export const barCommand = buildCommand({
-  loader: async () => {
-    const { bar } = await import("./impl");
-    return bar;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
     },
-  },
-  docs: {
-    brief: "Nested bar command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
 });
 
 export const nestedRoutes = buildRouteMap({
-  routes: {
-    foo: fooCommand,
-    bar: barCommand,
-  },
-  docs: {
-    brief: "Nested commands",
-  },
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
 });
 
 ::::/root/test/src/commands/nested/impl.ts
 import type { LocalContext } from "../../context";
 
 interface FooCommandFlags {
-  // ...
+    // ...
 }
 
 export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 interface BarCommandFlags {
-  // ...
+    // ...
 }
 
 export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/commands/subdir/command.ts
 import { buildCommand } from "@stricli/core";
 
 export const subdirCommand = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
     },
-  },
-  docs: {
-    brief: "Command in subdirectory",
-  },
+    docs: {
+        brief: "Command in subdirectory",
+    },
 });
 
 ::::/root/test/src/commands/subdir/impl.ts
 import type { LocalContext } from "../../context";
 
 interface SubdirCommandFlags {
-  // ...
+    // ...
 }
 
 export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/context.ts
 import type { CommandContext } from "@stricli/core";
 
 export interface LocalContext extends CommandContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-  };
+    return {
+        process,
+    };
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom bin command.txt
@@ -87,26 +87,26 @@ import { subdirCommand } from "./commands/subdir/command";
 import { nestedRoutes } from "./commands/nested/commands";
 
 const routes = buildRouteMap({
-  routes: {
-    subdir: subdirCommand,
-    nested: nestedRoutes,
-    install: buildInstallCommand("test-cli", { bash: "__test-cli_bash_complete" }),
-    uninstall: buildUninstallCommand("test-cli", { bash: true }),
-  },
-  docs: {
-    brief: description,
-    hideRoute: {
-      install: true,
-      uninstall: true,
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("test-cli", { bash: "__test-cli_bash_complete" }),
+        uninstall: buildUninstallCommand("test-cli", { bash: true }),
     },
-  },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
 });
 
 export const app = buildApplication(routes, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -116,9 +116,15 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
-void proposeCompletions(app, inputs, buildContext(process));
+void proposeCompletions(app, inputs, buildContext(process)).then((completions) => {
+    for (const { completion } of completions) {
+        process.stdout.write(`${completion}\n`);
+    }
+}, () => {
+    // ignore
+});
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -131,91 +137,91 @@ void run(app, process.argv.slice(2), buildContext(process));
 import { buildCommand, buildRouteMap } from "@stricli/core";
 
 export const fooCommand = buildCommand({
-  loader: async () => {
-    const { foo } = await import("./impl");
-    return foo;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
     },
-  },
-  docs: {
-    brief: "Nested foo command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
 });
 
 export const barCommand = buildCommand({
-  loader: async () => {
-    const { bar } = await import("./impl");
-    return bar;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
     },
-  },
-  docs: {
-    brief: "Nested bar command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
 });
 
 export const nestedRoutes = buildRouteMap({
-  routes: {
-    foo: fooCommand,
-    bar: barCommand,
-  },
-  docs: {
-    brief: "Nested commands",
-  },
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
 });
 
 ::::/root/test/src/commands/nested/impl.ts
 import type { LocalContext } from "../../context";
 
 interface FooCommandFlags {
-  // ...
+    // ...
 }
 
 export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 interface BarCommandFlags {
-  // ...
+    // ...
 }
 
 export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/commands/subdir/command.ts
 import { buildCommand } from "@stricli/core";
 
 export const subdirCommand = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
     },
-  },
-  docs: {
-    brief: "Command in subdirectory",
-  },
+    docs: {
+        brief: "Command in subdirectory",
+    },
 });
 
 ::::/root/test/src/commands/subdir/impl.ts
 import type { LocalContext } from "../../context";
 
 interface SubdirCommandFlags {
-  // ...
+    // ...
 }
 
 export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/context.ts
@@ -226,45 +232,45 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom metadata.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom metadata.txt
@@ -87,26 +87,26 @@ import { subdirCommand } from "./commands/subdir/command";
 import { nestedRoutes } from "./commands/nested/commands";
 
 const routes = buildRouteMap({
-  routes: {
-    subdir: subdirCommand,
-    nested: nestedRoutes,
-    install: buildInstallCommand("test", { bash: "__test_bash_complete" }),
-    uninstall: buildUninstallCommand("test", { bash: true }),
-  },
-  docs: {
-    brief: description,
-    hideRoute: {
-      install: true,
-      uninstall: true,
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("test", { bash: "__test_bash_complete" }),
+        uninstall: buildUninstallCommand("test", { bash: true }),
     },
-  },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
 });
 
 export const app = buildApplication(routes, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -116,9 +116,15 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
-void proposeCompletions(app, inputs, buildContext(process));
+void proposeCompletions(app, inputs, buildContext(process)).then((completions) => {
+    for (const { completion } of completions) {
+        process.stdout.write(`${completion}\n`);
+    }
+}, () => {
+    // ignore
+});
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -131,91 +137,91 @@ void run(app, process.argv.slice(2), buildContext(process));
 import { buildCommand, buildRouteMap } from "@stricli/core";
 
 export const fooCommand = buildCommand({
-  loader: async () => {
-    const { foo } = await import("./impl");
-    return foo;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
     },
-  },
-  docs: {
-    brief: "Nested foo command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
 });
 
 export const barCommand = buildCommand({
-  loader: async () => {
-    const { bar } = await import("./impl");
-    return bar;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
     },
-  },
-  docs: {
-    brief: "Nested bar command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
 });
 
 export const nestedRoutes = buildRouteMap({
-  routes: {
-    foo: fooCommand,
-    bar: barCommand,
-  },
-  docs: {
-    brief: "Nested commands",
-  },
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
 });
 
 ::::/root/test/src/commands/nested/impl.ts
 import type { LocalContext } from "../../context";
 
 interface FooCommandFlags {
-  // ...
+    // ...
 }
 
 export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 interface BarCommandFlags {
-  // ...
+    // ...
 }
 
 export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/commands/subdir/command.ts
 import { buildCommand } from "@stricli/core";
 
 export const subdirCommand = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
     },
-  },
-  docs: {
-    brief: "Command in subdirectory",
-  },
+    docs: {
+        brief: "Command in subdirectory",
+    },
 });
 
 ::::/root/test/src/commands/subdir/impl.ts
 import type { LocalContext } from "../../context";
 
 interface SubdirCommandFlags {
-  // ...
+    // ...
 }
 
 export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/context.ts
@@ -226,45 +232,45 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom name and bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom name and bin command.txt
@@ -87,26 +87,26 @@ import { subdirCommand } from "./commands/subdir/command";
 import { nestedRoutes } from "./commands/nested/commands";
 
 const routes = buildRouteMap({
-  routes: {
-    subdir: subdirCommand,
-    nested: nestedRoutes,
-    install: buildInstallCommand("test-cli", { bash: "__test-cli_bash_complete" }),
-    uninstall: buildUninstallCommand("test-cli", { bash: true }),
-  },
-  docs: {
-    brief: description,
-    hideRoute: {
-      install: true,
-      uninstall: true,
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("test-cli", { bash: "__test-cli_bash_complete" }),
+        uninstall: buildUninstallCommand("test-cli", { bash: true }),
     },
-  },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
 });
 
 export const app = buildApplication(routes, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -116,9 +116,15 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
-void proposeCompletions(app, inputs, buildContext(process));
+void proposeCompletions(app, inputs, buildContext(process)).then((completions) => {
+    for (const { completion } of completions) {
+        process.stdout.write(`${completion}\n`);
+    }
+}, () => {
+    // ignore
+});
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -131,91 +137,91 @@ void run(app, process.argv.slice(2), buildContext(process));
 import { buildCommand, buildRouteMap } from "@stricli/core";
 
 export const fooCommand = buildCommand({
-  loader: async () => {
-    const { foo } = await import("./impl");
-    return foo;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
     },
-  },
-  docs: {
-    brief: "Nested foo command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
 });
 
 export const barCommand = buildCommand({
-  loader: async () => {
-    const { bar } = await import("./impl");
-    return bar;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
     },
-  },
-  docs: {
-    brief: "Nested bar command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
 });
 
 export const nestedRoutes = buildRouteMap({
-  routes: {
-    foo: fooCommand,
-    bar: barCommand,
-  },
-  docs: {
-    brief: "Nested commands",
-  },
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
 });
 
 ::::/root/test/src/commands/nested/impl.ts
 import type { LocalContext } from "../../context";
 
 interface FooCommandFlags {
-  // ...
+    // ...
 }
 
 export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 interface BarCommandFlags {
-  // ...
+    // ...
 }
 
 export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/commands/subdir/command.ts
 import { buildCommand } from "@stricli/core";
 
 export const subdirCommand = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
     },
-  },
-  docs: {
-    brief: "Command in subdirectory",
-  },
+    docs: {
+        brief: "Command in subdirectory",
+    },
 });
 
 ::::/root/test/src/commands/subdir/impl.ts
 import type { LocalContext } from "../../context";
 
 interface SubdirCommandFlags {
-  // ...
+    // ...
 }
 
 export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/context.ts
@@ -226,45 +232,45 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom name.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom name.txt
@@ -87,26 +87,26 @@ import { subdirCommand } from "./commands/subdir/command";
 import { nestedRoutes } from "./commands/nested/commands";
 
 const routes = buildRouteMap({
-  routes: {
-    subdir: subdirCommand,
-    nested: nestedRoutes,
-    install: buildInstallCommand("@org/test-cli", { bash: "__@org/test-cli_bash_complete" }),
-    uninstall: buildUninstallCommand("@org/test-cli", { bash: true }),
-  },
-  docs: {
-    brief: description,
-    hideRoute: {
-      install: true,
-      uninstall: true,
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("@org/test-cli", { bash: "__@org/test-cli_bash_complete" }),
+        uninstall: buildUninstallCommand("@org/test-cli", { bash: true }),
     },
-  },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
 });
 
 export const app = buildApplication(routes, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -116,9 +116,15 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
-void proposeCompletions(app, inputs, buildContext(process));
+void proposeCompletions(app, inputs, buildContext(process)).then((completions) => {
+    for (const { completion } of completions) {
+        process.stdout.write(`${completion}\n`);
+    }
+}, () => {
+    // ignore
+});
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -131,91 +137,91 @@ void run(app, process.argv.slice(2), buildContext(process));
 import { buildCommand, buildRouteMap } from "@stricli/core";
 
 export const fooCommand = buildCommand({
-  loader: async () => {
-    const { foo } = await import("./impl");
-    return foo;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
     },
-  },
-  docs: {
-    brief: "Nested foo command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
 });
 
 export const barCommand = buildCommand({
-  loader: async () => {
-    const { bar } = await import("./impl");
-    return bar;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
     },
-  },
-  docs: {
-    brief: "Nested bar command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
 });
 
 export const nestedRoutes = buildRouteMap({
-  routes: {
-    foo: fooCommand,
-    bar: barCommand,
-  },
-  docs: {
-    brief: "Nested commands",
-  },
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
 });
 
 ::::/root/test/src/commands/nested/impl.ts
 import type { LocalContext } from "../../context";
 
 interface FooCommandFlags {
-  // ...
+    // ...
 }
 
 export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 interface BarCommandFlags {
-  // ...
+    // ...
 }
 
 export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/commands/subdir/command.ts
 import { buildCommand } from "@stricli/core";
 
 export const subdirCommand = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
     },
-  },
-  docs: {
-    brief: "Command in subdirectory",
-  },
+    docs: {
+        brief: "Command in subdirectory",
+    },
 });
 
 ::::/root/test/src/commands/subdir/impl.ts
 import type { LocalContext } from "../../context";
 
 interface SubdirCommandFlags {
-  // ...
+    // ...
 }
 
 export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/context.ts
@@ -226,45 +232,45 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/with default flags.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/with default flags.txt
@@ -87,26 +87,26 @@ import { subdirCommand } from "./commands/subdir/command";
 import { nestedRoutes } from "./commands/nested/commands";
 
 const routes = buildRouteMap({
-  routes: {
-    subdir: subdirCommand,
-    nested: nestedRoutes,
-    install: buildInstallCommand("test", { bash: "__test_bash_complete" }),
-    uninstall: buildUninstallCommand("test", { bash: true }),
-  },
-  docs: {
-    brief: description,
-    hideRoute: {
-      install: true,
-      uninstall: true,
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("test", { bash: "__test_bash_complete" }),
+        uninstall: buildUninstallCommand("test", { bash: true }),
     },
-  },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
 });
 
 export const app = buildApplication(routes, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -116,9 +116,15 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
-void proposeCompletions(app, inputs, buildContext(process));
+void proposeCompletions(app, inputs, buildContext(process)).then((completions) => {
+    for (const { completion } of completions) {
+        process.stdout.write(`${completion}\n`);
+    }
+}, () => {
+    // ignore
+});
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -131,91 +137,91 @@ void run(app, process.argv.slice(2), buildContext(process));
 import { buildCommand, buildRouteMap } from "@stricli/core";
 
 export const fooCommand = buildCommand({
-  loader: async () => {
-    const { foo } = await import("./impl");
-    return foo;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
     },
-  },
-  docs: {
-    brief: "Nested foo command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
 });
 
 export const barCommand = buildCommand({
-  loader: async () => {
-    const { bar } = await import("./impl");
-    return bar;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
     },
-  },
-  docs: {
-    brief: "Nested bar command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
 });
 
 export const nestedRoutes = buildRouteMap({
-  routes: {
-    foo: fooCommand,
-    bar: barCommand,
-  },
-  docs: {
-    brief: "Nested commands",
-  },
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
 });
 
 ::::/root/test/src/commands/nested/impl.ts
 import type { LocalContext } from "../../context";
 
 interface FooCommandFlags {
-  // ...
+    // ...
 }
 
 export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 interface BarCommandFlags {
-  // ...
+    // ...
 }
 
 export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/commands/subdir/command.ts
 import { buildCommand } from "@stricli/core";
 
 export const subdirCommand = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
     },
-  },
-  docs: {
-    brief: "Command in subdirectory",
-  },
+    docs: {
+        brief: "Command in subdirectory",
+    },
 });
 
 ::::/root/test/src/commands/subdir/impl.ts
 import type { LocalContext } from "../../context";
 
 interface SubdirCommandFlags {
-  // ...
+    // ...
 }
 
 export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/context.ts
@@ -226,45 +232,45 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/additional features/without auto-complete.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/additional features/without auto-complete.txt
@@ -82,20 +82,20 @@ import { subdirCommand } from "./commands/subdir/command";
 import { nestedRoutes } from "./commands/nested/commands";
 
 const routes = buildRouteMap({
-  routes: {
-    subdir: subdirCommand,
-    nested: nestedRoutes,
-  },
-  docs: {
-    brief: description,
-  },
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+    },
+    docs: {
+        brief: description,
+    },
 });
 
 export const app = buildApplication(routes, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/cli.ts
@@ -109,133 +109,133 @@ await run(app, process.argv.slice(2), buildContext(process));
 import { buildCommand, buildRouteMap } from "@stricli/core";
 
 export const fooCommand = buildCommand({
-  loader: async () => {
-    const { foo } = await import("./impl");
-    return foo;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
     },
-  },
-  docs: {
-    brief: "Nested foo command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
 });
 
 export const barCommand = buildCommand({
-  loader: async () => {
-    const { bar } = await import("./impl");
-    return bar;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
     },
-  },
-  docs: {
-    brief: "Nested bar command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
 });
 
 export const nestedRoutes = buildRouteMap({
-  routes: {
-    foo: fooCommand,
-    bar: barCommand,
-  },
-  docs: {
-    brief: "Nested commands",
-  },
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
 });
 
 ::::/root/test/src/commands/nested/impl.ts
 import type { LocalContext } from "../../context";
 
 interface FooCommandFlags {
-  // ...
+    // ...
 }
 
 export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 interface BarCommandFlags {
-  // ...
+    // ...
 }
 
 export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/commands/subdir/command.ts
 import { buildCommand } from "@stricli/core";
 
 export const subdirCommand = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
     },
-  },
-  docs: {
-    brief: "Command in subdirectory",
-  },
+    docs: {
+        brief: "Command in subdirectory",
+    },
 });
 
 ::::/root/test/src/commands/subdir/impl.ts
 import type { LocalContext } from "../../context";
 
 interface SubdirCommandFlags {
-  // ...
+    // ...
 }
 
 export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/context.ts
 import type { CommandContext } from "@stricli/core";
 
 export interface LocalContext extends CommandContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-  };
+    return {
+        process,
+    };
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom bin command.txt
@@ -87,26 +87,26 @@ import { subdirCommand } from "./commands/subdir/command";
 import { nestedRoutes } from "./commands/nested/commands";
 
 const routes = buildRouteMap({
-  routes: {
-    subdir: subdirCommand,
-    nested: nestedRoutes,
-    install: buildInstallCommand("test-cli", { bash: "__test-cli_bash_complete" }),
-    uninstall: buildUninstallCommand("test-cli", { bash: true }),
-  },
-  docs: {
-    brief: description,
-    hideRoute: {
-      install: true,
-      uninstall: true,
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("test-cli", { bash: "__test-cli_bash_complete" }),
+        uninstall: buildUninstallCommand("test-cli", { bash: true }),
     },
-  },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
 });
 
 export const app = buildApplication(routes, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -116,9 +116,16 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
 await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -131,91 +138,91 @@ await run(app, process.argv.slice(2), buildContext(process));
 import { buildCommand, buildRouteMap } from "@stricli/core";
 
 export const fooCommand = buildCommand({
-  loader: async () => {
-    const { foo } = await import("./impl");
-    return foo;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
     },
-  },
-  docs: {
-    brief: "Nested foo command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
 });
 
 export const barCommand = buildCommand({
-  loader: async () => {
-    const { bar } = await import("./impl");
-    return bar;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
     },
-  },
-  docs: {
-    brief: "Nested bar command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
 });
 
 export const nestedRoutes = buildRouteMap({
-  routes: {
-    foo: fooCommand,
-    bar: barCommand,
-  },
-  docs: {
-    brief: "Nested commands",
-  },
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
 });
 
 ::::/root/test/src/commands/nested/impl.ts
 import type { LocalContext } from "../../context";
 
 interface FooCommandFlags {
-  // ...
+    // ...
 }
 
 export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 interface BarCommandFlags {
-  // ...
+    // ...
 }
 
 export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/commands/subdir/command.ts
 import { buildCommand } from "@stricli/core";
 
 export const subdirCommand = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
     },
-  },
-  docs: {
-    brief: "Command in subdirectory",
-  },
+    docs: {
+        brief: "Command in subdirectory",
+    },
 });
 
 ::::/root/test/src/commands/subdir/impl.ts
 import type { LocalContext } from "../../context";
 
 interface SubdirCommandFlags {
-  // ...
+    // ...
 }
 
 export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/context.ts
@@ -226,45 +233,45 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom metadata.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom metadata.txt
@@ -87,26 +87,26 @@ import { subdirCommand } from "./commands/subdir/command";
 import { nestedRoutes } from "./commands/nested/commands";
 
 const routes = buildRouteMap({
-  routes: {
-    subdir: subdirCommand,
-    nested: nestedRoutes,
-    install: buildInstallCommand("test", { bash: "__test_bash_complete" }),
-    uninstall: buildUninstallCommand("test", { bash: true }),
-  },
-  docs: {
-    brief: description,
-    hideRoute: {
-      install: true,
-      uninstall: true,
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("test", { bash: "__test_bash_complete" }),
+        uninstall: buildUninstallCommand("test", { bash: true }),
     },
-  },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
 });
 
 export const app = buildApplication(routes, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -116,9 +116,16 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
 await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -131,91 +138,91 @@ await run(app, process.argv.slice(2), buildContext(process));
 import { buildCommand, buildRouteMap } from "@stricli/core";
 
 export const fooCommand = buildCommand({
-  loader: async () => {
-    const { foo } = await import("./impl");
-    return foo;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
     },
-  },
-  docs: {
-    brief: "Nested foo command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
 });
 
 export const barCommand = buildCommand({
-  loader: async () => {
-    const { bar } = await import("./impl");
-    return bar;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
     },
-  },
-  docs: {
-    brief: "Nested bar command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
 });
 
 export const nestedRoutes = buildRouteMap({
-  routes: {
-    foo: fooCommand,
-    bar: barCommand,
-  },
-  docs: {
-    brief: "Nested commands",
-  },
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
 });
 
 ::::/root/test/src/commands/nested/impl.ts
 import type { LocalContext } from "../../context";
 
 interface FooCommandFlags {
-  // ...
+    // ...
 }
 
 export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 interface BarCommandFlags {
-  // ...
+    // ...
 }
 
 export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/commands/subdir/command.ts
 import { buildCommand } from "@stricli/core";
 
 export const subdirCommand = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
     },
-  },
-  docs: {
-    brief: "Command in subdirectory",
-  },
+    docs: {
+        brief: "Command in subdirectory",
+    },
 });
 
 ::::/root/test/src/commands/subdir/impl.ts
 import type { LocalContext } from "../../context";
 
 interface SubdirCommandFlags {
-  // ...
+    // ...
 }
 
 export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/context.ts
@@ -226,45 +233,45 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom name and bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom name and bin command.txt
@@ -87,26 +87,26 @@ import { subdirCommand } from "./commands/subdir/command";
 import { nestedRoutes } from "./commands/nested/commands";
 
 const routes = buildRouteMap({
-  routes: {
-    subdir: subdirCommand,
-    nested: nestedRoutes,
-    install: buildInstallCommand("test-cli", { bash: "__test-cli_bash_complete" }),
-    uninstall: buildUninstallCommand("test-cli", { bash: true }),
-  },
-  docs: {
-    brief: description,
-    hideRoute: {
-      install: true,
-      uninstall: true,
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("test-cli", { bash: "__test-cli_bash_complete" }),
+        uninstall: buildUninstallCommand("test-cli", { bash: true }),
     },
-  },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
 });
 
 export const app = buildApplication(routes, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -116,9 +116,16 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
 await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -131,91 +138,91 @@ await run(app, process.argv.slice(2), buildContext(process));
 import { buildCommand, buildRouteMap } from "@stricli/core";
 
 export const fooCommand = buildCommand({
-  loader: async () => {
-    const { foo } = await import("./impl");
-    return foo;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
     },
-  },
-  docs: {
-    brief: "Nested foo command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
 });
 
 export const barCommand = buildCommand({
-  loader: async () => {
-    const { bar } = await import("./impl");
-    return bar;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
     },
-  },
-  docs: {
-    brief: "Nested bar command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
 });
 
 export const nestedRoutes = buildRouteMap({
-  routes: {
-    foo: fooCommand,
-    bar: barCommand,
-  },
-  docs: {
-    brief: "Nested commands",
-  },
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
 });
 
 ::::/root/test/src/commands/nested/impl.ts
 import type { LocalContext } from "../../context";
 
 interface FooCommandFlags {
-  // ...
+    // ...
 }
 
 export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 interface BarCommandFlags {
-  // ...
+    // ...
 }
 
 export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/commands/subdir/command.ts
 import { buildCommand } from "@stricli/core";
 
 export const subdirCommand = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
     },
-  },
-  docs: {
-    brief: "Command in subdirectory",
-  },
+    docs: {
+        brief: "Command in subdirectory",
+    },
 });
 
 ::::/root/test/src/commands/subdir/impl.ts
 import type { LocalContext } from "../../context";
 
 interface SubdirCommandFlags {
-  // ...
+    // ...
 }
 
 export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/context.ts
@@ -226,45 +233,45 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom name.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom name.txt
@@ -87,26 +87,26 @@ import { subdirCommand } from "./commands/subdir/command";
 import { nestedRoutes } from "./commands/nested/commands";
 
 const routes = buildRouteMap({
-  routes: {
-    subdir: subdirCommand,
-    nested: nestedRoutes,
-    install: buildInstallCommand("@org/test-cli", { bash: "__@org/test-cli_bash_complete" }),
-    uninstall: buildUninstallCommand("@org/test-cli", { bash: true }),
-  },
-  docs: {
-    brief: description,
-    hideRoute: {
-      install: true,
-      uninstall: true,
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("@org/test-cli", { bash: "__@org/test-cli_bash_complete" }),
+        uninstall: buildUninstallCommand("@org/test-cli", { bash: true }),
     },
-  },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
 });
 
 export const app = buildApplication(routes, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -116,9 +116,16 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
 await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -131,91 +138,91 @@ await run(app, process.argv.slice(2), buildContext(process));
 import { buildCommand, buildRouteMap } from "@stricli/core";
 
 export const fooCommand = buildCommand({
-  loader: async () => {
-    const { foo } = await import("./impl");
-    return foo;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
     },
-  },
-  docs: {
-    brief: "Nested foo command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
 });
 
 export const barCommand = buildCommand({
-  loader: async () => {
-    const { bar } = await import("./impl");
-    return bar;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
     },
-  },
-  docs: {
-    brief: "Nested bar command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
 });
 
 export const nestedRoutes = buildRouteMap({
-  routes: {
-    foo: fooCommand,
-    bar: barCommand,
-  },
-  docs: {
-    brief: "Nested commands",
-  },
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
 });
 
 ::::/root/test/src/commands/nested/impl.ts
 import type { LocalContext } from "../../context";
 
 interface FooCommandFlags {
-  // ...
+    // ...
 }
 
 export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 interface BarCommandFlags {
-  // ...
+    // ...
 }
 
 export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/commands/subdir/command.ts
 import { buildCommand } from "@stricli/core";
 
 export const subdirCommand = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
     },
-  },
-  docs: {
-    brief: "Command in subdirectory",
-  },
+    docs: {
+        brief: "Command in subdirectory",
+    },
 });
 
 ::::/root/test/src/commands/subdir/impl.ts
 import type { LocalContext } from "../../context";
 
 interface SubdirCommandFlags {
-  // ...
+    // ...
 }
 
 export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/context.ts
@@ -226,45 +233,45 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/with default flags.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/with default flags.txt
@@ -87,26 +87,26 @@ import { subdirCommand } from "./commands/subdir/command";
 import { nestedRoutes } from "./commands/nested/commands";
 
 const routes = buildRouteMap({
-  routes: {
-    subdir: subdirCommand,
-    nested: nestedRoutes,
-    install: buildInstallCommand("test", { bash: "__test_bash_complete" }),
-    uninstall: buildUninstallCommand("test", { bash: true }),
-  },
-  docs: {
-    brief: description,
-    hideRoute: {
-      install: true,
-      uninstall: true,
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("test", { bash: "__test_bash_complete" }),
+        uninstall: buildUninstallCommand("test", { bash: true }),
     },
-  },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
 });
 
 export const app = buildApplication(routes, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -116,9 +116,16 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
 await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -131,91 +138,91 @@ await run(app, process.argv.slice(2), buildContext(process));
 import { buildCommand, buildRouteMap } from "@stricli/core";
 
 export const fooCommand = buildCommand({
-  loader: async () => {
-    const { foo } = await import("./impl");
-    return foo;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
     },
-  },
-  docs: {
-    brief: "Nested foo command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
 });
 
 export const barCommand = buildCommand({
-  loader: async () => {
-    const { bar } = await import("./impl");
-    return bar;
-  },
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
     },
-  },
-  docs: {
-    brief: "Nested bar command",
-  },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
 });
 
 export const nestedRoutes = buildRouteMap({
-  routes: {
-    foo: fooCommand,
-    bar: barCommand,
-  },
-  docs: {
-    brief: "Nested commands",
-  },
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
 });
 
 ::::/root/test/src/commands/nested/impl.ts
 import type { LocalContext } from "../../context";
 
 interface FooCommandFlags {
-  // ...
+    // ...
 }
 
 export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 interface BarCommandFlags {
-  // ...
+    // ...
 }
 
 export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/commands/subdir/command.ts
 import { buildCommand } from "@stricli/core";
 
 export const subdirCommand = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [],
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
     },
-  },
-  docs: {
-    brief: "Command in subdirectory",
-  },
+    docs: {
+        brief: "Command in subdirectory",
+    },
 });
 
 ::::/root/test/src/commands/subdir/impl.ts
 import type { LocalContext } from "../../context";
 
 interface SubdirCommandFlags {
-  // ...
+    // ...
 }
 
 export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
-  // ...
+    // ...
 }
 
 ::::/root/test/src/context.ts
@@ -226,45 +233,45 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/additional features/without auto-complete.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/additional features/without auto-complete.txt
@@ -80,35 +80,35 @@ import { buildApplication, buildCommand, numberParser } from "@stricli/core";
 import { name, version, description } from "../package.json";
 
 const command = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [
-        {
-          brief: "Your name",
-          parse: String,
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [
+                {
+                    brief: "Your name",
+                    parse: String,
+                },
+            ],
         },
-      ],
+        flags: {
+            count: {
+                kind: "parsed",
+                brief: "Number of times to say hello",
+                parse: numberParser,
+            },
+        },
     },
-    flags: {
-      count: {
-        kind: "parsed",
-        brief: "Number of times to say hello",
-        parse: numberParser,
-      },
+    docs: {
+        brief: description,
     },
-  },
-  docs: {
-    brief: description,
-  },
 });
 
 export const app = buildApplication(command, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/cli.ts
@@ -122,53 +122,53 @@ void run(app, process.argv.slice(2), buildContext(process));
 import type { CommandContext } from "@stricli/core";
 
 export interface LocalContext extends CommandContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-  };
+    return {
+        process,
+    };
 }
 
 ::::/root/test/src/impl.ts
 import type { LocalContext } from "./context";
 
 interface CommandFlags {
-  readonly count: number;
+    readonly count: number;
 }
 
 export default async function(this: LocalContext, flags: CommandFlags, name: string): Promise<void> {
-  this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
+    this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom bin command.txt
@@ -84,35 +84,35 @@ import { buildApplication, buildCommand, numberParser } from "@stricli/core";
 import { name, version, description } from "../package.json";
 
 const command = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [
-        {
-          brief: "Your name",
-          parse: String,
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [
+                {
+                    brief: "Your name",
+                    parse: String,
+                },
+            ],
         },
-      ],
+        flags: {
+            count: {
+                kind: "parsed",
+                brief: "Number of times to say hello",
+                parse: numberParser,
+            },
+        },
     },
-    flags: {
-      count: {
-        kind: "parsed",
-        brief: "Number of times to say hello",
-        parse: numberParser,
-      },
+    docs: {
+        brief: description,
     },
-  },
-  docs: {
-    brief: description,
-  },
 });
 
 export const app = buildApplication(command, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -122,9 +122,15 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
-void proposeCompletions(app, inputs, buildContext(process));
+void proposeCompletions(app, inputs, buildContext(process)).then((completions) => {
+    for (const { completion } of completions) {
+        process.stdout.write(`${completion}\n`);
+    }
+}, () => {
+    // ignore
+});
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -141,56 +147,56 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/impl.ts
 import type { LocalContext } from "./context";
 
 interface CommandFlags {
-  readonly count: number;
+    readonly count: number;
 }
 
 export default async function(this: LocalContext, flags: CommandFlags, name: string): Promise<void> {
-  this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
+    this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom metadata.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom metadata.txt
@@ -84,35 +84,35 @@ import { buildApplication, buildCommand, numberParser } from "@stricli/core";
 import { name, version, description } from "../package.json";
 
 const command = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [
-        {
-          brief: "Your name",
-          parse: String,
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [
+                {
+                    brief: "Your name",
+                    parse: String,
+                },
+            ],
         },
-      ],
+        flags: {
+            count: {
+                kind: "parsed",
+                brief: "Number of times to say hello",
+                parse: numberParser,
+            },
+        },
     },
-    flags: {
-      count: {
-        kind: "parsed",
-        brief: "Number of times to say hello",
-        parse: numberParser,
-      },
+    docs: {
+        brief: description,
     },
-  },
-  docs: {
-    brief: description,
-  },
 });
 
 export const app = buildApplication(command, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -122,9 +122,15 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
-void proposeCompletions(app, inputs, buildContext(process));
+void proposeCompletions(app, inputs, buildContext(process)).then((completions) => {
+    for (const { completion } of completions) {
+        process.stdout.write(`${completion}\n`);
+    }
+}, () => {
+    // ignore
+});
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -141,56 +147,56 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/impl.ts
 import type { LocalContext } from "./context";
 
 interface CommandFlags {
-  readonly count: number;
+    readonly count: number;
 }
 
 export default async function(this: LocalContext, flags: CommandFlags, name: string): Promise<void> {
-  this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
+    this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom name and bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom name and bin command.txt
@@ -84,35 +84,35 @@ import { buildApplication, buildCommand, numberParser } from "@stricli/core";
 import { name, version, description } from "../package.json";
 
 const command = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [
-        {
-          brief: "Your name",
-          parse: String,
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [
+                {
+                    brief: "Your name",
+                    parse: String,
+                },
+            ],
         },
-      ],
+        flags: {
+            count: {
+                kind: "parsed",
+                brief: "Number of times to say hello",
+                parse: numberParser,
+            },
+        },
     },
-    flags: {
-      count: {
-        kind: "parsed",
-        brief: "Number of times to say hello",
-        parse: numberParser,
-      },
+    docs: {
+        brief: description,
     },
-  },
-  docs: {
-    brief: description,
-  },
 });
 
 export const app = buildApplication(command, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -122,9 +122,15 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
-void proposeCompletions(app, inputs, buildContext(process));
+void proposeCompletions(app, inputs, buildContext(process)).then((completions) => {
+    for (const { completion } of completions) {
+        process.stdout.write(`${completion}\n`);
+    }
+}, () => {
+    // ignore
+});
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -141,56 +147,56 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/impl.ts
 import type { LocalContext } from "./context";
 
 interface CommandFlags {
-  readonly count: number;
+    readonly count: number;
 }
 
 export default async function(this: LocalContext, flags: CommandFlags, name: string): Promise<void> {
-  this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
+    this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom name.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom name.txt
@@ -84,35 +84,35 @@ import { buildApplication, buildCommand, numberParser } from "@stricli/core";
 import { name, version, description } from "../package.json";
 
 const command = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [
-        {
-          brief: "Your name",
-          parse: String,
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [
+                {
+                    brief: "Your name",
+                    parse: String,
+                },
+            ],
         },
-      ],
+        flags: {
+            count: {
+                kind: "parsed",
+                brief: "Number of times to say hello",
+                parse: numberParser,
+            },
+        },
     },
-    flags: {
-      count: {
-        kind: "parsed",
-        brief: "Number of times to say hello",
-        parse: numberParser,
-      },
+    docs: {
+        brief: description,
     },
-  },
-  docs: {
-    brief: description,
-  },
 });
 
 export const app = buildApplication(command, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -122,9 +122,15 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
-void proposeCompletions(app, inputs, buildContext(process));
+void proposeCompletions(app, inputs, buildContext(process)).then((completions) => {
+    for (const { completion } of completions) {
+        process.stdout.write(`${completion}\n`);
+    }
+}, () => {
+    // ignore
+});
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -141,56 +147,56 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/impl.ts
 import type { LocalContext } from "./context";
 
 interface CommandFlags {
-  readonly count: number;
+    readonly count: number;
 }
 
 export default async function(this: LocalContext, flags: CommandFlags, name: string): Promise<void> {
-  this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
+    this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/with default flags.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/with default flags.txt
@@ -84,35 +84,35 @@ import { buildApplication, buildCommand, numberParser } from "@stricli/core";
 import { name, version, description } from "../package.json";
 
 const command = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [
-        {
-          brief: "Your name",
-          parse: String,
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [
+                {
+                    brief: "Your name",
+                    parse: String,
+                },
+            ],
         },
-      ],
+        flags: {
+            count: {
+                kind: "parsed",
+                brief: "Number of times to say hello",
+                parse: numberParser,
+            },
+        },
     },
-    flags: {
-      count: {
-        kind: "parsed",
-        brief: "Number of times to say hello",
-        parse: numberParser,
-      },
+    docs: {
+        brief: description,
     },
-  },
-  docs: {
-    brief: description,
-  },
 });
 
 export const app = buildApplication(command, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -122,9 +122,15 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
-void proposeCompletions(app, inputs, buildContext(process));
+void proposeCompletions(app, inputs, buildContext(process)).then((completions) => {
+    for (const { completion } of completions) {
+        process.stdout.write(`${completion}\n`);
+    }
+}, () => {
+    // ignore
+});
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -141,56 +147,56 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/impl.ts
 import type { LocalContext } from "./context";
 
 interface CommandFlags {
-  readonly count: number;
+    readonly count: number;
 }
 
 export default async function(this: LocalContext, flags: CommandFlags, name: string): Promise<void> {
-  this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
+    this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/additional features/without auto-complete.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/additional features/without auto-complete.txt
@@ -80,35 +80,35 @@ import { buildApplication, buildCommand, numberParser } from "@stricli/core";
 import { name, version, description } from "../package.json";
 
 const command = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [
-        {
-          brief: "Your name",
-          parse: String,
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [
+                {
+                    brief: "Your name",
+                    parse: String,
+                },
+            ],
         },
-      ],
+        flags: {
+            count: {
+                kind: "parsed",
+                brief: "Number of times to say hello",
+                parse: numberParser,
+            },
+        },
     },
-    flags: {
-      count: {
-        kind: "parsed",
-        brief: "Number of times to say hello",
-        parse: numberParser,
-      },
+    docs: {
+        brief: description,
     },
-  },
-  docs: {
-    brief: description,
-  },
 });
 
 export const app = buildApplication(command, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/cli.ts
@@ -122,53 +122,53 @@ await run(app, process.argv.slice(2), buildContext(process));
 import type { CommandContext } from "@stricli/core";
 
 export interface LocalContext extends CommandContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-  };
+    return {
+        process,
+    };
 }
 
 ::::/root/test/src/impl.ts
 import type { LocalContext } from "./context";
 
 interface CommandFlags {
-  readonly count: number;
+    readonly count: number;
 }
 
 export default async function(this: LocalContext, flags: CommandFlags, name: string): Promise<void> {
-  this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
+    this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom bin command.txt
@@ -84,35 +84,35 @@ import { buildApplication, buildCommand, numberParser } from "@stricli/core";
 import { name, version, description } from "../package.json";
 
 const command = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [
-        {
-          brief: "Your name",
-          parse: String,
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [
+                {
+                    brief: "Your name",
+                    parse: String,
+                },
+            ],
         },
-      ],
+        flags: {
+            count: {
+                kind: "parsed",
+                brief: "Number of times to say hello",
+                parse: numberParser,
+            },
+        },
     },
-    flags: {
-      count: {
-        kind: "parsed",
-        brief: "Number of times to say hello",
-        parse: numberParser,
-      },
+    docs: {
+        brief: description,
     },
-  },
-  docs: {
-    brief: description,
-  },
 });
 
 export const app = buildApplication(command, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -122,9 +122,16 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
 await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -141,56 +148,56 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/impl.ts
 import type { LocalContext } from "./context";
 
 interface CommandFlags {
-  readonly count: number;
+    readonly count: number;
 }
 
 export default async function(this: LocalContext, flags: CommandFlags, name: string): Promise<void> {
-  this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
+    this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom metadata.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom metadata.txt
@@ -84,35 +84,35 @@ import { buildApplication, buildCommand, numberParser } from "@stricli/core";
 import { name, version, description } from "../package.json";
 
 const command = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [
-        {
-          brief: "Your name",
-          parse: String,
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [
+                {
+                    brief: "Your name",
+                    parse: String,
+                },
+            ],
         },
-      ],
+        flags: {
+            count: {
+                kind: "parsed",
+                brief: "Number of times to say hello",
+                parse: numberParser,
+            },
+        },
     },
-    flags: {
-      count: {
-        kind: "parsed",
-        brief: "Number of times to say hello",
-        parse: numberParser,
-      },
+    docs: {
+        brief: description,
     },
-  },
-  docs: {
-    brief: description,
-  },
 });
 
 export const app = buildApplication(command, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -122,9 +122,16 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
 await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -141,56 +148,56 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/impl.ts
 import type { LocalContext } from "./context";
 
 interface CommandFlags {
-  readonly count: number;
+    readonly count: number;
 }
 
 export default async function(this: LocalContext, flags: CommandFlags, name: string): Promise<void> {
-  this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
+    this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom name and bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom name and bin command.txt
@@ -84,35 +84,35 @@ import { buildApplication, buildCommand, numberParser } from "@stricli/core";
 import { name, version, description } from "../package.json";
 
 const command = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [
-        {
-          brief: "Your name",
-          parse: String,
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [
+                {
+                    brief: "Your name",
+                    parse: String,
+                },
+            ],
         },
-      ],
+        flags: {
+            count: {
+                kind: "parsed",
+                brief: "Number of times to say hello",
+                parse: numberParser,
+            },
+        },
     },
-    flags: {
-      count: {
-        kind: "parsed",
-        brief: "Number of times to say hello",
-        parse: numberParser,
-      },
+    docs: {
+        brief: description,
     },
-  },
-  docs: {
-    brief: description,
-  },
 });
 
 export const app = buildApplication(command, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -122,9 +122,16 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
 await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -141,56 +148,56 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/impl.ts
 import type { LocalContext } from "./context";
 
 interface CommandFlags {
-  readonly count: number;
+    readonly count: number;
 }
 
 export default async function(this: LocalContext, flags: CommandFlags, name: string): Promise<void> {
-  this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
+    this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom name.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom name.txt
@@ -84,35 +84,35 @@ import { buildApplication, buildCommand, numberParser } from "@stricli/core";
 import { name, version, description } from "../package.json";
 
 const command = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [
-        {
-          brief: "Your name",
-          parse: String,
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [
+                {
+                    brief: "Your name",
+                    parse: String,
+                },
+            ],
         },
-      ],
+        flags: {
+            count: {
+                kind: "parsed",
+                brief: "Number of times to say hello",
+                parse: numberParser,
+            },
+        },
     },
-    flags: {
-      count: {
-        kind: "parsed",
-        brief: "Number of times to say hello",
-        parse: numberParser,
-      },
+    docs: {
+        brief: description,
     },
-  },
-  docs: {
-    brief: description,
-  },
 });
 
 export const app = buildApplication(command, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -122,9 +122,16 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
 await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -141,56 +148,56 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/impl.ts
 import type { LocalContext } from "./context";
 
 interface CommandFlags {
-  readonly count: number;
+    readonly count: number;
 }
 
 export default async function(this: LocalContext, flags: CommandFlags, name: string): Promise<void> {
-  this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
+    this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/with default flags.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/with default flags.txt
@@ -84,35 +84,35 @@ import { buildApplication, buildCommand, numberParser } from "@stricli/core";
 import { name, version, description } from "../package.json";
 
 const command = buildCommand({
-  loader: async () => import("./impl"),
-  parameters: {
-    positional: {
-      kind: "tuple",
-      parameters: [
-        {
-          brief: "Your name",
-          parse: String,
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [
+                {
+                    brief: "Your name",
+                    parse: String,
+                },
+            ],
         },
-      ],
+        flags: {
+            count: {
+                kind: "parsed",
+                brief: "Number of times to say hello",
+                parse: numberParser,
+            },
+        },
     },
-    flags: {
-      count: {
-        kind: "parsed",
-        brief: "Number of times to say hello",
-        parse: numberParser,
-      },
+    docs: {
+        brief: description,
     },
-  },
-  docs: {
-    brief: description,
-  },
 });
 
 export const app = buildApplication(command, {
-  name,
-  versionInfo: {
-    currentVersion: version,
-  },
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
 });
 
 ::::/root/test/src/bin/bash-complete.ts
@@ -122,9 +122,16 @@ import { buildContext } from "../context";
 import { app } from "../app";
 const inputs = process.argv.slice(3);
 if (process.env["COMP_LINE"]?.endsWith(" ")) {
-  inputs.push("");
+    inputs.push("");
 }
 await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
 
 ::::/root/test/src/bin/cli.ts
 #!/usr/bin/env node
@@ -141,56 +148,56 @@ import os from "node:os";
 import path from "node:path";
 
 export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
-  readonly process: NodeJS.Process;
-  // ...
+    readonly process: NodeJS.Process;
+    // ...
 }
 
 export function buildContext(process: NodeJS.Process): LocalContext {
-  return {
-    process,
-    os,
-    fs,
-    path,
-  };
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
 }
 
 ::::/root/test/src/impl.ts
 import type { LocalContext } from "./context";
 
 interface CommandFlags {
-  readonly count: number;
+    readonly count: number;
 }
 
 export default async function(this: LocalContext, flags: CommandFlags, name: string): Promise<void> {
-  this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
+    this.process.stdout.write(`Hello ${name}!\n`.repeat(flags.count));
 }
 
 ::::/root/test/src/tsconfig.json
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "rootDir": "..",
-    "types": [
-      "node"
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
     ],
-    "resolveJsonModule": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": [
-      "esnext"
-    ],
-    "skipLibCheck": true,
-    "strict": true,
-    "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true
-  },
-  "include": [
-    "**/*"
-  ],
-  "exclude": []
+    "exclude": []
 }


### PR DESCRIPTION
Resolves #17 

**Describe your changes**
Updates the autocomplete templates to iterate over the completions and print them to stdout (with a newline separator).

**Testing performed**
Generated sample app and tested/confirmed autocomplete functionality.

**Additional context**
While editing the files I also switched to 4-space in the template files so it would match our internal Prettier config.
