### PR TITLE
fix: export constituent types of TypedCommandParameters individually

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,7 +48,13 @@ export {
     UnsatisfiedPositionalError,
     formatMessageForArgumentScannerError,
 } from "./parameter/scanner";
-export type { InputParser, TypedCommandParameters } from "./parameter/types";
+export type {
+    Aliases,
+    InputParser,
+    TypedCommandFlagParameters,
+    TypedCommandParameters,
+    TypedCommandPositionalParameters,
+} from "./parameter/types";
 export { buildCommand } from "./routing/command/builder";
 export type { CommandBuilderArguments } from "./routing/command/builder";
 export type { Command } from "./routing/command/types";

--- a/packages/core/src/parameter/types.ts
+++ b/packages/core/src/parameter/types.ts
@@ -61,7 +61,7 @@ export type Aliases<T> = Readonly<Partial<Record<AvailableAlias, T>>>;
 
 export type BaseFlags = Readonly<Record<string, unknown>>;
 
-interface TypedCommandFlagParameters<FLAGS extends BaseFlags, CONTEXT extends CommandContext> {
+interface TypedCommandFlagParameters_<FLAGS extends BaseFlags, CONTEXT extends CommandContext> {
     /**
      * Typed definitions for all flag parameters.
      */
@@ -72,21 +72,21 @@ interface TypedCommandFlagParameters<FLAGS extends BaseFlags, CONTEXT extends Co
     readonly aliases?: Aliases<keyof FLAGS & string>;
 }
 
-type TypedCommandFlagParameters_<FLAGS extends BaseFlags, CONTEXT extends CommandContext> =
+export type TypedCommandFlagParameters<FLAGS extends BaseFlags, CONTEXT extends CommandContext> =
     Record<string, never> extends FLAGS
-        ? Partial<TypedCommandFlagParameters<FLAGS, CONTEXT>>
-        : TypedCommandFlagParameters<FLAGS, CONTEXT>;
+        ? Partial<TypedCommandFlagParameters_<FLAGS, CONTEXT>>
+        : TypedCommandFlagParameters_<FLAGS, CONTEXT>;
 
-interface TypedCommandPositionalParameters<ARGS extends BaseArgs, CONTEXT extends CommandContext> {
+interface TypedCommandPositionalParameters_<ARGS extends BaseArgs, CONTEXT extends CommandContext> {
     /**
      * Typed definitions for all positional parameters.
      */
     readonly positional: TypedPositionalParameters<ARGS, CONTEXT>;
 }
 
-type TypedCommandPositionalParameters_<ARGS extends BaseArgs, CONTEXT extends CommandContext> = [] extends ARGS
-    ? Partial<TypedCommandPositionalParameters<ARGS, CONTEXT>>
-    : TypedCommandPositionalParameters<ARGS, CONTEXT>;
+export type TypedCommandPositionalParameters<ARGS extends BaseArgs, CONTEXT extends CommandContext> = [] extends ARGS
+    ? Partial<TypedCommandPositionalParameters_<ARGS, CONTEXT>>
+    : TypedCommandPositionalParameters_<ARGS, CONTEXT>;
 
 /**
  * Definitions for all parameters requested by the corresponding command.
@@ -95,7 +95,7 @@ export type TypedCommandParameters<
     FLAGS extends BaseFlags,
     ARGS extends BaseArgs,
     CONTEXT extends CommandContext,
-> = TypedCommandFlagParameters_<FLAGS, CONTEXT> & TypedCommandPositionalParameters_<ARGS, CONTEXT>;
+> = TypedCommandFlagParameters<FLAGS, CONTEXT> & TypedCommandPositionalParameters<ARGS, CONTEXT>;
 
 /**
  * Definitions for all parameters requested by the corresponding command.


### PR DESCRIPTION
Resolves #22 

**Describe your changes**
Export constituent types of TypedCommandParameters individually. Renamed `TypedCommandFlagParameters` and `TypedCommandPositionalParameters` before exporting so the correct user-facing type is used.

**Testing performed**
Changes are type-only, relying on CI tests
