### PR TITLE
fix: allow flags to parse arrays without variadic modifier

### DIFF
--- a/packages/core/src/parameter/flag/types.ts
+++ b/packages/core/src/parameter/flag/types.ts
@@ -298,8 +298,11 @@ interface RequiredVariadicParsedFlagParameter<T, CONTEXT extends CommandContext>
 
 type TypedFlagParameter_Optional<T, CONTEXT extends CommandContext> = [T] extends [readonly (infer A)[]]
     ? [A] extends [string]
-        ? OptionalVariadicParsedFlagParameter<A, CONTEXT> | OptionalVariadicEnumFlagParameter<A>
-        : OptionalVariadicParsedFlagParameter<A, CONTEXT>
+        ?
+              | OptionalVariadicParsedFlagParameter<A, CONTEXT>
+              | OptionalParsedFlagParameter<T, CONTEXT>
+              | OptionalVariadicEnumFlagParameter<A>
+        : OptionalVariadicParsedFlagParameter<A, CONTEXT> | OptionalParsedFlagParameter<T, CONTEXT>
     : [T] extends [boolean]
       ? OptionalBooleanFlagParameter | OptionalParsedFlagParameter<boolean, CONTEXT>
       : [T] extends [number]
@@ -312,8 +315,11 @@ type TypedFlagParameter_Optional<T, CONTEXT extends CommandContext> = [T] extend
 
 type TypedFlagParameter_Required<T, CONTEXT extends CommandContext> = [T] extends [readonly (infer A)[]]
     ? [A] extends [string]
-        ? RequiredVariadicParsedFlagParameter<A, CONTEXT> | RequiredVariadicEnumFlagParameter<A>
-        : RequiredVariadicParsedFlagParameter<A, CONTEXT>
+        ?
+              | RequiredVariadicParsedFlagParameter<A, CONTEXT>
+              | RequiredParsedFlagParameter<readonly A[], CONTEXT>
+              | RequiredVariadicEnumFlagParameter<A>
+        : RequiredVariadicParsedFlagParameter<A, CONTEXT> | RequiredParsedFlagParameter<readonly A[], CONTEXT>
     : [T] extends [boolean]
       ? RequiredBooleanFlagParameter | RequiredParsedFlagParameter<boolean, CONTEXT>
       : [T] extends [number]

--- a/packages/core/tests/baselines/reference/parameter/flag/formatting.txt
+++ b/packages/core/tests/baselines/reference/parameter/flag/formatting.txt
@@ -50,6 +50,10 @@
 [97m[39m   [97m--required-parsed-with-kebab-case-name[39m  [03mrequired parsed flag with kebab-case name[23m
 [97m-h[39m [97m--help[39m                                  [03mPrint help information and exit[23m
 [97m[39m   [97m--[39m                                      [03mAll subsequent inputs should be interpreted as arguments[23m
+:::: formatDocumentationForFlagParameters / parsed / optional array parsed flag
+[97m[39m   [97m[--optionalArrayParsed][39m  [03moptional array parsed flag[23m
+[97m-h[39m [97m --help[39m                  [03mPrint help information and exit[23m
+[97m[39m   [97m --[39m                      [03mAll subsequent inputs should be interpreted as arguments[23m
 :::: formatDocumentationForFlagParameters / parsed / optional parsed flag
 [97m[39m   [97m[--optionalParsed][39m  [03moptional parsed flag[23m
 [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
@@ -62,6 +66,10 @@
 [97m[39m   [97m[--optionalVariadicParsed]...[39m  [03moptional variadic parsed flag[23m
 [97m-h[39m [97m --help[39m                        [03mPrint help information and exit[23m
 [97m[39m   [97m --[39m                            [03mAll subsequent inputs should be interpreted as arguments[23m
+:::: formatDocumentationForFlagParameters / parsed / required array parsed flag
+[97m[39m   [97m--requiredArrayParsed[39m  [03mrequired array parsed flag[23m
+[97m-h[39m [97m--help[39m                 [03mPrint help information and exit[23m
+[97m[39m   [97m--[39m                     [03mAll subsequent inputs should be interpreted as arguments[23m
 :::: formatDocumentationForFlagParameters / parsed / required parsed flag
 [97m[39m   [97m--requiredParsed[39m  [03mrequired parsed flag[23m
 [97m-h[39m [97m--help[39m            [03mPrint help information and exit[23m

--- a/packages/core/tests/baselines/reference/parameter/formatting.txt
+++ b/packages/core/tests/baselines/reference/parameter/formatting.txt
@@ -12,6 +12,8 @@ cli [--optionalEnum a|b|c]
 cli (--requiredEnum a|b|c)
 :::: formatUsageLineForParameters / flags / enum / required enum flag with default
 cli [--requiredEnum a|b|c]
+:::: formatUsageLineForParameters / flags / parsed / optional array parsed flag
+cli [--optionalArrayParsed value]
 :::: formatUsageLineForParameters / flags / parsed / optional parsed flag
 cli [--optionalParsed value]
 :::: formatUsageLineForParameters / flags / parsed / optional parsed flag [hidden]
@@ -20,6 +22,8 @@ cli
 cli [--optionalParsed parsed]
 :::: formatUsageLineForParameters / flags / parsed / optional variadic parsed flag
 cli [--optionalVariadicParsed value]...
+:::: formatUsageLineForParameters / flags / parsed / required array parsed flag
+cli (--requiredArrayParsed value)
 :::: formatUsageLineForParameters / flags / parsed / required parsed flag
 cli (--requiredParsed value)
 :::: formatUsageLineForParameters / flags / parsed / required parsed flag with alias

--- a/packages/core/tests/parameter/flag/formatting.spec.ts
+++ b/packages/core/tests/parameter/flag/formatting.spec.ts
@@ -637,6 +637,61 @@ describe("formatDocumentationForFlagParameters", function () {
             compareToBaseline(this, StringArrayBaselineFormat, lines);
         });
 
+        it("required array parsed flag", function () {
+            // GIVEN
+            type Positional = [];
+            type Flags = {
+                readonly requiredArrayParsed: string[];
+            };
+
+            const parameters: TypedCommandParameters<Flags, Positional, CommandContext> = {
+                flags: {
+                    requiredArrayParsed: {
+                        kind: "parsed",
+                        parse: (values) => values.split(","),
+                        brief: "required array parsed flag",
+                    },
+                },
+                positional: { kind: "tuple", parameters: [] },
+            };
+
+            // WHEN
+            const lines = formatDocumentationForFlagParameters(parameters.flags, parameters.aliases ?? {}, defaultArgs);
+
+            // THEN
+            compareToBaseline(this, StringArrayBaselineFormat, lines);
+        });
+
+        it("optional array parsed flag", function () {
+            // GIVEN
+            type Positional = [];
+            type Flags = {
+                readonly optionalArrayParsed?: string[];
+            };
+
+            const parameters: TypedCommandParameters<Flags, Positional, CommandContext> = {
+                flags: {
+                    optionalArrayParsed: {
+                        kind: "parsed",
+                        parse: (values) => values.split(","),
+                        optional: true,
+                        brief: "optional array parsed flag",
+                    },
+                },
+                positional: { kind: "tuple", parameters: [] },
+            };
+
+            // WHEN
+            const lines = formatDocumentationForFlagParameters(
+                parameters.flags ?? {},
+                parameters.aliases ?? {},
+                defaultArgs,
+            );
+
+            // THEN
+            compareToBaseline(this, StringArrayBaselineFormat, lines);
+        });
+
         it("multiple parsed flags", function () {
             // GIVEN
             type Positional = [];

--- a/packages/core/tests/parameter/formatting.spec.ts
+++ b/packages/core/tests/parameter/formatting.spec.ts
@@ -676,6 +676,57 @@ describe("formatUsageLineForParameters", function () {
                 // THEN
                 compareToBaseline(this, StringArrayBaselineFormat, [line]);
             });
+
+            it("required array parsed flag", function () {
+                // GIVEN
+                type Positional = [];
+                type Flags = {
+                    readonly requiredArrayParsed: string[];
+                };
+
+                const parameters: TypedCommandParameters<Flags, Positional, CommandContext> = {
+                    flags: {
+                        requiredArrayParsed: {
+                            kind: "parsed",
+                            parse: (values) => values.split(","),
+                            brief: "required array parsed flag",
+                        },
+                    },
+                    positional: { kind: "tuple", parameters: [] },
+                };
+
+                // WHEN
+                const line = formatUsageLineForParameters(parameters, defaultArgs);
+
+                // THEN
+                compareToBaseline(this, StringArrayBaselineFormat, [line]);
+            });
+
+            it("optional array parsed flag", function () {
+                // GIVEN
+                type Positional = [];
+                type Flags = {
+                    readonly optionalArrayParsed?: string[];
+                };
+
+                const parameters: TypedCommandParameters<Flags, Positional, CommandContext> = {
+                    flags: {
+                        optionalArrayParsed: {
+                            kind: "parsed",
+                            parse: (values) => values.split(","),
+                            optional: true,
+                            brief: "optional array parsed flag",
+                        },
+                    },
+                    positional: { kind: "tuple", parameters: [] },
+                };
+
+                // WHEN
+                const line = formatUsageLineForParameters(parameters, defaultArgs);
+
+                // THEN
+                compareToBaseline(this, StringArrayBaselineFormat, [line]);
+            });
         });
     });
 });


### PR DESCRIPTION
Resolves #21 

**Describe your changes**
Prior to this change, any flag type that extended from `readonly (infer A)[]` would be interpreted as a `variadic` parameter. The variadic modifier allows the flag to be specified multiple times, each input parsed separately, and the results returned as an array. However, this did not allow for the use case that a single parsed value (i.e. `--flag=a,b,c`) could produce an array as output (`["a", "b", "c"]`).

With this change, the `variadic` modifier can be dropped from flags with an array-based type and the parser will then expect that exact array-based type as output.

**Testing performed**
Updated both formatting and scanner tests to confirm the new behavior.

**Additional context**
This also allows for the possibility of accepting specific array-based types as flags, such as subclasses of `TypedArray` (types that are not only `Array`).