### PR TITLE
chore: remove docs/examples from release, use conventional commits

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -45,8 +45,11 @@
     },
     "defaultBase": "main",
     "release": {
-        "projects": ["@stricli/*", "stricli-*-example"],
+        "projects": ["@stricli/*", "!@stricli/docs"],
         "releaseTagPattern": "release/{version}",
+        "version": {
+            "conventionalCommits": true
+        },
         "git": {
             "commitMessage": "chore(release): {version}"
         }


### PR DESCRIPTION
**Describe your changes**
Should not release `stricli-*-example` packages or `@stricli/docs` package (as they are not published). As well, use conventional commits to determine the next version.

**Testing performed**
Ran `nx release --dry-run`.
