### PR TITLE
ci: enable id-token permission for npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
 permissions:
     actions: read
     contents: write
+    id-token: write
 
 jobs:
     release:


### PR DESCRIPTION
**Describe your changes**
Required to publish npm provenance https://nx.dev/recipes/nx-release/publish-in-ci-cd#npm-provenance
