### PR TITLE
fix: verify @types/node version with registry

### DIFF
--- a/packages/create-app/src/app.ts
+++ b/packages/create-app/src/app.ts
@@ -1,6 +1,6 @@
 // Copyright 2024 Bloomberg Finance L.P.
 // Distributed under the terms of the Apache 2.0 license.
-import { buildApplication, buildCommand } from "@stricli/core";
+import { buildApplication, buildCommand, numberParser } from "@stricli/core";
 import packageJson from "../package.json";
 
 const command = buildCommand({
@@ -66,6 +66,13 @@ const command = buildCommand({
                 brief: "Package author",
                 parse: String,
                 default: "",
+            },
+            nodeVersion: {
+                kind: "parsed",
+                brief: "Node.js major version to use for engines.node minimum and @types/node, bypasses version discovery logic",
+                parse: numberParser,
+                optional: true,
+                hidden: true,
             },
         },
         aliases: {

--- a/packages/create-app/src/app.ts
+++ b/packages/create-app/src/app.ts
@@ -4,6 +4,7 @@ import { buildApplication, buildCommand } from "@stricli/core";
 import packageJson from "../package.json";
 
 const command = buildCommand({
+    /* c8 ignore next */
     loader: async () => import("./impl"),
     parameters: {
         positional: {

--- a/packages/create-app/src/impl.ts
+++ b/packages/create-app/src/impl.ts
@@ -115,6 +115,7 @@ export interface CreateProjectFlags extends PackageJsonTemplateValues {
     readonly template: "single" | "multi";
     readonly autoComplete: boolean;
     readonly command?: string;
+    readonly nodeVersion?: number;
 }
 
 export default async function (this: LocalContext, flags: CreateProjectFlags, directoryPath: string): Promise<void> {
@@ -137,7 +138,12 @@ export default async function (this: LocalContext, flags: CreateProjectFlags, di
     const packageName = flags.name ?? path.basename(directoryPath);
     const commandName = flags.command ?? packageName;
 
-    const nodeVersions = await calculateAcceptableNodeVersions(this.process);
+    let nodeVersions: NodeVersions;
+    if (flags.nodeVersion) {
+        nodeVersions = { engine: `>=${flags.nodeVersion}`, types: `${flags.nodeVersion}.x` };
+    } else {
+        nodeVersions = await calculateAcceptableNodeVersions(this.process);
+    }
 
     let packageJson = buildPackageJson(
         {

--- a/packages/create-app/src/node.ts
+++ b/packages/create-app/src/node.ts
@@ -36,6 +36,9 @@ export async function calculateAcceptableNodeVersions(process: NodeJS.Process): 
                     process.stderr.write(
                         `No version of @types/node found with major ${majorVersion}, falling back to ${typesVersion}\n`,
                     );
+                    process.stderr.write(
+                        `Rerun this command with the hidden flag --node-version to manually specify the Node.js major version`,
+                    );
                 }
             }
         }
@@ -48,6 +51,9 @@ export async function calculateAcceptableNodeVersions(process: NodeJS.Process): 
         // Should only be hit if something went wrong determining registry URL or fetching from registry.
         process.stderr.write(
             `Unable to determine version of @types/node for ${process.versions.node}, assuming ${typesVersion}\n`,
+        );
+        process.stderr.write(
+            `Rerun this command with the hidden flag --node-version to manually specify the Node.js major version`,
         );
     }
 

--- a/packages/create-app/src/node.ts
+++ b/packages/create-app/src/node.ts
@@ -1,0 +1,58 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// Distributed under the terms of the Apache 2.0 license.
+import { discoverPackageRegistry, fetchPackageVersions } from "./registry";
+
+export interface NodeVersions {
+    readonly engine: string;
+    readonly types: string;
+}
+
+const MAXIMUM_KNOWN_SAFE_NODE_TYPES_VERSION = 22;
+
+export async function calculateAcceptableNodeVersions(process: NodeJS.Process): Promise<NodeVersions> {
+    const majorVersion = Number(process.versions.node.split(".")[0]);
+    let typesVersion: string | undefined;
+
+    if (majorVersion > MAXIMUM_KNOWN_SAFE_NODE_TYPES_VERSION) {
+        // To avoid hitting the registry every time, only run when higher than a statically-known maximum safe value.
+        const registry = discoverPackageRegistry(process);
+        const versions = registry && (await fetchPackageVersions(registry, "@types/node"));
+        if (versions?.includes(process.versions.node)) {
+            typesVersion = `^${process.versions.node}`;
+        } else if (versions) {
+            const typeMajors = new Set(versions.map((version) => Number(version.split(".")[0])));
+            if (typeMajors.has(majorVersion)) {
+                // Previously unknown major version exists, which means MAXIMUM_KNOWN_SAFE_NODE_TYPES_VERSION should be updated.
+                typesVersion = `${majorVersion}.x`;
+            } else {
+                // Filter available major versions to just even (LTS) and pick highest.
+                // This assumes that types will exist for the LTS version just prior to the current unknown major version.
+                const highestEvenTypeMajor = [...typeMajors]
+                    .filter((major) => major % 2 === 0)
+                    .toSorted()
+                    .at(-1);
+                if (highestEvenTypeMajor) {
+                    typesVersion = `${highestEvenTypeMajor}.x`;
+                    process.stderr.write(
+                        `No version of @types/node found with major ${majorVersion}, falling back to ${typesVersion}\n`,
+                    );
+                }
+            }
+        }
+    } else {
+        typesVersion = `${majorVersion}.x`;
+    }
+
+    if (!typesVersion) {
+        typesVersion = `${majorVersion}.x`;
+        // Should only be hit if something went wrong determining registry URL or fetching from registry.
+        process.stderr.write(
+            `Unable to determine version of @types/node for ${process.versions.node}, assuming ${typesVersion}\n`,
+        );
+    }
+
+    return {
+        engine: `>=${majorVersion}`,
+        types: typesVersion,
+    };
+}

--- a/packages/create-app/src/registry.ts
+++ b/packages/create-app/src/registry.ts
@@ -1,0 +1,29 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// Distributed under the terms of the Apache 2.0 license.
+import child_process from "node:child_process";
+
+export function discoverPackageRegistry(process: NodeJS.Process): string | undefined {
+    if (process.env["NPM_CONFIG_REGISTRY"]) {
+        return process.env["NPM_CONFIG_REGISTRY"];
+    }
+
+    if (process.env["NPM_EXECPATH"]) {
+        return child_process
+            .execFileSync(process.execPath, [process.env["NPM_EXECPATH"], "config", "get", "registry"], {
+                encoding: "utf-8",
+            })
+            .trim();
+    }
+}
+
+export async function fetchPackageVersions(
+    registry: string,
+    packageName: string,
+): Promise<readonly string[] | undefined> {
+    const input = registry + (registry.endsWith("/") ? packageName : `/${packageName}`);
+    const response = await fetch(input);
+    const data = await response.json();
+    if (typeof data === "object" && data && "versions" in data && typeof data.versions === "object") {
+        return Object.keys(data.versions ?? {});
+    }
+}

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/node version logic/exact version exists for types.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/node version logic/exact version exists for types.txt
@@ -1,0 +1,277 @@
+[STDOUT]
+
+[STDERR]
+
+[FILES]
+::::/home/node-version-test/.gitignore
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+*.tsbuildinfo
+dist
+
+::::/home/node-version-test/package.json
+{
+  "name": "node-version-test",
+  "author": "",
+  "description": "Stricli command line application",
+  "license": "MIT",
+  "type": "module",
+  "version": "0.0.0",
+  "files": [
+    "dist"
+  ],
+  "bin": {
+    "node-version-test": "dist/cli.js",
+    "__node-version-test_bash_complete": "dist/bash-complete.js"
+  },
+  "engines": {
+    "node": ">=30"
+  },
+  "scripts": {
+    "prebuild": "tsc -p src/tsconfig.json",
+    "build": "tsup",
+    "prepublishOnly": "npm run build",
+    "postinstall": "node-version-test install"
+  },
+  "tsup": {
+    "entry": [
+      "src/bin/cli.ts",
+      "src/bin/bash-complete.ts"
+    ],
+    "format": [
+      "esm"
+    ],
+    "tsconfig": "src/tsconfig.json",
+    "clean": true,
+    "splitting": true,
+    "minify": true
+  },
+  "dependencies": {
+    "@stricli/core": "<self>",
+    "@stricli/auto-complete": "<self>"
+  },
+  "devDependencies": {
+    "@types/node": "^30.0.0",
+    "tsup": "^6.7.0",
+    "typescript": "5.6.x"
+  }
+}
+::::/home/node-version-test/src/app.ts
+import { buildApplication, buildRouteMap } from "@stricli/core";
+import { buildInstallCommand, buildUninstallCommand } from "@stricli/auto-complete";
+import { name, version, description } from "../package.json";
+import { subdirCommand } from "./commands/subdir/command";
+import { nestedRoutes } from "./commands/nested/commands";
+
+const routes = buildRouteMap({
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("node-version-test", { bash: "__node-version-test_bash_complete" }),
+        uninstall: buildUninstallCommand("node-version-test", { bash: true }),
+    },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
+});
+
+export const app = buildApplication(routes, {
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
+});
+
+::::/home/node-version-test/src/bin/bash-complete.ts
+#!/usr/bin/env node
+import { proposeCompletions } from "@stricli/core";
+import { buildContext } from "../context";
+import { app } from "../app";
+const inputs = process.argv.slice(3);
+if (process.env["COMP_LINE"]?.endsWith(" ")) {
+    inputs.push("");
+}
+await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
+
+::::/home/node-version-test/src/bin/cli.ts
+#!/usr/bin/env node
+import { run } from "@stricli/core";
+import { buildContext } from "../context";
+import { app } from "../app";
+await run(app, process.argv.slice(2), buildContext(process));
+
+::::/home/node-version-test/src/commands/nested/commands.ts
+import { buildCommand, buildRouteMap } from "@stricli/core";
+
+export const fooCommand = buildCommand({
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
+    },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
+});
+
+export const barCommand = buildCommand({
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
+    },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
+});
+
+export const nestedRoutes = buildRouteMap({
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
+});
+
+::::/home/node-version-test/src/commands/nested/impl.ts
+import type { LocalContext } from "../../context";
+
+interface FooCommandFlags {
+    // ...
+}
+
+export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
+    // ...
+}
+
+interface BarCommandFlags {
+    // ...
+}
+
+export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
+    // ...
+}
+
+::::/home/node-version-test/src/commands/subdir/command.ts
+import { buildCommand } from "@stricli/core";
+
+export const subdirCommand = buildCommand({
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Command in subdirectory",
+    },
+});
+
+::::/home/node-version-test/src/commands/subdir/impl.ts
+import type { LocalContext } from "../../context";
+
+interface SubdirCommandFlags {
+    // ...
+}
+
+export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
+    // ...
+}
+
+::::/home/node-version-test/src/context.ts
+import type { CommandContext } from "@stricli/core";
+import type { StricliAutoCompleteContext } from "@stricli/auto-complete";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
+    readonly process: NodeJS.Process;
+    // ...
+}
+
+export function buildContext(process: NodeJS.Process): LocalContext {
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
+}
+
+::::/home/node-version-test/src/tsconfig.json
+{
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
+    ],
+    "exclude": []
+}

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/node version logic/major version does not exist in registry, picks highest even major.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/node version logic/major version does not exist in registry, picks highest even major.txt
@@ -1,0 +1,278 @@
+[STDOUT]
+
+[STDERR]
+No version of @types/node found with major 30, falling back to 20.x
+
+[FILES]
+::::/home/node-version-test/.gitignore
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+*.tsbuildinfo
+dist
+
+::::/home/node-version-test/package.json
+{
+  "name": "node-version-test",
+  "author": "",
+  "description": "Stricli command line application",
+  "license": "MIT",
+  "type": "module",
+  "version": "0.0.0",
+  "files": [
+    "dist"
+  ],
+  "bin": {
+    "node-version-test": "dist/cli.js",
+    "__node-version-test_bash_complete": "dist/bash-complete.js"
+  },
+  "engines": {
+    "node": ">=30"
+  },
+  "scripts": {
+    "prebuild": "tsc -p src/tsconfig.json",
+    "build": "tsup",
+    "prepublishOnly": "npm run build",
+    "postinstall": "node-version-test install"
+  },
+  "tsup": {
+    "entry": [
+      "src/bin/cli.ts",
+      "src/bin/bash-complete.ts"
+    ],
+    "format": [
+      "esm"
+    ],
+    "tsconfig": "src/tsconfig.json",
+    "clean": true,
+    "splitting": true,
+    "minify": true
+  },
+  "dependencies": {
+    "@stricli/core": "<self>",
+    "@stricli/auto-complete": "<self>"
+  },
+  "devDependencies": {
+    "@types/node": "20.x",
+    "tsup": "^6.7.0",
+    "typescript": "5.6.x"
+  }
+}
+::::/home/node-version-test/src/app.ts
+import { buildApplication, buildRouteMap } from "@stricli/core";
+import { buildInstallCommand, buildUninstallCommand } from "@stricli/auto-complete";
+import { name, version, description } from "../package.json";
+import { subdirCommand } from "./commands/subdir/command";
+import { nestedRoutes } from "./commands/nested/commands";
+
+const routes = buildRouteMap({
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("node-version-test", { bash: "__node-version-test_bash_complete" }),
+        uninstall: buildUninstallCommand("node-version-test", { bash: true }),
+    },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
+});
+
+export const app = buildApplication(routes, {
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
+});
+
+::::/home/node-version-test/src/bin/bash-complete.ts
+#!/usr/bin/env node
+import { proposeCompletions } from "@stricli/core";
+import { buildContext } from "../context";
+import { app } from "../app";
+const inputs = process.argv.slice(3);
+if (process.env["COMP_LINE"]?.endsWith(" ")) {
+    inputs.push("");
+}
+await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
+
+::::/home/node-version-test/src/bin/cli.ts
+#!/usr/bin/env node
+import { run } from "@stricli/core";
+import { buildContext } from "../context";
+import { app } from "../app";
+await run(app, process.argv.slice(2), buildContext(process));
+
+::::/home/node-version-test/src/commands/nested/commands.ts
+import { buildCommand, buildRouteMap } from "@stricli/core";
+
+export const fooCommand = buildCommand({
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
+    },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
+});
+
+export const barCommand = buildCommand({
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
+    },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
+});
+
+export const nestedRoutes = buildRouteMap({
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
+});
+
+::::/home/node-version-test/src/commands/nested/impl.ts
+import type { LocalContext } from "../../context";
+
+interface FooCommandFlags {
+    // ...
+}
+
+export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
+    // ...
+}
+
+interface BarCommandFlags {
+    // ...
+}
+
+export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
+    // ...
+}
+
+::::/home/node-version-test/src/commands/subdir/command.ts
+import { buildCommand } from "@stricli/core";
+
+export const subdirCommand = buildCommand({
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Command in subdirectory",
+    },
+});
+
+::::/home/node-version-test/src/commands/subdir/impl.ts
+import type { LocalContext } from "../../context";
+
+interface SubdirCommandFlags {
+    // ...
+}
+
+export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
+    // ...
+}
+
+::::/home/node-version-test/src/context.ts
+import type { CommandContext } from "@stricli/core";
+import type { StricliAutoCompleteContext } from "@stricli/auto-complete";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
+    readonly process: NodeJS.Process;
+    // ...
+}
+
+export function buildContext(process: NodeJS.Process): LocalContext {
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
+}
+
+::::/home/node-version-test/src/tsconfig.json
+{
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
+    ],
+    "exclude": []
+}

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/node version logic/major version exists in registry.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/node version logic/major version exists in registry.txt
@@ -1,0 +1,277 @@
+[STDOUT]
+
+[STDERR]
+
+[FILES]
+::::/home/node-version-test/.gitignore
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+*.tsbuildinfo
+dist
+
+::::/home/node-version-test/package.json
+{
+  "name": "node-version-test",
+  "author": "",
+  "description": "Stricli command line application",
+  "license": "MIT",
+  "type": "module",
+  "version": "0.0.0",
+  "files": [
+    "dist"
+  ],
+  "bin": {
+    "node-version-test": "dist/cli.js",
+    "__node-version-test_bash_complete": "dist/bash-complete.js"
+  },
+  "engines": {
+    "node": ">=30"
+  },
+  "scripts": {
+    "prebuild": "tsc -p src/tsconfig.json",
+    "build": "tsup",
+    "prepublishOnly": "npm run build",
+    "postinstall": "node-version-test install"
+  },
+  "tsup": {
+    "entry": [
+      "src/bin/cli.ts",
+      "src/bin/bash-complete.ts"
+    ],
+    "format": [
+      "esm"
+    ],
+    "tsconfig": "src/tsconfig.json",
+    "clean": true,
+    "splitting": true,
+    "minify": true
+  },
+  "dependencies": {
+    "@stricli/core": "<self>",
+    "@stricli/auto-complete": "<self>"
+  },
+  "devDependencies": {
+    "@types/node": "30.x",
+    "tsup": "^6.7.0",
+    "typescript": "5.6.x"
+  }
+}
+::::/home/node-version-test/src/app.ts
+import { buildApplication, buildRouteMap } from "@stricli/core";
+import { buildInstallCommand, buildUninstallCommand } from "@stricli/auto-complete";
+import { name, version, description } from "../package.json";
+import { subdirCommand } from "./commands/subdir/command";
+import { nestedRoutes } from "./commands/nested/commands";
+
+const routes = buildRouteMap({
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("node-version-test", { bash: "__node-version-test_bash_complete" }),
+        uninstall: buildUninstallCommand("node-version-test", { bash: true }),
+    },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
+});
+
+export const app = buildApplication(routes, {
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
+});
+
+::::/home/node-version-test/src/bin/bash-complete.ts
+#!/usr/bin/env node
+import { proposeCompletions } from "@stricli/core";
+import { buildContext } from "../context";
+import { app } from "../app";
+const inputs = process.argv.slice(3);
+if (process.env["COMP_LINE"]?.endsWith(" ")) {
+    inputs.push("");
+}
+await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
+
+::::/home/node-version-test/src/bin/cli.ts
+#!/usr/bin/env node
+import { run } from "@stricli/core";
+import { buildContext } from "../context";
+import { app } from "../app";
+await run(app, process.argv.slice(2), buildContext(process));
+
+::::/home/node-version-test/src/commands/nested/commands.ts
+import { buildCommand, buildRouteMap } from "@stricli/core";
+
+export const fooCommand = buildCommand({
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
+    },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
+});
+
+export const barCommand = buildCommand({
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
+    },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
+});
+
+export const nestedRoutes = buildRouteMap({
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
+});
+
+::::/home/node-version-test/src/commands/nested/impl.ts
+import type { LocalContext } from "../../context";
+
+interface FooCommandFlags {
+    // ...
+}
+
+export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
+    // ...
+}
+
+interface BarCommandFlags {
+    // ...
+}
+
+export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
+    // ...
+}
+
+::::/home/node-version-test/src/commands/subdir/command.ts
+import { buildCommand } from "@stricli/core";
+
+export const subdirCommand = buildCommand({
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Command in subdirectory",
+    },
+});
+
+::::/home/node-version-test/src/commands/subdir/impl.ts
+import type { LocalContext } from "../../context";
+
+interface SubdirCommandFlags {
+    // ...
+}
+
+export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
+    // ...
+}
+
+::::/home/node-version-test/src/context.ts
+import type { CommandContext } from "@stricli/core";
+import type { StricliAutoCompleteContext } from "@stricli/auto-complete";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
+    readonly process: NodeJS.Process;
+    // ...
+}
+
+export function buildContext(process: NodeJS.Process): LocalContext {
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
+}
+
+::::/home/node-version-test/src/tsconfig.json
+{
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
+    ],
+    "exclude": []
+}

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/node version logic/version discovery skipped when --node-version is provided.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/node version logic/version discovery skipped when --node-version is provided.txt
@@ -1,8 +1,7 @@
 [STDOUT]
 
 [STDERR]
-No version of @types/node found with major 30, falling back to 20.x
-Rerun this command with the hidden flag --node-version to manually specify the Node.js major version
+
 [FILES]
 ::::/home/node-version-test/.gitignore
 # Logs
@@ -49,7 +48,7 @@ dist
     "__node-version-test_bash_complete": "dist/bash-complete.js"
   },
   "engines": {
-    "node": ">=30"
+    "node": ">=31"
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
@@ -75,7 +74,7 @@ dist
     "@stricli/auto-complete": "<self>"
   },
   "devDependencies": {
-    "@types/node": "20.x",
+    "@types/node": "31.x",
     "tsup": "^6.7.0",
     "typescript": "5.6.x"
   }

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/NPM_EXECPATH throws an error.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/NPM_EXECPATH throws an error.txt
@@ -1,0 +1,7 @@
+[STDOUT]
+
+[STDERR]
+Command failed, Error: Failed to execute NPM_EXECPATH
+    at Context.<anonymous> (#/tests/app.spec.ts:?:?)
+
+[FILES]

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/no check for safe major version.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/no check for safe major version.txt
@@ -1,0 +1,277 @@
+[STDOUT]
+
+[STDERR]
+
+[FILES]
+::::/home/node-version-test/.gitignore
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+*.tsbuildinfo
+dist
+
+::::/home/node-version-test/package.json
+{
+  "name": "node-version-test",
+  "author": "",
+  "description": "Stricli command line application",
+  "license": "MIT",
+  "type": "module",
+  "version": "0.0.0",
+  "files": [
+    "dist"
+  ],
+  "bin": {
+    "node-version-test": "dist/cli.js",
+    "__node-version-test_bash_complete": "dist/bash-complete.js"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "prebuild": "tsc -p src/tsconfig.json",
+    "build": "tsup",
+    "prepublishOnly": "npm run build",
+    "postinstall": "node-version-test install"
+  },
+  "tsup": {
+    "entry": [
+      "src/bin/cli.ts",
+      "src/bin/bash-complete.ts"
+    ],
+    "format": [
+      "esm"
+    ],
+    "tsconfig": "src/tsconfig.json",
+    "clean": true,
+    "splitting": true,
+    "minify": true
+  },
+  "dependencies": {
+    "@stricli/core": "<self>",
+    "@stricli/auto-complete": "<self>"
+  },
+  "devDependencies": {
+    "@types/node": "20.x",
+    "tsup": "^6.7.0",
+    "typescript": "5.6.x"
+  }
+}
+::::/home/node-version-test/src/app.ts
+import { buildApplication, buildRouteMap } from "@stricli/core";
+import { buildInstallCommand, buildUninstallCommand } from "@stricli/auto-complete";
+import { name, version, description } from "../package.json";
+import { subdirCommand } from "./commands/subdir/command";
+import { nestedRoutes } from "./commands/nested/commands";
+
+const routes = buildRouteMap({
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("node-version-test", { bash: "__node-version-test_bash_complete" }),
+        uninstall: buildUninstallCommand("node-version-test", { bash: true }),
+    },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
+});
+
+export const app = buildApplication(routes, {
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
+});
+
+::::/home/node-version-test/src/bin/bash-complete.ts
+#!/usr/bin/env node
+import { proposeCompletions } from "@stricli/core";
+import { buildContext } from "../context";
+import { app } from "../app";
+const inputs = process.argv.slice(3);
+if (process.env["COMP_LINE"]?.endsWith(" ")) {
+    inputs.push("");
+}
+await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
+
+::::/home/node-version-test/src/bin/cli.ts
+#!/usr/bin/env node
+import { run } from "@stricli/core";
+import { buildContext } from "../context";
+import { app } from "../app";
+await run(app, process.argv.slice(2), buildContext(process));
+
+::::/home/node-version-test/src/commands/nested/commands.ts
+import { buildCommand, buildRouteMap } from "@stricli/core";
+
+export const fooCommand = buildCommand({
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
+    },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
+});
+
+export const barCommand = buildCommand({
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
+    },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
+});
+
+export const nestedRoutes = buildRouteMap({
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
+});
+
+::::/home/node-version-test/src/commands/nested/impl.ts
+import type { LocalContext } from "../../context";
+
+interface FooCommandFlags {
+    // ...
+}
+
+export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
+    // ...
+}
+
+interface BarCommandFlags {
+    // ...
+}
+
+export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
+    // ...
+}
+
+::::/home/node-version-test/src/commands/subdir/command.ts
+import { buildCommand } from "@stricli/core";
+
+export const subdirCommand = buildCommand({
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Command in subdirectory",
+    },
+});
+
+::::/home/node-version-test/src/commands/subdir/impl.ts
+import type { LocalContext } from "../../context";
+
+interface SubdirCommandFlags {
+    // ...
+}
+
+export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
+    // ...
+}
+
+::::/home/node-version-test/src/context.ts
+import type { CommandContext } from "@stricli/core";
+import type { StricliAutoCompleteContext } from "@stricli/auto-complete";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
+    readonly process: NodeJS.Process;
+    // ...
+}
+
+export function buildContext(process: NodeJS.Process): LocalContext {
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
+}
+
+::::/home/node-version-test/src/tsconfig.json
+{
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
+    ],
+    "exclude": []
+}

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/reads registry direct from NPM_CONFIG_REGISTRY, URL ends with slash.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/reads registry direct from NPM_CONFIG_REGISTRY, URL ends with slash.txt
@@ -2,7 +2,7 @@
 
 [STDERR]
 Unable to determine version of @types/node for 30.0.0, assuming 30.x
-
+Rerun this command with the hidden flag --node-version to manually specify the Node.js major version
 [FILES]
 ::::/home/node-version-test/.gitignore
 # Logs

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/reads registry direct from NPM_CONFIG_REGISTRY, URL ends with slash.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/reads registry direct from NPM_CONFIG_REGISTRY, URL ends with slash.txt
@@ -1,0 +1,278 @@
+[STDOUT]
+
+[STDERR]
+Unable to determine version of @types/node for 30.0.0, assuming 30.x
+
+[FILES]
+::::/home/node-version-test/.gitignore
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+*.tsbuildinfo
+dist
+
+::::/home/node-version-test/package.json
+{
+  "name": "node-version-test",
+  "author": "",
+  "description": "Stricli command line application",
+  "license": "MIT",
+  "type": "module",
+  "version": "0.0.0",
+  "files": [
+    "dist"
+  ],
+  "bin": {
+    "node-version-test": "dist/cli.js",
+    "__node-version-test_bash_complete": "dist/bash-complete.js"
+  },
+  "engines": {
+    "node": ">=30"
+  },
+  "scripts": {
+    "prebuild": "tsc -p src/tsconfig.json",
+    "build": "tsup",
+    "prepublishOnly": "npm run build",
+    "postinstall": "node-version-test install"
+  },
+  "tsup": {
+    "entry": [
+      "src/bin/cli.ts",
+      "src/bin/bash-complete.ts"
+    ],
+    "format": [
+      "esm"
+    ],
+    "tsconfig": "src/tsconfig.json",
+    "clean": true,
+    "splitting": true,
+    "minify": true
+  },
+  "dependencies": {
+    "@stricli/core": "<self>",
+    "@stricli/auto-complete": "<self>"
+  },
+  "devDependencies": {
+    "@types/node": "30.x",
+    "tsup": "^6.7.0",
+    "typescript": "5.6.x"
+  }
+}
+::::/home/node-version-test/src/app.ts
+import { buildApplication, buildRouteMap } from "@stricli/core";
+import { buildInstallCommand, buildUninstallCommand } from "@stricli/auto-complete";
+import { name, version, description } from "../package.json";
+import { subdirCommand } from "./commands/subdir/command";
+import { nestedRoutes } from "./commands/nested/commands";
+
+const routes = buildRouteMap({
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("node-version-test", { bash: "__node-version-test_bash_complete" }),
+        uninstall: buildUninstallCommand("node-version-test", { bash: true }),
+    },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
+});
+
+export const app = buildApplication(routes, {
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
+});
+
+::::/home/node-version-test/src/bin/bash-complete.ts
+#!/usr/bin/env node
+import { proposeCompletions } from "@stricli/core";
+import { buildContext } from "../context";
+import { app } from "../app";
+const inputs = process.argv.slice(3);
+if (process.env["COMP_LINE"]?.endsWith(" ")) {
+    inputs.push("");
+}
+await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
+
+::::/home/node-version-test/src/bin/cli.ts
+#!/usr/bin/env node
+import { run } from "@stricli/core";
+import { buildContext } from "../context";
+import { app } from "../app";
+await run(app, process.argv.slice(2), buildContext(process));
+
+::::/home/node-version-test/src/commands/nested/commands.ts
+import { buildCommand, buildRouteMap } from "@stricli/core";
+
+export const fooCommand = buildCommand({
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
+    },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
+});
+
+export const barCommand = buildCommand({
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
+    },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
+});
+
+export const nestedRoutes = buildRouteMap({
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
+});
+
+::::/home/node-version-test/src/commands/nested/impl.ts
+import type { LocalContext } from "../../context";
+
+interface FooCommandFlags {
+    // ...
+}
+
+export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
+    // ...
+}
+
+interface BarCommandFlags {
+    // ...
+}
+
+export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
+    // ...
+}
+
+::::/home/node-version-test/src/commands/subdir/command.ts
+import { buildCommand } from "@stricli/core";
+
+export const subdirCommand = buildCommand({
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Command in subdirectory",
+    },
+});
+
+::::/home/node-version-test/src/commands/subdir/impl.ts
+import type { LocalContext } from "../../context";
+
+interface SubdirCommandFlags {
+    // ...
+}
+
+export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
+    // ...
+}
+
+::::/home/node-version-test/src/context.ts
+import type { CommandContext } from "@stricli/core";
+import type { StricliAutoCompleteContext } from "@stricli/auto-complete";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
+    readonly process: NodeJS.Process;
+    // ...
+}
+
+export function buildContext(process: NodeJS.Process): LocalContext {
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
+}
+
+::::/home/node-version-test/src/tsconfig.json
+{
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
+    ],
+    "exclude": []
+}

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/reads registry direct from NPM_CONFIG_REGISTRY.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/reads registry direct from NPM_CONFIG_REGISTRY.txt
@@ -2,7 +2,7 @@
 
 [STDERR]
 Unable to determine version of @types/node for 30.0.0, assuming 30.x
-
+Rerun this command with the hidden flag --node-version to manually specify the Node.js major version
 [FILES]
 ::::/home/node-version-test/.gitignore
 # Logs

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/reads registry direct from NPM_CONFIG_REGISTRY.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/reads registry direct from NPM_CONFIG_REGISTRY.txt
@@ -1,0 +1,278 @@
+[STDOUT]
+
+[STDERR]
+Unable to determine version of @types/node for 30.0.0, assuming 30.x
+
+[FILES]
+::::/home/node-version-test/.gitignore
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+*.tsbuildinfo
+dist
+
+::::/home/node-version-test/package.json
+{
+  "name": "node-version-test",
+  "author": "",
+  "description": "Stricli command line application",
+  "license": "MIT",
+  "type": "module",
+  "version": "0.0.0",
+  "files": [
+    "dist"
+  ],
+  "bin": {
+    "node-version-test": "dist/cli.js",
+    "__node-version-test_bash_complete": "dist/bash-complete.js"
+  },
+  "engines": {
+    "node": ">=30"
+  },
+  "scripts": {
+    "prebuild": "tsc -p src/tsconfig.json",
+    "build": "tsup",
+    "prepublishOnly": "npm run build",
+    "postinstall": "node-version-test install"
+  },
+  "tsup": {
+    "entry": [
+      "src/bin/cli.ts",
+      "src/bin/bash-complete.ts"
+    ],
+    "format": [
+      "esm"
+    ],
+    "tsconfig": "src/tsconfig.json",
+    "clean": true,
+    "splitting": true,
+    "minify": true
+  },
+  "dependencies": {
+    "@stricli/core": "<self>",
+    "@stricli/auto-complete": "<self>"
+  },
+  "devDependencies": {
+    "@types/node": "30.x",
+    "tsup": "^6.7.0",
+    "typescript": "5.6.x"
+  }
+}
+::::/home/node-version-test/src/app.ts
+import { buildApplication, buildRouteMap } from "@stricli/core";
+import { buildInstallCommand, buildUninstallCommand } from "@stricli/auto-complete";
+import { name, version, description } from "../package.json";
+import { subdirCommand } from "./commands/subdir/command";
+import { nestedRoutes } from "./commands/nested/commands";
+
+const routes = buildRouteMap({
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("node-version-test", { bash: "__node-version-test_bash_complete" }),
+        uninstall: buildUninstallCommand("node-version-test", { bash: true }),
+    },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
+});
+
+export const app = buildApplication(routes, {
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
+});
+
+::::/home/node-version-test/src/bin/bash-complete.ts
+#!/usr/bin/env node
+import { proposeCompletions } from "@stricli/core";
+import { buildContext } from "../context";
+import { app } from "../app";
+const inputs = process.argv.slice(3);
+if (process.env["COMP_LINE"]?.endsWith(" ")) {
+    inputs.push("");
+}
+await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
+
+::::/home/node-version-test/src/bin/cli.ts
+#!/usr/bin/env node
+import { run } from "@stricli/core";
+import { buildContext } from "../context";
+import { app } from "../app";
+await run(app, process.argv.slice(2), buildContext(process));
+
+::::/home/node-version-test/src/commands/nested/commands.ts
+import { buildCommand, buildRouteMap } from "@stricli/core";
+
+export const fooCommand = buildCommand({
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
+    },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
+});
+
+export const barCommand = buildCommand({
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
+    },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
+});
+
+export const nestedRoutes = buildRouteMap({
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
+});
+
+::::/home/node-version-test/src/commands/nested/impl.ts
+import type { LocalContext } from "../../context";
+
+interface FooCommandFlags {
+    // ...
+}
+
+export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
+    // ...
+}
+
+interface BarCommandFlags {
+    // ...
+}
+
+export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
+    // ...
+}
+
+::::/home/node-version-test/src/commands/subdir/command.ts
+import { buildCommand } from "@stricli/core";
+
+export const subdirCommand = buildCommand({
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Command in subdirectory",
+    },
+});
+
+::::/home/node-version-test/src/commands/subdir/impl.ts
+import type { LocalContext } from "../../context";
+
+interface SubdirCommandFlags {
+    // ...
+}
+
+export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
+    // ...
+}
+
+::::/home/node-version-test/src/context.ts
+import type { CommandContext } from "@stricli/core";
+import type { StricliAutoCompleteContext } from "@stricli/auto-complete";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
+    readonly process: NodeJS.Process;
+    // ...
+}
+
+export function buildContext(process: NodeJS.Process): LocalContext {
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
+}
+
+::::/home/node-version-test/src/tsconfig.json
+{
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
+    ],
+    "exclude": []
+}

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/registry data has no versions.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/registry data has no versions.txt
@@ -2,7 +2,7 @@
 
 [STDERR]
 Unable to determine version of @types/node for 30.0.0, assuming 30.x
-
+Rerun this command with the hidden flag --node-version to manually specify the Node.js major version
 [FILES]
 ::::/home/node-version-test/.gitignore
 # Logs

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/registry data has no versions.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/registry data has no versions.txt
@@ -1,0 +1,278 @@
+[STDOUT]
+
+[STDERR]
+Unable to determine version of @types/node for 30.0.0, assuming 30.x
+
+[FILES]
+::::/home/node-version-test/.gitignore
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+*.tsbuildinfo
+dist
+
+::::/home/node-version-test/package.json
+{
+  "name": "node-version-test",
+  "author": "",
+  "description": "Stricli command line application",
+  "license": "MIT",
+  "type": "module",
+  "version": "0.0.0",
+  "files": [
+    "dist"
+  ],
+  "bin": {
+    "node-version-test": "dist/cli.js",
+    "__node-version-test_bash_complete": "dist/bash-complete.js"
+  },
+  "engines": {
+    "node": ">=30"
+  },
+  "scripts": {
+    "prebuild": "tsc -p src/tsconfig.json",
+    "build": "tsup",
+    "prepublishOnly": "npm run build",
+    "postinstall": "node-version-test install"
+  },
+  "tsup": {
+    "entry": [
+      "src/bin/cli.ts",
+      "src/bin/bash-complete.ts"
+    ],
+    "format": [
+      "esm"
+    ],
+    "tsconfig": "src/tsconfig.json",
+    "clean": true,
+    "splitting": true,
+    "minify": true
+  },
+  "dependencies": {
+    "@stricli/core": "<self>",
+    "@stricli/auto-complete": "<self>"
+  },
+  "devDependencies": {
+    "@types/node": "30.x",
+    "tsup": "^6.7.0",
+    "typescript": "5.6.x"
+  }
+}
+::::/home/node-version-test/src/app.ts
+import { buildApplication, buildRouteMap } from "@stricli/core";
+import { buildInstallCommand, buildUninstallCommand } from "@stricli/auto-complete";
+import { name, version, description } from "../package.json";
+import { subdirCommand } from "./commands/subdir/command";
+import { nestedRoutes } from "./commands/nested/commands";
+
+const routes = buildRouteMap({
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("node-version-test", { bash: "__node-version-test_bash_complete" }),
+        uninstall: buildUninstallCommand("node-version-test", { bash: true }),
+    },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
+});
+
+export const app = buildApplication(routes, {
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
+});
+
+::::/home/node-version-test/src/bin/bash-complete.ts
+#!/usr/bin/env node
+import { proposeCompletions } from "@stricli/core";
+import { buildContext } from "../context";
+import { app } from "../app";
+const inputs = process.argv.slice(3);
+if (process.env["COMP_LINE"]?.endsWith(" ")) {
+    inputs.push("");
+}
+await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
+
+::::/home/node-version-test/src/bin/cli.ts
+#!/usr/bin/env node
+import { run } from "@stricli/core";
+import { buildContext } from "../context";
+import { app } from "../app";
+await run(app, process.argv.slice(2), buildContext(process));
+
+::::/home/node-version-test/src/commands/nested/commands.ts
+import { buildCommand, buildRouteMap } from "@stricli/core";
+
+export const fooCommand = buildCommand({
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
+    },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
+});
+
+export const barCommand = buildCommand({
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
+    },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
+});
+
+export const nestedRoutes = buildRouteMap({
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
+});
+
+::::/home/node-version-test/src/commands/nested/impl.ts
+import type { LocalContext } from "../../context";
+
+interface FooCommandFlags {
+    // ...
+}
+
+export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
+    // ...
+}
+
+interface BarCommandFlags {
+    // ...
+}
+
+export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
+    // ...
+}
+
+::::/home/node-version-test/src/commands/subdir/command.ts
+import { buildCommand } from "@stricli/core";
+
+export const subdirCommand = buildCommand({
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Command in subdirectory",
+    },
+});
+
+::::/home/node-version-test/src/commands/subdir/impl.ts
+import type { LocalContext } from "../../context";
+
+interface SubdirCommandFlags {
+    // ...
+}
+
+export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
+    // ...
+}
+
+::::/home/node-version-test/src/context.ts
+import type { CommandContext } from "@stricli/core";
+import type { StricliAutoCompleteContext } from "@stricli/auto-complete";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
+    readonly process: NodeJS.Process;
+    // ...
+}
+
+export function buildContext(process: NodeJS.Process): LocalContext {
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
+}
+
+::::/home/node-version-test/src/tsconfig.json
+{
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
+    ],
+    "exclude": []
+}

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/request to registry throws error.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/request to registry throws error.txt
@@ -1,0 +1,7 @@
+[STDOUT]
+
+[STDERR]
+Command failed, Error: Failed to fetch data from REGISTRY
+    at Context.<anonymous> (#/tests/app.spec.ts:?:?)
+
+[FILES]

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/unable to discover registry from process.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/unable to discover registry from process.txt
@@ -2,7 +2,7 @@
 
 [STDERR]
 Unable to determine version of @types/node for 30.0.0, assuming 30.x
-
+Rerun this command with the hidden flag --node-version to manually specify the Node.js major version
 [FILES]
 ::::/home/node-version-test/.gitignore
 # Logs

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/unable to discover registry from process.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/unable to discover registry from process.txt
@@ -1,0 +1,278 @@
+[STDOUT]
+
+[STDERR]
+Unable to determine version of @types/node for 30.0.0, assuming 30.x
+
+[FILES]
+::::/home/node-version-test/.gitignore
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+*.tsbuildinfo
+dist
+
+::::/home/node-version-test/package.json
+{
+  "name": "node-version-test",
+  "author": "",
+  "description": "Stricli command line application",
+  "license": "MIT",
+  "type": "module",
+  "version": "0.0.0",
+  "files": [
+    "dist"
+  ],
+  "bin": {
+    "node-version-test": "dist/cli.js",
+    "__node-version-test_bash_complete": "dist/bash-complete.js"
+  },
+  "engines": {
+    "node": ">=30"
+  },
+  "scripts": {
+    "prebuild": "tsc -p src/tsconfig.json",
+    "build": "tsup",
+    "prepublishOnly": "npm run build",
+    "postinstall": "node-version-test install"
+  },
+  "tsup": {
+    "entry": [
+      "src/bin/cli.ts",
+      "src/bin/bash-complete.ts"
+    ],
+    "format": [
+      "esm"
+    ],
+    "tsconfig": "src/tsconfig.json",
+    "clean": true,
+    "splitting": true,
+    "minify": true
+  },
+  "dependencies": {
+    "@stricli/core": "<self>",
+    "@stricli/auto-complete": "<self>"
+  },
+  "devDependencies": {
+    "@types/node": "30.x",
+    "tsup": "^6.7.0",
+    "typescript": "5.6.x"
+  }
+}
+::::/home/node-version-test/src/app.ts
+import { buildApplication, buildRouteMap } from "@stricli/core";
+import { buildInstallCommand, buildUninstallCommand } from "@stricli/auto-complete";
+import { name, version, description } from "../package.json";
+import { subdirCommand } from "./commands/subdir/command";
+import { nestedRoutes } from "./commands/nested/commands";
+
+const routes = buildRouteMap({
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("node-version-test", { bash: "__node-version-test_bash_complete" }),
+        uninstall: buildUninstallCommand("node-version-test", { bash: true }),
+    },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
+});
+
+export const app = buildApplication(routes, {
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
+});
+
+::::/home/node-version-test/src/bin/bash-complete.ts
+#!/usr/bin/env node
+import { proposeCompletions } from "@stricli/core";
+import { buildContext } from "../context";
+import { app } from "../app";
+const inputs = process.argv.slice(3);
+if (process.env["COMP_LINE"]?.endsWith(" ")) {
+    inputs.push("");
+}
+await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
+
+::::/home/node-version-test/src/bin/cli.ts
+#!/usr/bin/env node
+import { run } from "@stricli/core";
+import { buildContext } from "../context";
+import { app } from "../app";
+await run(app, process.argv.slice(2), buildContext(process));
+
+::::/home/node-version-test/src/commands/nested/commands.ts
+import { buildCommand, buildRouteMap } from "@stricli/core";
+
+export const fooCommand = buildCommand({
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
+    },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
+});
+
+export const barCommand = buildCommand({
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
+    },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
+});
+
+export const nestedRoutes = buildRouteMap({
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
+});
+
+::::/home/node-version-test/src/commands/nested/impl.ts
+import type { LocalContext } from "../../context";
+
+interface FooCommandFlags {
+    // ...
+}
+
+export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
+    // ...
+}
+
+interface BarCommandFlags {
+    // ...
+}
+
+export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
+    // ...
+}
+
+::::/home/node-version-test/src/commands/subdir/command.ts
+import { buildCommand } from "@stricli/core";
+
+export const subdirCommand = buildCommand({
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Command in subdirectory",
+    },
+});
+
+::::/home/node-version-test/src/commands/subdir/impl.ts
+import type { LocalContext } from "../../context";
+
+interface SubdirCommandFlags {
+    // ...
+}
+
+export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
+    // ...
+}
+
+::::/home/node-version-test/src/context.ts
+import type { CommandContext } from "@stricli/core";
+import type { StricliAutoCompleteContext } from "@stricli/auto-complete";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
+    readonly process: NodeJS.Process;
+    // ...
+}
+
+export function buildContext(process: NodeJS.Process): LocalContext {
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
+}
+
+::::/home/node-version-test/src/tsconfig.json
+{
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
+    ],
+    "exclude": []
+}

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/uses NPM_EXECPATH to get registry config value.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/uses NPM_EXECPATH to get registry config value.txt
@@ -2,7 +2,7 @@
 
 [STDERR]
 Unable to determine version of @types/node for 30.0.0, assuming 30.x
-
+Rerun this command with the hidden flag --node-version to manually specify the Node.js major version
 [FILES]
 ::::/home/node-version-test/.gitignore
 # Logs

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/uses NPM_EXECPATH to get registry config value.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/uses NPM_EXECPATH to get registry config value.txt
@@ -1,0 +1,278 @@
+[STDOUT]
+
+[STDERR]
+Unable to determine version of @types/node for 30.0.0, assuming 30.x
+
+[FILES]
+::::/home/node-version-test/.gitignore
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+*.tsbuildinfo
+dist
+
+::::/home/node-version-test/package.json
+{
+  "name": "node-version-test",
+  "author": "",
+  "description": "Stricli command line application",
+  "license": "MIT",
+  "type": "module",
+  "version": "0.0.0",
+  "files": [
+    "dist"
+  ],
+  "bin": {
+    "node-version-test": "dist/cli.js",
+    "__node-version-test_bash_complete": "dist/bash-complete.js"
+  },
+  "engines": {
+    "node": ">=30"
+  },
+  "scripts": {
+    "prebuild": "tsc -p src/tsconfig.json",
+    "build": "tsup",
+    "prepublishOnly": "npm run build",
+    "postinstall": "node-version-test install"
+  },
+  "tsup": {
+    "entry": [
+      "src/bin/cli.ts",
+      "src/bin/bash-complete.ts"
+    ],
+    "format": [
+      "esm"
+    ],
+    "tsconfig": "src/tsconfig.json",
+    "clean": true,
+    "splitting": true,
+    "minify": true
+  },
+  "dependencies": {
+    "@stricli/core": "<self>",
+    "@stricli/auto-complete": "<self>"
+  },
+  "devDependencies": {
+    "@types/node": "30.x",
+    "tsup": "^6.7.0",
+    "typescript": "5.6.x"
+  }
+}
+::::/home/node-version-test/src/app.ts
+import { buildApplication, buildRouteMap } from "@stricli/core";
+import { buildInstallCommand, buildUninstallCommand } from "@stricli/auto-complete";
+import { name, version, description } from "../package.json";
+import { subdirCommand } from "./commands/subdir/command";
+import { nestedRoutes } from "./commands/nested/commands";
+
+const routes = buildRouteMap({
+    routes: {
+        subdir: subdirCommand,
+        nested: nestedRoutes,
+        install: buildInstallCommand("node-version-test", { bash: "__node-version-test_bash_complete" }),
+        uninstall: buildUninstallCommand("node-version-test", { bash: true }),
+    },
+    docs: {
+        brief: description,
+        hideRoute: {
+            install: true,
+            uninstall: true,
+        },
+    },
+});
+
+export const app = buildApplication(routes, {
+    name,
+    versionInfo: {
+        currentVersion: version,
+    },
+});
+
+::::/home/node-version-test/src/bin/bash-complete.ts
+#!/usr/bin/env node
+import { proposeCompletions } from "@stricli/core";
+import { buildContext } from "../context";
+import { app } from "../app";
+const inputs = process.argv.slice(3);
+if (process.env["COMP_LINE"]?.endsWith(" ")) {
+    inputs.push("");
+}
+await proposeCompletions(app, inputs, buildContext(process));
+try {
+    for (const { completion } of await proposeCompletions(app, inputs, buildContext(process))) {
+        process.stdout.write(`${completion}\n`);
+    }
+} catch {
+    // ignore
+}
+
+::::/home/node-version-test/src/bin/cli.ts
+#!/usr/bin/env node
+import { run } from "@stricli/core";
+import { buildContext } from "../context";
+import { app } from "../app";
+await run(app, process.argv.slice(2), buildContext(process));
+
+::::/home/node-version-test/src/commands/nested/commands.ts
+import { buildCommand, buildRouteMap } from "@stricli/core";
+
+export const fooCommand = buildCommand({
+    loader: async () => {
+        const { foo } = await import("./impl");
+        return foo;
+    },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested foo command",
+    },
+});
+
+export const barCommand = buildCommand({
+    loader: async () => {
+        const { bar } = await import("./impl");
+        return bar;
+    },
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Nested bar command",
+    },
+});
+
+export const nestedRoutes = buildRouteMap({
+    routes: {
+        foo: fooCommand,
+        bar: barCommand,
+    },
+    docs: {
+        brief: "Nested commands",
+    },
+});
+
+::::/home/node-version-test/src/commands/nested/impl.ts
+import type { LocalContext } from "../../context";
+
+interface FooCommandFlags {
+    // ...
+}
+
+export async function foo(this: LocalContext, flags: FooCommandFlags): Promise<void> {
+    // ...
+}
+
+interface BarCommandFlags {
+    // ...
+}
+
+export async function bar(this: LocalContext, flags: BarCommandFlags): Promise<void> {
+    // ...
+}
+
+::::/home/node-version-test/src/commands/subdir/command.ts
+import { buildCommand } from "@stricli/core";
+
+export const subdirCommand = buildCommand({
+    loader: async () => import("./impl"),
+    parameters: {
+        positional: {
+            kind: "tuple",
+            parameters: [],
+        },
+    },
+    docs: {
+        brief: "Command in subdirectory",
+    },
+});
+
+::::/home/node-version-test/src/commands/subdir/impl.ts
+import type { LocalContext } from "../../context";
+
+interface SubdirCommandFlags {
+    // ...
+}
+
+export default async function(this: LocalContext, flags: SubdirCommandFlags): Promise<void> {
+    // ...
+}
+
+::::/home/node-version-test/src/context.ts
+import type { CommandContext } from "@stricli/core";
+import type { StricliAutoCompleteContext } from "@stricli/auto-complete";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface LocalContext extends CommandContext, StricliAutoCompleteContext {
+    readonly process: NodeJS.Process;
+    // ...
+}
+
+export function buildContext(process: NodeJS.Process): LocalContext {
+    return {
+        process,
+        os,
+        fs,
+        path,
+    };
+}
+
+::::/home/node-version-test/src/tsconfig.json
+{
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "..",
+        "types": [
+            "node"
+        ],
+        "resolveJsonModule": true,
+        "target": "esnext",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": [
+            "esnext"
+        ],
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "verbatimModuleSyntax": true
+    },
+    "include": [
+        "**/*"
+    ],
+    "exclude": []
+}

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/additional features/without eslint and prettier.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/additional features/without eslint and prettier.txt
@@ -1,6 +1,0 @@
-[STDOUT]
-
-[STDERR]
-No flag registered for --no-eslint
-
-[FILES]

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/additional features/without eslint.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/additional features/without eslint.txt
@@ -1,6 +1,0 @@
-[STDOUT]
-
-[STDERR]
-No flag registered for --no-eslint
-
-[FILES]

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/additional features/without prettier.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/additional features/without prettier.txt
@@ -1,6 +1,0 @@
-[STDOUT]
-
-[STDERR]
-No flag registered for --no-prettier
-
-[FILES]

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/additional features/without eslint and prettier.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/additional features/without eslint and prettier.txt
@@ -1,6 +1,0 @@
-[STDOUT]
-
-[STDERR]
-No flag registered for --no-eslint
-
-[FILES]

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/additional features/without eslint.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/additional features/without eslint.txt
@@ -1,6 +1,0 @@
-[STDOUT]
-
-[STDERR]
-No flag registered for --no-eslint
-
-[FILES]

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/additional features/without prettier.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/additional features/without prettier.txt
@@ -1,6 +1,0 @@
-[STDOUT]
-
-[STDERR]
-No flag registered for --no-prettier
-
-[FILES]

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/additional features/without eslint and prettier.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/additional features/without eslint and prettier.txt
@@ -1,6 +1,0 @@
-[STDOUT]
-
-[STDERR]
-No flag registered for --no-eslint
-
-[FILES]

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/additional features/without eslint.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/additional features/without eslint.txt
@@ -1,6 +1,0 @@
-[STDOUT]
-
-[STDERR]
-No flag registered for --no-eslint
-
-[FILES]

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/additional features/without prettier.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/additional features/without prettier.txt
@@ -1,6 +1,0 @@
-[STDOUT]
-
-[STDERR]
-No flag registered for --no-prettier
-
-[FILES]

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/additional features/without eslint and prettier.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/additional features/without eslint and prettier.txt
@@ -1,6 +1,0 @@
-[STDOUT]
-
-[STDERR]
-No flag registered for --no-eslint
-
-[FILES]

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/additional features/without eslint.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/additional features/without eslint.txt
@@ -1,6 +1,0 @@
-[STDOUT]
-
-[STDERR]
-No flag registered for --no-eslint
-
-[FILES]

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/additional features/without prettier.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/additional features/without prettier.txt
@@ -1,6 +1,0 @@
-[STDOUT]
-
-[STDERR]
-No flag registered for --no-prettier
-
-[FILES]


### PR DESCRIPTION
Resolves #30 

**Describe your changes**
New behavior to check the locally-configured registry for `@types/node` and only write a version that exists to the `package.json` for the new project.

The registry URL is pulled from one of two sources:
- The `NPM_CONFIG_REGISTRY` environment variable
  - Less common use case, but good to read from an env var if possible
- Executes `NPM_EXECPATH` with `process.execPath` and args `config get registry`
  - This method works for npm, yarn, and pnpm as all of them set that environment variable and share those command line args (tested this manually)

Once the data is fetched from the registry, there is additional logic to determine if there is an exact or approximate (same major version) version of `@types/node` available. If not it defaults to the highest published LTS version.

**Testing performed**
Updated test suite to hit 100% coverage. (Also removed some outdated baselines)

