### PR TITLE
docs: populate brief for all live playground examples

### DIFF
--- a/docs/docs/features/argument-parsing/examples/array-argument.txt
+++ b/docs/docs/features/argument-parsing/examples/array-argument.txt
@@ -14,6 +14,6 @@ export const root = buildCommand({
     },
   },
   docs: {
-    brief: "",
+    brief: "Example for live playground with homogenous positional parameters",
   },
 });

--- a/docs/docs/features/argument-parsing/examples/boolean-flag.txt
+++ b/docs/docs/features/argument-parsing/examples/boolean-flag.txt
@@ -17,7 +17,7 @@ export const root = buildCommand({
     },
   },
   docs: {
-    brief: "",
+    brief: "Example for live playground with boolean flag",
     customUsage: [
       "--quiet",
       "--quiet=yes",

--- a/docs/docs/features/argument-parsing/examples/bounded-array-argument.txt
+++ b/docs/docs/features/argument-parsing/examples/bounded-array-argument.txt
@@ -16,6 +16,6 @@ export const root = buildCommand({
     },
   },
   docs: {
-    brief: "",
+    brief: "Example for live playground with bounded positional parameters",
   },
 });

--- a/docs/docs/features/argument-parsing/examples/counter-flag.txt
+++ b/docs/docs/features/argument-parsing/examples/counter-flag.txt
@@ -20,7 +20,7 @@ export const root = buildCommand({
     },
   },
   docs: {
-    brief: "",
+    brief: "Example for live playground with counter flag",
     customUsage: [
       "--verbose",
       "-v",

--- a/docs/docs/features/argument-parsing/examples/default-flag.txt
+++ b/docs/docs/features/argument-parsing/examples/default-flag.txt
@@ -19,6 +19,6 @@ export const root = buildCommand({
     },
   },
   docs: {
-    brief: "",
+    brief: "Example for live playground with flag configured with default value",
   },
 });

--- a/docs/docs/features/argument-parsing/examples/default-tuple-argument.txt
+++ b/docs/docs/features/argument-parsing/examples/default-tuple-argument.txt
@@ -17,6 +17,6 @@ export const root = buildCommand({
     },
   },
   docs: {
-    brief: "",
+    brief: "Example for live playground with positional parameter configured with default value",
   },
 });

--- a/docs/docs/features/argument-parsing/examples/enum-flag.txt
+++ b/docs/docs/features/argument-parsing/examples/enum-flag.txt
@@ -21,6 +21,6 @@ export const root = buildCommand({
     },
   },
   docs: {
-    brief: ""
+    brief: "Example for live playground with enum flag"
   },
 });

--- a/docs/docs/features/argument-parsing/examples/hidden-flag.txt
+++ b/docs/docs/features/argument-parsing/examples/hidden-flag.txt
@@ -28,6 +28,6 @@ export const root = buildCommand({
     },
   },
   docs: {
-    brief: ""
+    brief: "Example for live playground with hidden flag"
   },
 });

--- a/docs/docs/features/argument-parsing/examples/optional-flag.txt
+++ b/docs/docs/features/argument-parsing/examples/optional-flag.txt
@@ -19,7 +19,7 @@ export const root = buildCommand({
     },
   },
   docs: {
-    brief: "",
+    brief: "Example for live playground with optional flag",
     customUsage: [
       "",
       "--limit 1000",

--- a/docs/docs/features/argument-parsing/examples/optional-tuple-argument.txt
+++ b/docs/docs/features/argument-parsing/examples/optional-tuple-argument.txt
@@ -25,6 +25,6 @@ export const root = buildCommand({
     },
   },
   docs: {
-    brief: "",
+    brief: "Example for live playground with optional positional parameter",
   },
 });

--- a/docs/docs/features/argument-parsing/examples/parsed-flag.txt
+++ b/docs/docs/features/argument-parsing/examples/parsed-flag.txt
@@ -24,7 +24,7 @@ export const root = buildCommand({
     },
   },
   docs: {
-    brief: "",
+    brief: "Example for live playground with parsed flags",
     customUsage: [
       "--item apple --price 1",
       "--item orange --price 3.5",

--- a/docs/docs/features/argument-parsing/examples/tuple-argument.txt
+++ b/docs/docs/features/argument-parsing/examples/tuple-argument.txt
@@ -20,6 +20,6 @@ export const root = buildCommand({
     },
   },
   docs: {
-    brief: "",
+    brief: "Example for live playground with positional parameters",
   },
 });

--- a/docs/docs/features/argument-parsing/examples/variadic-flag.txt
+++ b/docs/docs/features/argument-parsing/examples/variadic-flag.txt
@@ -22,7 +22,7 @@ export const root = buildCommand({
     },
   },
   docs: {
-    brief: "",
+    brief: "Example for live playground with variadic flag",
     customUsage: [
       "--id 10",
       "--id 10 --id 20 --id 30",


### PR DESCRIPTION
**Describe your changes**
This property is required, but the playground examples used an empty string. This results in less than optimal help text and is not the pattern that we want to recommend.

**Testing performed**
Tested against a local copy of the documentation site.
