### PR TITLE
docs: increase z-index of navbar to place on top of editor

### DIFF
--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -118,7 +118,7 @@ a.button {
 }
 
 .editor-navbar {
-    z-index: 1;
+    z-index: 10;
     position: absolute;
     top: 3px;
     right: 20px;


### PR DESCRIPTION
**Describe your changes**
Button to expand/collapse the monaco portion of the live playground had an insufficient `z-index` value and was partially obscured by some monaco elements. Raised the `z-index` to 10 as that seemed to be sufficient.

**Testing performed**
Editor toggle button before:
![image](https://github.com/user-attachments/assets/7f4c0cda-464d-4ae8-b01e-39d9ff85d978)

Editor toggle button after:
![image](https://github.com/user-attachments/assets/ce43ea93-21c0-4ddf-8844-05cf4743bc56)


