### PR TITLE
ci: set github-actions[bot] as git user for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
             - run: npm ci --legacy-peer-deps
             - uses: nrwl/nx-set-shas@v4
 
+            - run: git config --global user.name "github-actions[bot]"
+            - run: git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
             - run: npx nx release --yes ${{ inputs.dry-run && '--dry-run' }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Describe your changes**
Release workflow needs git user to correctly commit/tag/push changes. As per [this thread](https://github.com/orgs/community/discussions/26560#discussioncomment-3531273), the user name and email were set for `github-actions[bot]`.

