### PR TITLE
ci: use event sender as DCO signoff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,12 @@ jobs:
 
             - run: git config --global user.name "github-actions[bot]"
             - run: git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            - run: cp scripts/dco_commit_msg_hook.sh .git/hooks/prepare-commit-msg
 
             - run: npx nx release --yes ${{ inputs.dry-run && '--dry-run' }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                   NPM_CONFIG_PROVENANCE: true
+                  DCO_NAME: ${{ sender.name }}
+                  DCO_EMAIL: ${{ sender.email }}

--- a/scripts/dco_commit_msg_hook.sh
+++ b/scripts/dco_commit_msg_hook.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+git interpret-trailers --if-exists doNothing --trailer \
+    "Signed-off-by: $DCO_NAME <$DCO_EMAIL>" \
+    --in-place "$1"


### PR DESCRIPTION
**Describe your changes**
The release workflow as it currently exists fails because the `github-actions[bot]` account attempts to push and it get blocked by the DCO requirement. The `nx release` command doesn't allow us to customize the body of the commit, but we can use a git hook to append the DCO suffix to the end of the body. The name/email are derived from the `sender` object, which reflects the github user that triggered the action.