### PR TITLE
fix: loosen character restrictions on flags

### DIFF
--- a/packages/core/src/parameter/scanner.ts
+++ b/packages/core/src/parameter/scanner.ts
@@ -439,7 +439,7 @@ function findFlagsByArgument<CONTEXT extends CommandContext>(
     return [];
 }
 
-const FLAG_NAME_VALUE_PATTERN = /^--([a-z][a-z-]+)=(.+)$/i;
+const FLAG_NAME_VALUE_PATTERN = /^--([a-z][a-z-.\d_]+)=(.+)$/i;
 const ALIAS_VALUE_PATTERN = /^-([a-z])=(.+)$/i;
 
 /**

--- a/packages/core/tests/baselines/reference/parameter/flag/formatting.txt
+++ b/packages/core/tests/baselines/reference/parameter/flag/formatting.txt
@@ -44,6 +44,14 @@
 :::: formatDocumentationForFlagParameters / no flags
 [97m-h[39m [97m--help[39m  [03mPrint help information and exit[23m
 [97m[39m   [97m--[39m      [03mAll subsequent inputs should be interpreted as arguments[23m
+:::: formatDocumentationForFlagParameters / parsed / flag with nonstandard character
+[97m[39m   [97m--a.b.c_10[39m  [03mrequired parsed flag[23m
+[97m-h[39m [97m--help[39m      [03mPrint help information and exit[23m
+[97m[39m   [97m--[39m          [03mAll subsequent inputs should be interpreted as arguments[23m
+:::: formatDocumentationForFlagParameters / parsed / multipart flag
+[97m[39m   [97m--multi.part[39m  [03mrequired parsed flag[23m
+[97m-h[39m [97m--help[39m        [03mPrint help information and exit[23m
+[97m[39m   [97m--[39m            [03mAll subsequent inputs should be interpreted as arguments[23m
 :::: formatDocumentationForFlagParameters / parsed / multiple parsed flags
 [97m[39m   [97m--requiredParsed[39m                        [03mrequired parsed flag[23m
 [97m[39m   [97m--requiredParsedWithLongerName[39m          [03mrequired parsed flag with longer name[23m

--- a/packages/core/tests/parameter/flag/formatting.spec.ts
+++ b/packages/core/tests/parameter/flag/formatting.spec.ts
@@ -728,5 +728,55 @@ describe("formatDocumentationForFlagParameters", function () {
             // THEN
             compareToBaseline(this, StringArrayBaselineFormat, lines);
         });
+
+        it("multipart flag", function () {
+            // GIVEN
+            type Positional = [];
+            type Flags = {
+                readonly "multi.part": string;
+            };
+
+            const parameters: TypedCommandParameters<Flags, Positional, CommandContext> = {
+                flags: {
+                    "multi.part": {
+                        kind: "parsed",
+                        parse: String,
+                        brief: "required parsed flag",
+                    },
+                },
+                positional: { kind: "tuple", parameters: [] },
+            };
+
+            // WHEN
+            const lines = formatDocumentationForFlagParameters(parameters.flags, parameters.aliases ?? {}, defaultArgs);
+
+            // THEN
+            compareToBaseline(this, StringArrayBaselineFormat, lines);
+        });
+
+        it("flag with nonstandard character", function () {
+            // GIVEN
+            type Positional = [];
+            type Flags = {
+                readonly "a.b.c_10": string;
+            };
+
+            const parameters: TypedCommandParameters<Flags, Positional, CommandContext> = {
+                flags: {
+                    "a.b.c_10": {
+                        kind: "parsed",
+                        parse: String,
+                        brief: "required parsed flag",
+                    },
+                },
+                positional: { kind: "tuple", parameters: [] },
+            };
+
+            // WHEN
+            const lines = formatDocumentationForFlagParameters(parameters.flags, parameters.aliases ?? {}, defaultArgs);
+
+            // THEN
+            compareToBaseline(this, StringArrayBaselineFormat, lines);
+        });
     });
 });


### PR DESCRIPTION
Loosens the regex used for flag pattern matching to allow:

- Periods
- Underscores
- Digits

...which enables flags like `--foo.bar`, `--foo123`, and `--foo_bar`.