### PR TITLE
chore: remove explicit permissions

### DIFF
--- a/.github/workflows/pr_labels.yml
+++ b/.github/workflows/pr_labels.yml
@@ -7,11 +7,6 @@ on:
             - reopened
             - synchronize
 
-permissions:
-    actions: read
-    contents: read
-    pull-requests: write
-
 jobs:
     main:
         runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/bloomberg/stricli/settings/actions

All workflows have read/write permissions for all scopes, so this shouldn't be necessary