### PR TITLE
fix: use exit code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
                 "@stricli/core": "^1.0.0"
             },
             "devDependencies": {
-                "@types/bun": "*"
+                "@types/bun": "latest"
             },
             "peerDependencies": {
                 "typescript": "5.6.x"
@@ -80,7 +80,7 @@
                 "@stricli/core": "^1.0.0"
             },
             "devDependencies": {
-                "@types/bun": "*"
+                "@types/bun": "latest"
             },
             "peerDependencies": {
                 "typescript": "5.6.x"

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -46,9 +46,9 @@ export interface StricliProcess extends WritableStreams {
      */
     readonly env?: Readonly<Partial<Record<string, string>>>;
     /**
-     * Set the exit code and end the current process.
+     * A number which will be the process exit code.
      */
-    readonly exit?: (code: number) => void;
+    exitCode?: number | string;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,5 +76,8 @@ export async function run<CONTEXT extends CommandContext>(
     context: StricliDynamicCommandContext<CONTEXT>,
 ): Promise<void> {
     const exitCode = await runApplication(app, inputs, context);
-    context.process.exit?.(exitCode);
+
+    // We set the exit code instead of calling exit() so as not
+    // to cancel any pending tasks (e.g. stdout writes)
+    context.process.exitCode = exitCode;
 }

--- a/packages/core/tests/application.spec.ts
+++ b/packages/core/tests/application.spec.ts
@@ -94,7 +94,7 @@ function buildBasicRouteMap(brief: string) {
 interface ApplicationRunResult {
     readonly stdout: string;
     readonly stderr: string;
-    readonly exitCode: number | undefined;
+    readonly exitCode: number | string | undefined;
 }
 
 async function runWithInputs(
@@ -111,7 +111,7 @@ async function runWithInputs(
     };
 }
 
-function serializeExitCode(exitCode: number | undefined): string {
+function serializeExitCode(exitCode: number | string | undefined): string {
     const knownExitCode = Object.entries(ExitCode).find(([_, value]) => value === exitCode);
     if (knownExitCode) {
         return knownExitCode[0];

--- a/packages/core/tests/fakes/context.ts
+++ b/packages/core/tests/fakes/context.ts
@@ -16,7 +16,6 @@ interface FakeProcess extends StricliProcess {
     readonly stdout: FakeWritable;
     readonly stderr: FakeWritable;
     readonly exit: (code: number) => void;
-    readonly exitCode: number;
 }
 
 export type FakeContext = StricliDynamicCommandContext<CommandContext> & {
@@ -59,9 +58,6 @@ export function buildFakeContext(options: FakeContextOptions = { forCommand: tru
             env: options.env,
             exit: (code) => {
                 exitCode = code;
-            },
-            get exitCode() {
-                return exitCode;
             },
         },
         locale: options.locale,


### PR DESCRIPTION
Resolves #44 

swiches to setting `exitCode` rather than calling `exit()`, per the [node](https://nodejs.org/download/release/v18.20.0/docs/api/process.html#processexitcode) guidance:

> The reason this is problematic is because writes to process.stdout in Node.js are sometimes asynchronous and may occur over multiple ticks of the Node.js event loop. Calling process.exit(), however, forces the process to exit before those additional writes to stdout can be performed.
>
> Rather than calling process.exit() directly, the code should set the process.exitCode and allow the process to exit naturally by avoiding scheduling any additional work for the event loop