### PR TITLE
chore: add --signoff to git commit args for release

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -56,7 +56,8 @@
             }
         },
         "git": {
-            "commitMessage": "chore(release): {version}"
+            "commitMessage": "chore(release): {version}",
+            "commitArgs": "--signoff"
         }
     },
     "namedInputs": {


### PR DESCRIPTION
**Describe your changes**
Add `--signoff` to git commit args for release commit, so that all commits are signed off (for DCO).
