### PR TITLE
ci: use more accurate job names for actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
     contents: read
 
 jobs:
-    main:
+    nx:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/pr_labels.yml
+++ b/.github/workflows/pr_labels.yml
@@ -8,7 +8,7 @@ on:
             - synchronize
 
 jobs:
-    main:
+    pr-labels:
         # Only run on local PRs, not forks
         if: github.event.pull_request.head.repo.full_name == github.repository
         runs-on: ubuntu-latest


### PR DESCRIPTION
**Describe your changes**
Both of these jobs were named 'main' which made it impossible to disambiguate them or require one of them on PR.