### PR TITLE
docs(quick-start): rename tutorial to quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,7 @@ This framework was developed by Bloomberg after evaluating the [available altern
 
 ## Quick Start
 
-Check out [the tutorial](https://bloomberg.github.io/stricli/docs/tutorial) to learn how to generate a new Stricli application.
-
-## Building
-
-Run `npm ci` to initialize the repo. We use Nx to manage tasks, so you can run the following to build it:
-
-```
-npx nx@latest run-many -t build
-```
+Check out [the quick start](https://bloomberg.github.io/stricli/docs/quick-start) to learn how to generate a new Stricli application.
 
 ## Installation
 
@@ -37,6 +29,14 @@ The core Stricli framework is available on npmjs.com, and can be installed with 
 
 ```
 npm i -P @stricli/core
+```
+
+## Development
+
+Run `npm ci` to initialize the repo. We use Nx to manage tasks, so you can run the following to build all of the packages at once:
+
+```
+npx nx@latest run-many -t build
 ```
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Check out [the quick start](https://bloomberg.github.io/stricli/docs/quick-start
 The core Stricli framework is available on npmjs.com, and can be installed with the following command:
 
 ```
-npm i -P @stricli/core
+npm i --save-prod @stricli/core
 ```
 
 ## Development

--- a/docs/blog/2024-10-01-introducing-stricli.mdx
+++ b/docs/blog/2024-10-01-introducing-stricli.mdx
@@ -100,4 +100,4 @@ Stricli was purposefully designed not to subsume every library that a command li
 
 ## Available Now!
 
-Check out the full documentation at [bloomberg.github.io/stricli](https://bloomberg.github.io/stricli). Start adding Stricli to your application today by running `npm i -P @stricli/core`, or you can bootstrap a new project with `npx @stricli/create-app@latest`. A step-by-step guide for creating a new application can be found in the [tutorial](https://bloomberg.github.io/stricli/docs/tutorial) included in Stricli's documentation.
+Check out the full documentation at [bloomberg.github.io/stricli](https://bloomberg.github.io/stricli). Start adding Stricli to your application today by running `npm i -P @stricli/core`, or you can bootstrap a new project with `npx @stricli/create-app@latest`. A step-by-step guide for creating a new application can be found in the [quick start](https://bloomberg.github.io/stricli/docs/quick-start) included in Stricli's documentation.

--- a/docs/blog/2024-10-01-introducing-stricli.mdx
+++ b/docs/blog/2024-10-01-introducing-stricli.mdx
@@ -100,4 +100,4 @@ Stricli was purposefully designed not to subsume every library that a command li
 
 ## Available Now!
 
-Check out the full documentation at [bloomberg.github.io/stricli](https://bloomberg.github.io/stricli). Start adding Stricli to your application today by running `npm i -P @stricli/core`, or you can bootstrap a new project with `npx @stricli/create-app@latest`. A step-by-step guide for creating a new application can be found in the [quick start](https://bloomberg.github.io/stricli/docs/quick-start) included in Stricli's documentation.
+Check out the full documentation at [bloomberg.github.io/stricli](https://bloomberg.github.io/stricli). Start adding Stricli to your application today by running `npm i --save-prod @stricli/core`, or you can bootstrap a new project with `npx @stricli/create-app@latest`. A step-by-step guide for creating a new application can be found in the [quick start](https://bloomberg.github.io/stricli/docs/quick-start) included in Stricli's documentation.

--- a/docs/docs/features/shell-autocomplete.mdx
+++ b/docs/docs/features/shell-autocomplete.mdx
@@ -40,4 +40,4 @@ At this time, the only shell that `@stricli/auto-complete` supports is `bash`. S
 
 ### Adding a Built-In `install` Command
 
-To simplify the process of installing the auto complete command, `@stricli/auto-complete` also exposes methods that allow you to build a command to be added to your own app. It is recommended to hide these so that they do not show up in any help text, but they can still be run. To see an example of this setup, check out the [tutorial](../tutorial.mdx).
+To simplify the process of installing the auto complete command, `@stricli/auto-complete` also exposes methods that allow you to build a command to be added to your own app. It is recommended to hide these so that they do not show up in any help text, but they can still be run. To see an example of this setup, check out the [quick start](../quick-start.mdx).

--- a/docs/docs/quick-start.mdx
+++ b/docs/docs/quick-start.mdx
@@ -3,9 +3,9 @@ sidebar_position: 2
 toc_max_heading_level: 4
 ---
 
-# Tutorial
+# Quick Start
 
-This tutorial will get you started with a new, empty Stricli application and show you how to modify it to suit your needs.
+This quick start guide will get you started with a new, empty Stricli application and show you how to modify it to suit your needs.
 
 ## Generate a New Node Application
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -172,8 +172,8 @@ const config: Config = {
                             to: "/docs/category/getting-started",
                         },
                         {
-                            label: "Tutorial",
-                            to: "/docs/tutorial",
+                            label: "Quick Start",
+                            to: "/docs/quick-start",
                         },
                         {
                             label: "Features",

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -22,8 +22,8 @@ function HomepageHeader() {
                     <Link className="button button--secondary button--lg" to="/docs/getting-started/overview">
                         Overview
                     </Link>
-                    <Link className="button button--secondary button--lg" to="/docs/tutorial">
-                        Tutorial
+                    <Link className="button button--secondary button--lg" to="/docs/quick-start">
+                        Quick Start
                     </Link>
                 </div>
             </div>


### PR DESCRIPTION
Addresses some of the feedback from #51 

**Describe your changes**
Refer to the new application guide as a "quick start" rather than a "tutorial".
