### PR TITLE
ci: restore explicit PR write permission

### DIFF
--- a/.github/workflows/pr_labels.yml
+++ b/.github/workflows/pr_labels.yml
@@ -12,6 +12,8 @@ jobs:
         # Only run on local PRs, not forks
         if: github.event.pull_request.head.repo.full_name == github.repository
         runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
         steps:
             - uses: actions/checkout@v4
               with:


### PR DESCRIPTION
**Describe your changes**
This workflow had explicit permissions, it broke. They were removed and it started working again. Then randomly, it stopped working again. Restoring explicit permissions (`pull-requests: write`) to see if this functionality can be restored.

**Testing performed**
Will confirm action runs as expected on PR itself.
