### PR TITLE
fix: make looseBooleanParser even more permissive

### DIFF
--- a/packages/core/src/parameter/parser/boolean.ts
+++ b/packages/core/src/parameter/parser/boolean.ts
@@ -15,20 +15,22 @@ export const booleanParser = (input: string): boolean => {
     throw new SyntaxError(`Cannot convert ${input} to a boolean`);
 };
 
+const TRUTHY_VALUES = new Set(["true", "t", "yes", "y", "on", "1"]);
+const FALSY_VALUES = new Set(["false", "f", "no", "n", "off", "0"]);
+
 /**
  * Parses input strings as booleans (loosely).
- * Transforms to lowercase and then checks against "true", "false", "yes", "y", "no", and "n".
+ * Transforms to lowercase and then checks against the following values:
+ *  - `true`: `"true"`, `"t"`, `"yes"`, `"y"`, `"on"`, `"1"`
+ *  - `false`: `"false"`, `"f"`, `"no"`, `"n"`, `"off"`, `"0"`
  */
 export const looseBooleanParser = (input: string): boolean => {
-    switch (input.toLowerCase()) {
-        case "true":
-        case "yes":
-        case "y":
-            return true;
-        case "false":
-        case "no":
-        case "n":
-            return false;
+    const value = input.toLowerCase();
+    if (TRUTHY_VALUES.has(value)) {
+        return true;
+    }
+    if (FALSY_VALUES.has(value)) {
+        return false;
     }
     throw new SyntaxError(`Cannot convert ${input} to a boolean`);
 };

--- a/packages/core/tests/parameter/parsers/boolean.spec.ts
+++ b/packages/core/tests/parameter/parsers/boolean.spec.ts
@@ -20,6 +20,8 @@ describe("boolean parser", () => {
         ["no", "Cannot convert no to a boolean"],
         ["0", "Cannot convert 0 to a boolean"],
         ["1", "Cannot convert 1 to a boolean"],
+        ["off", "Cannot convert off to a boolean"],
+        ["on", "Cannot convert on to a boolean"],
     ]);
 });
 
@@ -35,16 +37,35 @@ describe("loose boolean parser", () => {
         ["Yes", true],
         ["YES", true],
         ["y", true],
+        ["Y", true],
         ["no", false],
         ["No", false],
         ["NO", false],
         ["n", false],
+        ["N", false],
+        ["t", true],
+        ["T", true],
+        ["f", false],
+        ["F", false],
+        ["0", false],
+        ["1", true],
+        ["on", true],
+        ["ON", true],
+        ["On", true],
+        ["off", false],
+        ["OFF", false],
+        ["Off", false],
     ]);
 
     testParserError(looseBooleanParser, [
-        ["t", "Cannot convert t to a boolean"],
-        ["f", "Cannot convert f to a boolean"],
-        ["0", "Cannot convert 0 to a boolean"],
-        ["1", "Cannot convert 1 to a boolean"],
+        ["truth", "Cannot convert truth to a boolean"],
+        ["lie", "Cannot convert lie to a boolean"],
+        ["📴", "Cannot convert 📴 to a boolean"],
+        ["❌", "Cannot convert ❌ to a boolean"],
+        ["⭕", "Cannot convert ⭕ to a boolean"],
+        ["✔", "Cannot convert ✔ to a boolean"],
+        ["✅", "Cannot convert ✅ to a boolean"],
+        ["🔛", "Cannot convert 🔛 to a boolean"],
+        ["🆗", "Cannot convert 🆗 to a boolean"],
     ]);
 });

--- a/packages/core/tests/parameter/scanner.spec.ts
+++ b/packages/core/tests/parameter/scanner.spec.ts
@@ -1389,7 +1389,7 @@ describe("ArgumentScanner", () => {
                 await testArgumentScannerParse<Flags, Positional>({
                     parameters,
                     config: defaultScannerConfig,
-                    inputs: ["--fooFlag=t"],
+                    inputs: ["--fooFlag=✅"],
                     expected: {
                         success: false,
                         errors: [
@@ -1397,8 +1397,8 @@ describe("ArgumentScanner", () => {
                                 type: "ArgumentParseError",
                                 properties: {
                                     externalFlagNameOrPlaceholder: "fooFlag",
-                                    input: "t",
-                                    exception: new Error("Cannot convert t to a boolean"),
+                                    input: "✅",
+                                    exception: new Error("Cannot convert ✅ to a boolean"),
                                 },
                             },
                         ],
@@ -1407,7 +1407,7 @@ describe("ArgumentScanner", () => {
                 await testArgumentScannerParse<Flags, Positional>({
                     parameters,
                     config: defaultScannerConfig,
-                    inputs: ["--fooFlag=0"],
+                    inputs: ["--fooFlag=❌"],
                     expected: {
                         success: false,
                         errors: [
@@ -1415,8 +1415,8 @@ describe("ArgumentScanner", () => {
                                 type: "ArgumentParseError",
                                 properties: {
                                     externalFlagNameOrPlaceholder: "fooFlag",
-                                    input: "0",
-                                    exception: new Error("Cannot convert 0 to a boolean"),
+                                    input: "❌",
+                                    exception: new Error("Cannot convert ❌ to a boolean"),
                                 },
                             },
                         ],
@@ -1790,7 +1790,7 @@ describe("ArgumentScanner", () => {
                     await testArgumentScannerParse<Flags, Positional>({
                         parameters: parametersWithAlias,
                         config: defaultScannerConfig,
-                        inputs: ["-f=t"],
+                        inputs: ["-f=✅"],
                         expected: {
                             success: false,
                             errors: [
@@ -1798,8 +1798,8 @@ describe("ArgumentScanner", () => {
                                     type: "ArgumentParseError",
                                     properties: {
                                         externalFlagNameOrPlaceholder: "fooFlag",
-                                        input: "t",
-                                        exception: new Error("Cannot convert t to a boolean"),
+                                        input: "✅",
+                                        exception: new Error("Cannot convert ✅ to a boolean"),
                                     },
                                 },
                             ],
@@ -1808,7 +1808,7 @@ describe("ArgumentScanner", () => {
                     await testArgumentScannerParse<Flags, Positional>({
                         parameters: parametersWithAlias,
                         config: defaultScannerConfig,
-                        inputs: ["-f=0"],
+                        inputs: ["-f=❌"],
                         expected: {
                             success: false,
                             errors: [
@@ -1816,8 +1816,8 @@ describe("ArgumentScanner", () => {
                                     type: "ArgumentParseError",
                                     properties: {
                                         externalFlagNameOrPlaceholder: "fooFlag",
-                                        input: "0",
-                                        exception: new Error("Cannot convert 0 to a boolean"),
+                                        input: "❌",
+                                        exception: new Error("Cannot convert ❌ to a boolean"),
                                     },
                                 },
                             ],


### PR DESCRIPTION
**Describe your changes**
In preparation for #62, the loose boolean parser should accept all commonly-used values for boolean environment variables. This list isn't exhaustive, but matches Python's (now deprecated) `distutils.util.strtobool`. 

**Testing performed**
Updated the test cases to ensure complete coverage.