### PR TITLE
ci: action to publish releases to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,22 +1,22 @@
-name: Nx Release
+name: Nx Publish
 
 on:
+    push:
+        branches:
+            - main
     workflow_dispatch:
         inputs:
             dry-run:
-                required: true
                 type: boolean
+                required: true
                 default: true
-                description: This should be a dry run release where no changes are committed/applied.
-
-permissions:
-    actions: read
-    contents: write
-    id-token: write
+                description: Trigger publish as a dry run, so no packages are published.
 
 jobs:
-    release:
+    publish:
         runs-on: ubuntu-latest
+        permissions:
+            id-token: write # needed for provenance data generation
         steps:
             - uses: actions/checkout@v4
               with:
@@ -31,11 +31,7 @@ jobs:
             - run: npm ci --legacy-peer-deps
             - uses: nrwl/nx-set-shas@v4
 
-            - run: git config --global user.name "github-actions[bot]"
-            - run: git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-            - run: npx nx release --yes ${{ inputs.dry-run && '--dry-run' }}
+            - run: npx nx release publish ${{ inputs.dry-run == 'true' && '--dry-run' || '' }}
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                   NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
**Describe your changes**
Change release workflow such that `nx release version` and `nx release changelog` will be run manually, and then once those changes have been merged to main they will then be released to npm with `nx release publish`.

This action will run on every push to main, but it can also be invoked via `workflow_dispatch`. The way that `nx release publish` works is that it will attempt to publish any releases that do not exist in the registry.

**Testing performed**
Changes have not been tested on this repo due to the nature of the workflow.
