### PR TITLE
chore: simplify release tag pattern

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -46,7 +46,7 @@
     "defaultBase": "main",
     "release": {
         "projects": ["@stricli/*", "!@stricli/docs"],
-        "releaseTagPattern": "release/{version}",
+        "releaseTagPattern": "v{version}",
         "version": {
             "conventionalCommits": true
         },


### PR DESCRIPTION
**Describe your changes**
Use `v{version}` instead of `release/{version}` for release tags. I've already gone through and created the `v{version}` tags for all of the existing (and pending) releases.