### PR TITLE
ci: set registry-url and auth token in setup-node

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,9 @@ jobs:
               with:
                   node-version: 20
                   cache: "npm"
+                  registry-url: "https://registry.npmjs.org/"
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - run: npm ci --legacy-peer-deps
             - uses: nrwl/nx-set-shas@v4


### PR DESCRIPTION
**Describe your changes**
The step `actions/setup-node@v4` has logic to account for authentication, which wasn't being invoked (despite passing `NODE_AUTH_TOKEN` to the publish step).

This just worked to publish `1.1.2` manually: https://github.com/bloomberg/stricli/actions/runs/14112648127