### PR TITLE
feat: support env var as default flag value

### DIFF
--- a/docs/docs/features/argument-parsing/flags.mdx
+++ b/docs/docs/features/argument-parsing/flags.mdx
@@ -149,6 +149,68 @@ import DefaultFlagCode from "./examples/default-flag.txt";
     {DefaultFlagCode}
 </StricliPlayground>
 
+#### Default from Environment Variables
+
+The default value can be sourced from anywhere, as long as it is a valid string. This includes environment variables, which can be useful for providing default values that are specific to the user's environment.
+
+```ts
+// output-next-line
+/// impl.ts
+export default function(flags: { token: string }) {
+  console.log(flags.token);
+}
+
+// output-next-line
+/// command.ts
+buildCommand({
+  loader: async () => import("./impl"),
+  parameters: {
+    flags: {
+      token: {
+        kind: "parsed",
+        parse: String,
+        brief: "Token used for authentication",
+        // highlight-next-line
+        default: process.env["SOME_TOKEN"],
+      },
+    },
+    ...
+  },
+  ...
+});
+```
+
+However, Stricli has built-in support for loading default values from environment variables. Specifying the default this way enables additional formatting to indicate to the user where this value came from, and the option to redact sensitive values from the output. This is done by passing an option with the `env` property in the flag configuration. The value of this property should be a string that represents the name of the environment variable to load. If the user does not pass in a value for the flag and the environment variable is not set, it will throw an `UnsatisfiedFlagError`.
+
+The additional `redact` config is optional, and if enabled will replace the value with `███` in the **Stricli-generated output**. Note that the value is still just a string passed to the flag, so there is nothing preventing the command implementation from displaying the value. There is no way for the command implementation to know where the value was sourced from, so it is up to the developer to ensure that the value is not printed if contains sensitive information.
+
+```ts
+// output-next-line
+/// impl.ts
+export default function(flags: { token: string }) {
+  console.log(flags.token);
+}
+
+// output-next-line
+/// command.ts
+buildCommand({
+  loader: async () => import("./impl"),
+  parameters: {
+    flags: {
+      token: {
+        kind: "parsed",
+        parse: String,
+        brief: "Token used for authentication",
+        // highlight-next-line
+        default: { env: "SOME_TOKEN", redact: true },
+      },
+    },
+    ...
+  },
+  ...
+});
+```
+
 ### Variadic
 
 A flag can be variadic when the type it represents is an array of values. In this case, the flag can be specified multiple times and each value is then parsed individually and added to a single array. If the type of a flag is an array it must be set as variadic.

--- a/packages/core/src/application/documentation.ts
+++ b/packages/core/src/application/documentation.ts
@@ -72,6 +72,7 @@ export function generateHelpTextForAllCommands(
                 aliases,
                 text,
                 ansiColor: false,
+                env: void 0,
             }),
         ];
     });

--- a/packages/core/src/application/run.ts
+++ b/packages/core/src/application/run.ts
@@ -111,6 +111,7 @@ export async function runApplication<CONTEXT extends CommandContext>(
                 aliases: result.aliases[config.documentation.caseStyle],
                 text,
                 ansiColor,
+                env: context.process.env,
             }),
         );
         return ExitCode.Success;

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,6 +1,8 @@
 // Copyright 2024 Bloomberg Finance L.P.
 // Distributed under the terms of the Apache 2.0 license.
 
+export type EnvironmentVariables = Readonly<Partial<Record<string, string>>>;
+
 /**
  * Minimal expected interface for an output stream; used to narrow the types of NodeJS's stdout/stderr.
  */
@@ -13,7 +15,7 @@ export interface Writable {
      * Determine the available color depth of the underlying stream.
      * Environment variables are also provided to control or suppress color output.
      */
-    readonly getColorDepth?: (env?: Readonly<Partial<Record<string, string>>>) => number;
+    readonly getColorDepth?: (env?: EnvironmentVariables) => number;
 }
 
 interface WritableStreams {
@@ -28,14 +30,6 @@ interface WritableStreams {
 }
 
 /**
- * Command-level context that provides necessary process information and is available to all command runs.
- * This type should be extended to include context specific to your command implementations.
- */
-export interface CommandContext {
-    readonly process: WritableStreams;
-}
-
-/**
  * Simple interface that mirrors NodeJS.Process but only requires the minimum API required by Stricli.
  */
 export interface StricliProcess extends WritableStreams {
@@ -44,11 +38,19 @@ export interface StricliProcess extends WritableStreams {
      *
      * @see {@link EnvironmentVariableName} for variable names used by Stricli.
      */
-    readonly env?: Readonly<Partial<Record<string, string>>>;
+    readonly env?: EnvironmentVariables;
     /**
      * A number which will be the process exit code.
      */
     exitCode?: number | string | null;
+}
+
+/**
+ * Command-level context that provides necessary process information and is available to all command runs.
+ * This type should be extended to include context specific to your command implementations.
+ */
+export interface CommandContext {
+    readonly process: StricliProcess;
 }
 
 /**

--- a/packages/core/src/parameter/flag/types.ts
+++ b/packages/core/src/parameter/flag/types.ts
@@ -3,6 +3,22 @@
 import type { CommandContext } from "../../context";
 import type { ParsedParameter } from "../types";
 
+/**
+ * Default value for flag when one is not provided by the end user.
+ */
+export type DefaultFlagValue<T> =
+    | T
+    | {
+          /**
+           * Default value should be read from the environment variable with this name.
+           */
+          readonly env: string;
+          /**
+           * When enabled, redact the value from the environment variable in all Stricli-generated output.
+           */
+          readonly redact?: boolean;
+      };
+
 interface BaseFlagParameter {
     /**
      * In-line documentation for this flag.
@@ -12,6 +28,10 @@ interface BaseFlagParameter {
      * String that serves as placeholder for the value in the generated usage line. Defaults to "value".
      */
     readonly placeholder?: string;
+    /**
+     * If no value was provided, attempt to read the environment variable with this name for the value.
+     */
+    readonly env?: string;
 }
 
 interface BaseBooleanFlagParameter extends BaseFlagParameter {
@@ -25,7 +45,7 @@ interface BaseBooleanFlagParameter extends BaseFlagParameter {
      *
      * If no value is provided, boolean flags default to `false`.
      */
-    readonly default?: boolean;
+    readonly default?: DefaultFlagValue<boolean>;
 }
 
 type RequiredBooleanFlagParameter = BaseBooleanFlagParameter & {
@@ -44,7 +64,7 @@ type RequiredBooleanFlagParameter = BaseBooleanFlagParameter & {
               /**
                * Default input value if one is not provided at runtime.
                */
-              readonly default: boolean;
+              readonly default: DefaultFlagValue<boolean>;
               /**
                * Parameter should be hidden from all help text and proposed completions.
                * Only available for runtime-optional parameters.
@@ -117,7 +137,7 @@ export interface BaseEnumFlagParameter<T extends string> extends BaseFlagParamet
     /**
      * Default input value if one is not provided at runtime.
      */
-    readonly default?: T;
+    readonly default?: DefaultFlagValue<T>;
     readonly optional?: boolean;
     readonly hidden?: boolean;
     readonly variadic?: boolean | string;
@@ -211,7 +231,7 @@ export interface BaseParsedFlagParameter<T, CONTEXT extends CommandContext>
     /**
      * Default input value if one is not provided at runtime.
      */
-    readonly default?: string;
+    readonly default?: DefaultFlagValue<string>;
     /**
      * If flag is specified with no corresponding input, infer an empty string `""` as the input.
      */
@@ -241,7 +261,7 @@ type RequiredParsedFlagParameter<T, CONTEXT extends CommandContext> = BaseParsed
               /**
                * Default input value if one is not provided at runtime.
                */
-              readonly default: string;
+              readonly default: DefaultFlagValue<string>;
               /**
                * Parameter should be hidden from all help text and proposed completions.
                * Only available for runtime-optional parameters.
@@ -376,7 +396,7 @@ export type FlagParameters<CONTEXT extends CommandContext = CommandContext> = Re
 
 export function hasDefault<CONTEXT extends CommandContext>(
     flag: FlagParameter<CONTEXT>,
-): flag is FlagParameter<CONTEXT> & { default: string | boolean } {
+): flag is FlagParameter<CONTEXT> & { default: DefaultFlagValue<string | boolean> } {
     return "default" in flag && typeof flag.default !== "undefined";
 }
 

--- a/packages/core/src/routing/route-map/documentation.ts
+++ b/packages/core/src/routing/route-map/documentation.ts
@@ -1,12 +1,12 @@
 // Copyright 2024 Bloomberg Finance L.P.
 // Distributed under the terms of the Apache 2.0 license.
-import type { CommandContext } from "../../context";
 import { formatForDisplay } from "../../config";
+import type { CommandContext } from "../../context";
+import { formatDocumentationForFlagParameters, generateBuiltInFlagUsageLines } from "../../parameter/flag/formatting";
 import { convertCamelCaseToKebabCase } from "../../util/case-style";
 import { formatRowsWithColumns } from "../../util/formatting";
 import type { HelpFormattingArguments } from "../types";
 import type { RouteMapRoutes } from "./builder";
-import { formatDocumentationForFlagParameters, generateBuiltInFlagUsageLines } from "../../parameter/flag/formatting";
 
 /**
  * Help documentation for route map.

--- a/packages/core/src/routing/types.ts
+++ b/packages/core/src/routing/types.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 Bloomberg Finance L.P.
 // Distributed under the terms of the Apache 2.0 license.
 import type { DocumentationText } from "../text";
-import type { CommandContext } from "../context";
+import type { CommandContext, EnvironmentVariables } from "../context";
 import type { UsageFormattingArguments } from "../parameter/formatting";
 import type { Command } from "./command/types";
 import type { RouteMap } from "./route-map/types";
@@ -12,7 +12,8 @@ export interface HelpFormattingArguments extends UsageFormattingArguments {
     readonly includeVersionFlag: boolean;
     readonly includeArgumentEscapeSequenceFlag: boolean;
     readonly includeHidden: boolean;
-    readonly aliases?: readonly string[];
+    readonly aliases: readonly string[] | undefined;
+    readonly env: EnvironmentVariables | undefined;
 }
 
 export interface DocumentedTarget {

--- a/packages/core/src/text.ts
+++ b/packages/core/src/text.ts
@@ -17,6 +17,12 @@ export interface DocumentationKeywords {
      */
     readonly default: string;
     /**
+     * Keyword to be included after default value from environment variable (if present) and name of environment variable.
+     *
+     * Defaults to `"env:"`.
+     */
+    readonly fromEnv: string;
+    /**
      * Keyword to be included when flags are variadic and have a defined separator.
      *
      * Defaults to `"separator ="`.
@@ -220,6 +226,7 @@ export const text_en: ApplicationText = {
     },
     keywords: {
         default: "default =",
+        fromEnv: "env:",
         separator: "separator =",
     },
     briefs: {

--- a/packages/core/tests/baselines/reference/parameter/flag/formatting.txt
+++ b/packages/core/tests/baselines/reference/parameter/flag/formatting.txt
@@ -28,6 +28,30 @@
 [97m[39m   [97m--requiredBoolean/--noRequiredBoolean[39m  [03mrequired boolean flag[23m
 [97m-h[39m [97m--help[39m                                 [03mPrint help information and exit[23m
 [97m[39m   [97m--[39m                                     [03mAll subsequent inputs should be interpreted as arguments[23m
+:::: formatDocumentationForFlagParameters / boolean / required boolean flag with default from env var (no value) / no ANSI color
+   [--requiredBoolean/--noRequiredBoolean]  required boolean flag                                    [default = env:REQUIRED_BOOLEAN]
+-h  --help                                  Print help information and exit
+    --                                      All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / boolean / required boolean flag with default from env var (no value) / with ANSI color
+[97m[39m   [97m[--requiredBoolean/--noRequiredBoolean][39m  [03mrequired boolean flag[23m                                    [[90mdefault =[39m [90menv:REQUIRED_BOOLEAN[39m]
+[97m-h[39m [97m --help[39m                                  [03mPrint help information and exit[23m
+[97m[39m   [97m --[39m                                      [03mAll subsequent inputs should be interpreted as arguments[23m
+:::: formatDocumentationForFlagParameters / boolean / required boolean flag with default from env var (value) / no ANSI color
+   [--requiredBoolean/--noRequiredBoolean]  required boolean flag                                    [default = yes | env:REQUIRED_BOOLEAN]
+-h  --help                                  Print help information and exit
+    --                                      All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / boolean / required boolean flag with default from env var (value) / with ANSI color
+[97m[39m   [97m[--requiredBoolean/--noRequiredBoolean][39m  [03mrequired boolean flag[23m                                    [[90mdefault =[39m yes [90m| env:REQUIRED_BOOLEAN[39m]
+[97m-h[39m [97m --help[39m                                  [03mPrint help information and exit[23m
+[97m[39m   [97m --[39m                                      [03mAll subsequent inputs should be interpreted as arguments[23m
+:::: formatDocumentationForFlagParameters / boolean / required boolean flag with default from env var (value, redacted) / no ANSI color
+   [--requiredBoolean/--noRequiredBoolean]  required boolean flag                                    [default = ███ | env:REQUIRED_BOOLEAN]
+-h  --help                                  Print help information and exit
+    --                                      All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / boolean / required boolean flag with default from env var (value, redacted) / with ANSI color
+[97m[39m   [97m[--requiredBoolean/--noRequiredBoolean][39m  [03mrequired boolean flag[23m                                    [[90mdefault =[39m ███ [90m| env:REQUIRED_BOOLEAN[39m]
+[97m-h[39m [97m --help[39m                                  [03mPrint help information and exit[23m
+[97m[39m   [97m --[39m                                      [03mAll subsequent inputs should be interpreted as arguments[23m
 :::: formatDocumentationForFlagParameters / boolean / required boolean flag with default=false / no ANSI color
    [--requiredBoolean]  required boolean flag                                    [default = false]
 -h  --help              Print help information and exit
@@ -74,6 +98,30 @@
     --               All subsequent inputs should be interpreted as arguments
 :::: formatDocumentationForFlagParameters / enum / required enum flag with default / with ANSI color
 [97m[39m   [97m[--requiredEnum][39m  [03mrequired enum flag[23m                                       [a|b|c, [90mdefault =[39m b]
+[97m-h[39m [97m --help[39m           [03mPrint help information and exit[23m
+[97m[39m   [97m --[39m               [03mAll subsequent inputs should be interpreted as arguments[23m
+:::: formatDocumentationForFlagParameters / enum / required enum flag with default from env var (no value) / no ANSI color
+   [--requiredEnum]  required enum flag                                       [a|b|c, default = env:REQUIRED_ENUM]
+-h  --help           Print help information and exit
+    --               All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / enum / required enum flag with default from env var (no value) / with ANSI color
+[97m[39m   [97m[--requiredEnum][39m  [03mrequired enum flag[23m                                       [a|b|c, [90mdefault =[39m [90menv:REQUIRED_ENUM[39m]
+[97m-h[39m [97m --help[39m           [03mPrint help information and exit[23m
+[97m[39m   [97m --[39m               [03mAll subsequent inputs should be interpreted as arguments[23m
+:::: formatDocumentationForFlagParameters / enum / required enum flag with default from env var (value) / no ANSI color
+   [--requiredEnum]  required enum flag                                       [a|b|c, default = a | env:REQUIRED_ENUM]
+-h  --help           Print help information and exit
+    --               All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / enum / required enum flag with default from env var (value) / with ANSI color
+[97m[39m   [97m[--requiredEnum][39m  [03mrequired enum flag[23m                                       [a|b|c, [90mdefault =[39m a [90m| env:REQUIRED_ENUM[39m]
+[97m-h[39m [97m --help[39m           [03mPrint help information and exit[23m
+[97m[39m   [97m --[39m               [03mAll subsequent inputs should be interpreted as arguments[23m
+:::: formatDocumentationForFlagParameters / enum / required enum flag with default from env var (value, redacted) / no ANSI color
+   [--requiredEnum]  required enum flag                                       [a|b|c, default = █ | env:REQUIRED_ENUM]
+-h  --help           Print help information and exit
+    --               All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / enum / required enum flag with default from env var (value, redacted) / with ANSI color
+[97m[39m   [97m[--requiredEnum][39m  [03mrequired enum flag[23m                                       [a|b|c, [90mdefault =[39m █ [90m| env:REQUIRED_ENUM[39m]
 [97m-h[39m [97m --help[39m           [03mPrint help information and exit[23m
 [97m[39m   [97m --[39m               [03mAll subsequent inputs should be interpreted as arguments[23m
 :::: formatDocumentationForFlagParameters / no flags / no ANSI color
@@ -194,6 +242,38 @@
     --                 All subsequent inputs should be interpreted as arguments
 :::: formatDocumentationForFlagParameters / parsed / required parsed flag with default and alias / with ANSI color
 [97m-p[39m [97m[--requiredParsed][39m  [03mrequired parsed flag[23m                                     [[90mdefault =[39m 100]
+[97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
+[97m[39m   [97m --[39m                 [03mAll subsequent inputs should be interpreted as arguments[23m
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default from env var (no value) / no ANSI color
+   [--requiredParsed]  required parsed flag                                     [default = env:REQUIRED_PARSED]
+-h  --help             Print help information and exit
+    --                 All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default from env var (no value) / with ANSI color
+[97m[39m   [97m[--requiredParsed][39m  [03mrequired parsed flag[23m                                     [[90mdefault =[39m [90menv:REQUIRED_PARSED[39m]
+[97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
+[97m[39m   [97m --[39m                 [03mAll subsequent inputs should be interpreted as arguments[23m
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default from env var (set, but empty) / no ANSI color
+   [--requiredParsed]  required parsed flag                                     [default = "" | env:REQUIRED_PARSED]
+-h  --help             Print help information and exit
+    --                 All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default from env var (set, but empty) / with ANSI color
+[97m[39m   [97m[--requiredParsed][39m  [03mrequired parsed flag[23m                                     [[90mdefault =[39m "" [90m| env:REQUIRED_PARSED[39m]
+[97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
+[97m[39m   [97m --[39m                 [03mAll subsequent inputs should be interpreted as arguments[23m
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default from env var (value) / no ANSI color
+   [--requiredParsed]  required parsed flag                                     [default = VALUE | env:REQUIRED_PARSED]
+-h  --help             Print help information and exit
+    --                 All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default from env var (value) / with ANSI color
+[97m[39m   [97m[--requiredParsed][39m  [03mrequired parsed flag[23m                                     [[90mdefault =[39m VALUE [90m| env:REQUIRED_PARSED[39m]
+[97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
+[97m[39m   [97m --[39m                 [03mAll subsequent inputs should be interpreted as arguments[23m
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default from env var (value, redacted) / no ANSI color
+   [--requiredParsed]  required parsed flag                                     [default = █████ | env:REQUIRED_PARSED]
+-h  --help             Print help information and exit
+    --                 All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default from env var (value, redacted) / with ANSI color
+[97m[39m   [97m[--requiredParsed][39m  [03mrequired parsed flag[23m                                     [[90mdefault =[39m █████ [90m| env:REQUIRED_PARSED[39m]
 [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
 [97m[39m   [97m --[39m                 [03mAll subsequent inputs should be interpreted as arguments[23m
 :::: formatDocumentationForFlagParameters / parsed / required variadic parsed flag / no ANSI color

--- a/packages/core/tests/parameter/flag/formatting.spec.ts
+++ b/packages/core/tests/parameter/flag/formatting.spec.ts
@@ -10,7 +10,7 @@ import type { BaseArgs } from "../../../src/parameter/positional/types";
 import type { HelpFormattingArguments } from "../../../src/routing/types";
 import { compareToBaseline, StringArrayBaselineFormat } from "../../baseline";
 
-type DocumentationArgs = Omit<HelpFormattingArguments, "prefix" | "ansiColor">;
+type DocumentationArgs = Omit<HelpFormattingArguments, "prefix">;
 
 function compareDocumentationToBaseline<FLAGS extends Readonly<Record<string, unknown>>, POSITIONAL extends BaseArgs>(
     parameters: TypedCommandParameters<FLAGS, POSITIONAL, CommandContext>,
@@ -77,6 +77,9 @@ describe("formatDocumentationForFlagParameters", function () {
             disableAnsiColor: false,
         },
         text: text_en,
+        ansiColor: true,
+        aliases: void 0,
+        env: void 0,
     };
 
     describe("no flags", function () {
@@ -153,6 +156,79 @@ describe("formatDocumentationForFlagParameters", function () {
             };
 
             compareDocumentationToBaseline(parameters, defaultArgs);
+        });
+
+        describe("required boolean flag with default from env var (no value)", function () {
+            // GIVEN
+            type Positional = [];
+            type Flags = {
+                readonly requiredBoolean: boolean;
+            };
+
+            const parameters: TypedCommandParameters<Flags, Positional, CommandContext> = {
+                flags: {
+                    requiredBoolean: {
+                        kind: "boolean",
+                        brief: "required boolean flag",
+                        default: { env: "REQUIRED_BOOLEAN" },
+                    },
+                },
+                positional: { kind: "tuple", parameters: [] },
+            };
+
+            compareDocumentationToBaseline(parameters, defaultArgs);
+        });
+
+        describe("required boolean flag with default from env var (value)", function () {
+            // GIVEN
+            type Positional = [];
+            type Flags = {
+                readonly requiredBoolean: boolean;
+            };
+
+            const parameters: TypedCommandParameters<Flags, Positional, CommandContext> = {
+                flags: {
+                    requiredBoolean: {
+                        kind: "boolean",
+                        brief: "required boolean flag",
+                        default: { env: "REQUIRED_BOOLEAN" },
+                    },
+                },
+                positional: { kind: "tuple", parameters: [] },
+            };
+
+            compareDocumentationToBaseline(parameters, {
+                ...defaultArgs,
+                env: {
+                    REQUIRED_BOOLEAN: "yes",
+                },
+            });
+        });
+
+        describe("required boolean flag with default from env var (value, redacted)", function () {
+            // GIVEN
+            type Positional = [];
+            type Flags = {
+                readonly requiredBoolean: boolean;
+            };
+
+            const parameters: TypedCommandParameters<Flags, Positional, CommandContext> = {
+                flags: {
+                    requiredBoolean: {
+                        kind: "boolean",
+                        brief: "required boolean flag",
+                        default: { env: "REQUIRED_BOOLEAN", redact: true },
+                    },
+                },
+                positional: { kind: "tuple", parameters: [] },
+            };
+
+            compareDocumentationToBaseline(parameters, {
+                ...defaultArgs,
+                env: {
+                    REQUIRED_BOOLEAN: "yes",
+                },
+            });
         });
 
         describe("optional boolean flag", function () {
@@ -266,6 +342,82 @@ describe("formatDocumentationForFlagParameters", function () {
             };
 
             compareDocumentationToBaseline(parameters, defaultArgs);
+        });
+
+        describe("required enum flag with default from env var (no value)", function () {
+            // GIVEN
+            type Positional = [];
+            type Flags = {
+                readonly requiredEnum: "a" | "b" | "c";
+            };
+
+            const parameters: TypedCommandParameters<Flags, Positional, CommandContext> = {
+                flags: {
+                    requiredEnum: {
+                        kind: "enum",
+                        values: ["a", "b", "c"],
+                        default: { env: "REQUIRED_ENUM" },
+                        brief: "required enum flag",
+                    },
+                },
+                positional: { kind: "tuple", parameters: [] },
+            };
+
+            compareDocumentationToBaseline(parameters, defaultArgs);
+        });
+
+        describe("required enum flag with default from env var (value)", function () {
+            // GIVEN
+            type Positional = [];
+            type Flags = {
+                readonly requiredEnum: "a" | "b" | "c";
+            };
+
+            const parameters: TypedCommandParameters<Flags, Positional, CommandContext> = {
+                flags: {
+                    requiredEnum: {
+                        kind: "enum",
+                        values: ["a", "b", "c"],
+                        default: { env: "REQUIRED_ENUM" },
+                        brief: "required enum flag",
+                    },
+                },
+                positional: { kind: "tuple", parameters: [] },
+            };
+
+            compareDocumentationToBaseline(parameters, {
+                ...defaultArgs,
+                env: {
+                    REQUIRED_ENUM: "a",
+                },
+            });
+        });
+
+        describe("required enum flag with default from env var (value, redacted)", function () {
+            // GIVEN
+            type Positional = [];
+            type Flags = {
+                readonly requiredEnum: "a" | "b" | "c";
+            };
+
+            const parameters: TypedCommandParameters<Flags, Positional, CommandContext> = {
+                flags: {
+                    requiredEnum: {
+                        kind: "enum",
+                        values: ["a", "b", "c"],
+                        default: { env: "REQUIRED_ENUM", redact: true },
+                        brief: "required enum flag",
+                    },
+                },
+                positional: { kind: "tuple", parameters: [] },
+            };
+
+            compareDocumentationToBaseline(parameters, {
+                ...defaultArgs,
+                env: {
+                    REQUIRED_ENUM: "a",
+                },
+            });
         });
 
         describe("optional enum flag", function () {
@@ -428,6 +580,109 @@ describe("formatDocumentationForFlagParameters", function () {
             compareDocumentationToBaseline(parameters, {
                 ...defaultArgs,
                 includeHidden: true,
+            });
+        });
+
+        describe("required parsed flag with default from env var (no value)", function () {
+            // GIVEN
+            type Positional = [];
+            type Flags = {
+                readonly requiredParsed: string;
+            };
+
+            const parameters: TypedCommandParameters<Flags, Positional, CommandContext> = {
+                flags: {
+                    requiredParsed: {
+                        kind: "parsed",
+                        parse: String,
+                        default: { env: "REQUIRED_PARSED" },
+                        brief: "required parsed flag",
+                    },
+                },
+                positional: { kind: "tuple", parameters: [] },
+            };
+
+            compareDocumentationToBaseline(parameters, defaultArgs);
+        });
+
+        describe("required parsed flag with default from env var (value)", function () {
+            // GIVEN
+            type Positional = [];
+            type Flags = {
+                readonly requiredParsed: string;
+            };
+
+            const parameters: TypedCommandParameters<Flags, Positional, CommandContext> = {
+                flags: {
+                    requiredParsed: {
+                        kind: "parsed",
+                        parse: String,
+                        default: { env: "REQUIRED_PARSED" },
+                        brief: "required parsed flag",
+                    },
+                },
+                positional: { kind: "tuple", parameters: [] },
+            };
+
+            compareDocumentationToBaseline(parameters, {
+                ...defaultArgs,
+                env: {
+                    REQUIRED_PARSED: "VALUE",
+                },
+            });
+        });
+
+        describe("required parsed flag with default from env var (set, but empty)", function () {
+            // GIVEN
+            type Positional = [];
+            type Flags = {
+                readonly requiredParsed: string;
+            };
+
+            const parameters: TypedCommandParameters<Flags, Positional, CommandContext> = {
+                flags: {
+                    requiredParsed: {
+                        kind: "parsed",
+                        parse: String,
+                        default: { env: "REQUIRED_PARSED" },
+                        brief: "required parsed flag",
+                    },
+                },
+                positional: { kind: "tuple", parameters: [] },
+            };
+
+            compareDocumentationToBaseline(parameters, {
+                ...defaultArgs,
+                env: {
+                    REQUIRED_PARSED: "",
+                },
+            });
+        });
+
+        describe("required parsed flag with default from env var (value, redacted)", function () {
+            // GIVEN
+            type Positional = [];
+            type Flags = {
+                readonly requiredParsed: string;
+            };
+
+            const parameters: TypedCommandParameters<Flags, Positional, CommandContext> = {
+                flags: {
+                    requiredParsed: {
+                        kind: "parsed",
+                        parse: String,
+                        default: { env: "REQUIRED_PARSED", redact: true },
+                        brief: "required parsed flag",
+                    },
+                },
+                positional: { kind: "tuple", parameters: [] },
+            };
+
+            compareDocumentationToBaseline(parameters, {
+                ...defaultArgs,
+                env: {
+                    REQUIRED_PARSED: "VALUE",
+                },
             });
         });
 

--- a/packages/core/tests/routing/command.spec.ts
+++ b/packages/core/tests/routing/command.spec.ts
@@ -331,6 +331,7 @@ describe("Command", function () {
             includeHelpAllFlag: false,
             includeHidden: false,
             ansiColor: false,
+            env: void 0,
         };
 
         describe("no parameters", function () {

--- a/packages/core/tests/routing/route-map.spec.ts
+++ b/packages/core/tests/routing/route-map.spec.ts
@@ -141,6 +141,7 @@ describe("RouteMap", () => {
             includeHelpAllFlag: false,
             includeHidden: false,
             ansiColor: false,
+            env: void 0,
         };
 
         // GIVEN


### PR DESCRIPTION
Resolves #62 

**Describe your changes**
Expose functionality for application developers to pull the default value for a flag from an environment variable. This was already possible manually, but integrating it as a first-class feature allows for better formatting of error messages and the ability to "redact" the value in Stricli-generated output (for secrets).

**Testing performed**
Added several new test cases and updated the formatting baselines to achieve complete coverage.

**Additional context**
One side-effect is that `CommandContext["process"]` is now `StricliProcess` rather than just `WritableStreams` to allow `env` to be defined. The differences between the two types are just optional properties so there shouldn't be any issues.
