### PR TITLE
feat: custom separators for variadic flags

### DIFF
--- a/docs/docs/features/argument-parsing/flags.mdx
+++ b/docs/docs/features/argument-parsing/flags.mdx
@@ -151,6 +151,8 @@ import DefaultFlagCode from "./examples/default-flag.txt";
 
 A flag can be variadic when the type it represents is an array of values. In this case, the flag can be specified multiple times and each value is then parsed individually and added to a single array. If the type of a flag is an array it must be set as variadic.
 
+If the `variadic` config property is set to a string, Stricli will use that as a separator and split each input string. This is useful for cases where the input string is a single value that contains multiple values separated by a specific character (like a comma).
+
 import VariadicFlagCode from "./examples/variadic-flag.txt";
 
 <StricliPlayground filename="variadic-flag" rootExport="root" appName="run" defaultInput="--id 5 -i 10 -i 15">

--- a/packages/core/src/parameter/flag/formatting.ts
+++ b/packages/core/src/parameter/flag/formatting.ts
@@ -61,6 +61,10 @@ export function formatDocumentationForFlagParameters(
             const defaultKeyword = args.ansiColor ? `\x1B[90m${keywords.default}\x1B[39m` : keywords.default;
             suffixParts.push(`${defaultKeyword} ${flag.default === "" ? `""` : String(flag.default)}`);
         }
+        if ("variadic" in flag && typeof flag.variadic === "string") {
+            const separatorKeyword = args.ansiColor ? `\x1B[90m${keywords.separator}\x1B[39m` : keywords.separator;
+            suffixParts.push(`${separatorKeyword} ${flag.variadic}`);
+        }
         const suffix = suffixParts.length > 0 ? `[${suffixParts.join(", ")}]` : void 0;
 
         return {

--- a/packages/core/src/parameter/flag/types.ts
+++ b/packages/core/src/parameter/flag/types.ts
@@ -120,7 +120,7 @@ export interface BaseEnumFlagParameter<T extends string> extends BaseFlagParamet
     readonly default?: T;
     readonly optional?: boolean;
     readonly hidden?: boolean;
-    readonly variadic?: boolean;
+    readonly variadic?: boolean | string;
 }
 
 interface RequiredEnumFlagParameter<T extends string> extends BaseEnumFlagParameter<T> {
@@ -169,8 +169,12 @@ interface OptionalVariadicEnumFlagParameter<T extends string> extends BaseEnumFl
     readonly hidden?: false;
     /**
      * Parameter extends array and must be set as variadic.
+     * Also supports using an arbitrary string as a separator for individual inputs.
+     * For example, `variadic: ","` will scan `--flag a,b,c` as `["a", "b", "c"]`.
+     * If no separator is provided, the default behavior is to parse the input as a single string.
+     * The separator cannot be the empty string or contain any whitespace.
      */
-    readonly variadic: true;
+    readonly variadic: true | string;
 }
 
 interface RequiredVariadicEnumFlagParameter<T extends string> extends BaseEnumFlagParameter<T> {
@@ -189,8 +193,12 @@ interface RequiredVariadicEnumFlagParameter<T extends string> extends BaseEnumFl
     readonly hidden?: false;
     /**
      * Parameter extends array and must be set as variadic.
+     * Also supports using an arbitrary string as a separator for individual inputs.
+     * For example, `variadic: ","` will scan `--flag a,b,c` as `["a", "b", "c"]`.
+     * If no separator is provided, the default behavior is to parse the input as a single string.
+     * The separator cannot be the empty string or contain any whitespace.
      */
-    readonly variadic: true;
+    readonly variadic: true | string;
 }
 
 export interface BaseParsedFlagParameter<T, CONTEXT extends CommandContext>
@@ -209,7 +217,7 @@ export interface BaseParsedFlagParameter<T, CONTEXT extends CommandContext>
      */
     readonly inferEmpty?: boolean;
     readonly optional?: boolean;
-    readonly variadic?: boolean;
+    readonly variadic?: boolean | string;
     readonly hidden?: boolean;
 }
 
@@ -271,8 +279,12 @@ interface OptionalVariadicParsedFlagParameter<T, CONTEXT extends CommandContext>
     readonly optional: true;
     /**
      * Parameter extends array and must be set as variadic.
+     * Also supports using an arbitrary string as a separator for individual inputs.
+     * For example, `variadic: ","` will scan `--flag a,b,c` as `["a", "b", "c"]`.
+     * If no separator is provided, the default behavior is to parse the input as a single string.
+     * The separator cannot be the empty string or contain any whitespace.
      */
-    readonly variadic: true;
+    readonly variadic: true | string;
     /**
      * Default values are not supported for variadic parameters.
      */
@@ -288,8 +300,12 @@ interface RequiredVariadicParsedFlagParameter<T, CONTEXT extends CommandContext>
     readonly optional?: false;
     /**
      * Parameter extends array and must be set as variadic.
+     * Also supports using an arbitrary string as a separator for individual inputs.
+     * For example, `variadic: ","` will scan `--flag a,b,c` as `["a", "b", "c"]`.
+     * If no separator is provided, the default behavior is to parse the input as a single string.
+     * The separator cannot be the empty string or contain any whitespace.
      */
-    readonly variadic: true;
+    readonly variadic: true | string;
     /**
      * Default values are not supported for variadic parameters.
      */

--- a/packages/core/src/text.ts
+++ b/packages/core/src/text.ts
@@ -13,9 +13,15 @@ export interface DocumentationKeywords {
     /**
      * Keyword to be included when flags or arguments have a default value.
      *
-     * Defaults to `"default"`.
+     * Defaults to `"default ="`.
      */
     readonly default: string;
+    /**
+     * Keyword to be included when flags are variadic and have a defined separator.
+     *
+     * Defaults to `"separator ="`.
+     */
+    readonly separator: string;
 }
 
 /**
@@ -214,6 +220,7 @@ export const text_en: ApplicationText = {
     },
     keywords: {
         default: "default =",
+        separator: "separator =",
     },
     briefs: {
         help: "Print help information and exit",

--- a/packages/core/tests/baselines/reference/parameter/flag/formatting.txt
+++ b/packages/core/tests/baselines/reference/parameter/flag/formatting.txt
@@ -105,3 +105,7 @@
 [97m[39m   [97m--requiredVariadicParsed...[39m  [03mrequired variadic parsed flag[23m
 [97m-h[39m [97m--help[39m                       [03mPrint help information and exit[23m
 [97m[39m   [97m--[39m                           [03mAll subsequent inputs should be interpreted as arguments[23m
+:::: formatDocumentationForFlagParameters / parsed / variadic parsed flag with separator
+[97m[39m   [97m--variadicParsed...[39m  [03mvariadic parsed flag with separator[23m                      [[90mseparator =[39m ,]
+[97m-h[39m [97m--help[39m               [03mPrint help information and exit[23m
+[97m[39m   [97m--[39m                   [03mAll subsequent inputs should be interpreted as arguments[23m

--- a/packages/core/tests/parameter/flag/formatting.spec.ts
+++ b/packages/core/tests/parameter/flag/formatting.spec.ts
@@ -637,6 +637,32 @@ describe("formatDocumentationForFlagParameters", function () {
             compareToBaseline(this, StringArrayBaselineFormat, lines);
         });
 
+        it("variadic parsed flag with separator", function () {
+            // GIVEN
+            type Positional = [];
+            type Flags = {
+                readonly variadicParsed: string[];
+            };
+
+            const parameters: TypedCommandParameters<Flags, Positional, CommandContext> = {
+                flags: {
+                    variadicParsed: {
+                        kind: "parsed",
+                        parse: String,
+                        variadic: ",",
+                        brief: "variadic parsed flag with separator",
+                    },
+                },
+                positional: { kind: "tuple", parameters: [] },
+            };
+
+            // WHEN
+            const lines = formatDocumentationForFlagParameters(parameters.flags, parameters.aliases ?? {}, defaultArgs);
+
+            // THEN
+            compareToBaseline(this, StringArrayBaselineFormat, lines);
+        });
+
         it("required array parsed flag", function () {
             // GIVEN
             type Positional = [];

--- a/packages/core/tests/routing/command.spec.ts
+++ b/packages/core/tests/routing/command.spec.ts
@@ -222,6 +222,56 @@ describe("Command", function () {
                 });
             }).to.throw("Unable to allow negation for --verbose as it conflicts with --no-verbose");
         });
+
+        it("fails with invalid variadic flag separator (empty)", function () {
+            expect(() => {
+                // WHEN
+                buildCommand({
+                    loader: async () => {
+                        return {
+                            default: (flags: { numbers: number[] }) => {},
+                        };
+                    },
+                    parameters: {
+                        positional: { kind: "tuple", parameters: [] },
+                        flags: {
+                            numbers: {
+                                brief: "numbers flag brief",
+                                kind: "parsed",
+                                parse: numberParser,
+                                variadic: "",
+                            },
+                        },
+                    },
+                    docs: { brief: "brief" },
+                });
+            }).to.throw('Unable to use "" as variadic separator for --numbers as it is empty');
+        });
+
+        it("fails with invalid variadic flag separator (contains whitespace)", function () {
+            expect(() => {
+                // WHEN
+                buildCommand({
+                    loader: async () => {
+                        return {
+                            default: (flags: { numbers: number[] }) => {},
+                        };
+                    },
+                    parameters: {
+                        positional: { kind: "tuple", parameters: [] },
+                        flags: {
+                            numbers: {
+                                brief: "numbers flag brief",
+                                kind: "parsed",
+                                parse: numberParser,
+                                variadic: "| |",
+                            },
+                        },
+                    },
+                    docs: { brief: "brief" },
+                });
+            }).to.throw('Unable to use "| |" as variadic separator for --numbers as it contains whitespace');
+        });
     });
 
     describe("printHelp", function () {


### PR DESCRIPTION
Resolves #74 

**Describe your changes**
Allow `variadic` option for flags to be a string. If set, Stricli will use that string as a separator and call `.split(separator)` on every raw input (before it is parsed/validated).

For example, `variadic: ","` will split the raw input `--flag 1,2,3` into `["1", "2", "3"]` which will each be parsed separately (assuming this is a parsed number flag). This can still be combined with multiple instances of the same flag, so `--flag 1,2 --flag 3` will be `["1", "2", "3"]` as well.

**Testing performed**
Added several new test cases to achieve complete coverage.

**Additional context**
I've also added some additional validation to the flag specification, as the separator cannot be the empty string and should not include any whitespace.

**Note:** I don't know what would be the best way to indicate this behavior in the help text. I experimented with `--flag <placeholder><separator><placeholder>` but that got too verbose too fast.