### PR TITLE
test: automatically run doc baselines with/without ANSI

### DIFF
--- a/packages/core/eslint.config.mjs
+++ b/packages/core/eslint.config.mjs
@@ -18,5 +18,8 @@ export default [
                 project: ["tsconfig.json"],
             },
         },
+        rules: {
+            "no-control-regex": "off",
+        },
     },
 ];

--- a/packages/core/tests/application.spec.ts
+++ b/packages/core/tests/application.spec.ts
@@ -18,8 +18,6 @@ import {
     type RouteMapBuilderArguments,
     type VersionInfo,
 } from "../src";
-// eslint-disable-next-line no-restricted-imports
-import type { RouteMapRoutes } from "../src/routing/route-map/builder";
 import { compareToBaseline, sanitizeStackTraceReferences, type BaselineFormat } from "./baseline";
 import { buildFakeApplicationText } from "./fakes/config";
 import { buildFakeContext, type FakeContext } from "./fakes/context";

--- a/packages/core/tests/baselines/reference/parameter/flag/formatting.txt
+++ b/packages/core/tests/baselines/reference/parameter/flag/formatting.txt
@@ -1,111 +1,214 @@
-:::: formatDocumentationForFlagParameters / boolean / hidden optional boolean flag
+:::: formatDocumentationForFlagParameters / boolean / hidden optional boolean flag / no ANSI color
+-h --help  Print help information and exit
+   --      All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / boolean / hidden optional boolean flag / with ANSI color
 [97m-h[39m [97m--help[39m  [03mPrint help information and exit[23m
 [97m[39m   [97m--[39m      [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / boolean / hidden optional boolean flag, help all
+:::: formatDocumentationForFlagParameters / boolean / hidden optional boolean flag, help all / no ANSI color
+   [--optionalBoolean/--noOptionalBoolean]  optional boolean flag
+-h  --help                                  Print help information and exit
+    --                                      All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / boolean / hidden optional boolean flag, help all / with ANSI color
 [90m[39m   [90m[--optionalBoolean/--noOptionalBoolean][39m  [90moptional boolean flag[39m
 [97m-h[39m [97m --help[39m                                  [03mPrint help information and exit[23m
 [97m[39m   [97m --[39m                                      [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / boolean / optional boolean flag
+:::: formatDocumentationForFlagParameters / boolean / optional boolean flag / no ANSI color
+   [--optionalBoolean/--noOptionalBoolean]  optional boolean flag
+-h  --help                                  Print help information and exit
+    --                                      All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / boolean / optional boolean flag / with ANSI color
 [97m[39m   [97m[--optionalBoolean/--noOptionalBoolean][39m  [03moptional boolean flag[23m
 [97m-h[39m [97m --help[39m                                  [03mPrint help information and exit[23m
 [97m[39m   [97m --[39m                                      [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / boolean / required boolean flag
+:::: formatDocumentationForFlagParameters / boolean / required boolean flag / no ANSI color
+   --requiredBoolean/--noRequiredBoolean  required boolean flag
+-h --help                                 Print help information and exit
+   --                                     All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / boolean / required boolean flag / with ANSI color
 [97m[39m   [97m--requiredBoolean/--noRequiredBoolean[39m  [03mrequired boolean flag[23m
 [97m-h[39m [97m--help[39m                                 [03mPrint help information and exit[23m
 [97m[39m   [97m--[39m                                     [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / boolean / required boolean flag with default=false
-[97m[39m   [97m[--requiredBoolean][39m  [03mrequired boolean flag[23m                                    [[90mdefault =[39m false]
-[97m-h[39m [97m --help[39m              [03mPrint help information and exit[23m
-[97m[39m   [97m --[39m                  [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / boolean / required boolean flag with default=false, no ansi color
+:::: formatDocumentationForFlagParameters / boolean / required boolean flag with default=false / no ANSI color
    [--requiredBoolean]  required boolean flag                                    [default = false]
 -h  --help              Print help information and exit
     --                  All subsequent inputs should be interpreted as arguments
-:::: formatDocumentationForFlagParameters / boolean / required boolean flag with default=true
+:::: formatDocumentationForFlagParameters / boolean / required boolean flag with default=false / with ANSI color
+[97m[39m   [97m[--requiredBoolean][39m  [03mrequired boolean flag[23m                                    [[90mdefault =[39m false]
+[97m-h[39m [97m --help[39m              [03mPrint help information and exit[23m
+[97m[39m   [97m --[39m                  [03mAll subsequent inputs should be interpreted as arguments[23m
+:::: formatDocumentationForFlagParameters / boolean / required boolean flag with default=true / no ANSI color
+   [--requiredBoolean/--noRequiredBoolean]  required boolean flag                                    [default = true]
+-h  --help                                  Print help information and exit
+    --                                      All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / boolean / required boolean flag with default=true / with ANSI color
 [97m[39m   [97m[--requiredBoolean/--noRequiredBoolean][39m  [03mrequired boolean flag[23m                                    [[90mdefault =[39m true]
 [97m-h[39m [97m --help[39m                                  [03mPrint help information and exit[23m
 [97m[39m   [97m --[39m                                      [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / enum / optional enum flag
+:::: formatDocumentationForFlagParameters / enum / optional enum flag / no ANSI color
+   [--optionalEnum]  optional enum flag                                       [a|b|c]
+-h  --help           Print help information and exit
+    --               All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / enum / optional enum flag / with ANSI color
 [97m[39m   [97m[--optionalEnum][39m  [03moptional enum flag[23m                                       [a|b|c]
 [97m-h[39m [97m --help[39m           [03mPrint help information and exit[23m
 [97m[39m   [97m --[39m               [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / enum / optional enum flag with default
+:::: formatDocumentationForFlagParameters / enum / optional enum flag with default / no ANSI color
+   [--optionalEnum]  optional enum flag                                       [a|b|c, default = b]
+-h  --help           Print help information and exit
+    --               All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / enum / optional enum flag with default / with ANSI color
 [97m[39m   [97m[--optionalEnum][39m  [03moptional enum flag[23m                                       [a|b|c, [90mdefault =[39m b]
 [97m-h[39m [97m --help[39m           [03mPrint help information and exit[23m
 [97m[39m   [97m --[39m               [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / enum / required enum flag
+:::: formatDocumentationForFlagParameters / enum / required enum flag / no ANSI color
+   --requiredEnum  required enum flag                                       [a|b|c]
+-h --help          Print help information and exit
+   --              All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / enum / required enum flag / with ANSI color
 [97m[39m   [97m--requiredEnum[39m  [03mrequired enum flag[23m                                       [a|b|c]
 [97m-h[39m [97m--help[39m          [03mPrint help information and exit[23m
 [97m[39m   [97m--[39m              [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / enum / required enum flag with default
+:::: formatDocumentationForFlagParameters / enum / required enum flag with default / no ANSI color
+   [--requiredEnum]  required enum flag                                       [a|b|c, default = b]
+-h  --help           Print help information and exit
+    --               All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / enum / required enum flag with default / with ANSI color
 [97m[39m   [97m[--requiredEnum][39m  [03mrequired enum flag[23m                                       [a|b|c, [90mdefault =[39m b]
 [97m-h[39m [97m --help[39m           [03mPrint help information and exit[23m
 [97m[39m   [97m --[39m               [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / no flags
+:::: formatDocumentationForFlagParameters / no flags / no ANSI color
+-h --help  Print help information and exit
+   --      All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / no flags / with ANSI color
 [97m-h[39m [97m--help[39m  [03mPrint help information and exit[23m
 [97m[39m   [97m--[39m      [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / parsed / flag with nonstandard character
+:::: formatDocumentationForFlagParameters / parsed / flag with nonstandard character / no ANSI color
+   --a.b.c_10  required parsed flag
+-h --help      Print help information and exit
+   --          All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / flag with nonstandard character / with ANSI color
 [97m[39m   [97m--a.b.c_10[39m  [03mrequired parsed flag[23m
 [97m-h[39m [97m--help[39m      [03mPrint help information and exit[23m
 [97m[39m   [97m--[39m          [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / parsed / multipart flag
+:::: formatDocumentationForFlagParameters / parsed / multipart flag / no ANSI color
+   --multi.part  required parsed flag
+-h --help        Print help information and exit
+   --            All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / multipart flag / with ANSI color
 [97m[39m   [97m--multi.part[39m  [03mrequired parsed flag[23m
 [97m-h[39m [97m--help[39m        [03mPrint help information and exit[23m
 [97m[39m   [97m--[39m            [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / parsed / multiple parsed flags
+:::: formatDocumentationForFlagParameters / parsed / multiple parsed flags / no ANSI color
+   --requiredParsed                        required parsed flag
+   --requiredParsedWithLongerName          required parsed flag with longer name
+   --required-parsed-with-kebab-case-name  required parsed flag with kebab-case name
+-h --help                                  Print help information and exit
+   --                                      All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / multiple parsed flags / with ANSI color
 [97m[39m   [97m--requiredParsed[39m                        [03mrequired parsed flag[23m
 [97m[39m   [97m--requiredParsedWithLongerName[39m          [03mrequired parsed flag with longer name[23m
 [97m[39m   [97m--required-parsed-with-kebab-case-name[39m  [03mrequired parsed flag with kebab-case name[23m
 [97m-h[39m [97m--help[39m                                  [03mPrint help information and exit[23m
 [97m[39m   [97m--[39m                                      [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / parsed / optional array parsed flag
+:::: formatDocumentationForFlagParameters / parsed / optional array parsed flag / no ANSI color
+   [--optionalArrayParsed]  optional array parsed flag
+-h  --help                  Print help information and exit
+    --                      All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / optional array parsed flag / with ANSI color
 [97m[39m   [97m[--optionalArrayParsed][39m  [03moptional array parsed flag[23m
 [97m-h[39m [97m --help[39m                  [03mPrint help information and exit[23m
 [97m[39m   [97m --[39m                      [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / parsed / optional parsed flag
+:::: formatDocumentationForFlagParameters / parsed / optional parsed flag / no ANSI color
+   [--optionalParsed]  optional parsed flag
+-h  --help             Print help information and exit
+    --                 All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / optional parsed flag / with ANSI color
 [97m[39m   [97m[--optionalParsed][39m  [03moptional parsed flag[23m
 [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
 [97m[39m   [97m --[39m                 [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / parsed / optional parsed flag with alias
+:::: formatDocumentationForFlagParameters / parsed / optional parsed flag with alias / no ANSI color
+-p [--optionalParsed]  optional parsed flag
+-h  --help             Print help information and exit
+    --                 All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / optional parsed flag with alias / with ANSI color
 [97m-p[39m [97m[--optionalParsed][39m  [03moptional parsed flag[23m
 [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
 [97m[39m   [97m --[39m                 [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / parsed / optional variadic parsed flag
+:::: formatDocumentationForFlagParameters / parsed / optional variadic parsed flag / no ANSI color
+   [--optionalVariadicParsed]...  optional variadic parsed flag
+-h  --help                        Print help information and exit
+    --                            All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / optional variadic parsed flag / with ANSI color
 [97m[39m   [97m[--optionalVariadicParsed]...[39m  [03moptional variadic parsed flag[23m
 [97m-h[39m [97m --help[39m                        [03mPrint help information and exit[23m
 [97m[39m   [97m --[39m                            [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / parsed / required array parsed flag
+:::: formatDocumentationForFlagParameters / parsed / required array parsed flag / no ANSI color
+   --requiredArrayParsed  required array parsed flag
+-h --help                 Print help information and exit
+   --                     All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / required array parsed flag / with ANSI color
 [97m[39m   [97m--requiredArrayParsed[39m  [03mrequired array parsed flag[23m
 [97m-h[39m [97m--help[39m                 [03mPrint help information and exit[23m
 [97m[39m   [97m--[39m                     [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / parsed / required parsed flag
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag / no ANSI color
+   --requiredParsed  required parsed flag
+-h --help            Print help information and exit
+   --                All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag / with ANSI color
 [97m[39m   [97m--requiredParsed[39m  [03mrequired parsed flag[23m
 [97m-h[39m [97m--help[39m            [03mPrint help information and exit[23m
 [97m[39m   [97m--[39m                [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / parsed / required parsed flag with alias
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag with alias / no ANSI color
+-p --requiredParsed  required parsed flag
+-h --help            Print help information and exit
+   --                All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag with alias / with ANSI color
 [97m-p[39m [97m--requiredParsed[39m  [03mrequired parsed flag[23m
 [97m-h[39m [97m--help[39m            [03mPrint help information and exit[23m
 [97m[39m   [97m--[39m                [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default / no ANSI color
+   [--requiredParsed]  required parsed flag                                     [default = ""]
+-h  --help             Print help information and exit
+    --                 All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default / with ANSI color
 [97m[39m   [97m[--requiredParsed][39m  [03mrequired parsed flag[23m                                     [[90mdefault =[39m ""]
 [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
 [97m[39m   [97m --[39m                 [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default [hidden]
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default [hidden] / no ANSI color
+-h --help  Print help information and exit
+   --      All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default [hidden] / with ANSI color
 [97m-h[39m [97m--help[39m  [03mPrint help information and exit[23m
 [97m[39m   [97m--[39m      [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default [hidden], hide all
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default [hidden], hide all / no ANSI color
+   [--requiredParsed]  required parsed flag                                     [default = 100]
+-h  --help             Print help information and exit
+    --                 All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default [hidden], hide all / with ANSI color
 [90m[39m   [90m[--requiredParsed][39m  [90mrequired parsed flag[39m                                     [[90mdefault =[39m 100]
 [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
 [97m[39m   [97m --[39m                 [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default and alias
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default and alias / no ANSI color
+-p [--requiredParsed]  required parsed flag                                     [default = 100]
+-h  --help             Print help information and exit
+    --                 All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / required parsed flag with default and alias / with ANSI color
 [97m-p[39m [97m[--requiredParsed][39m  [03mrequired parsed flag[23m                                     [[90mdefault =[39m 100]
 [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
 [97m[39m   [97m --[39m                 [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / parsed / required variadic parsed flag
+:::: formatDocumentationForFlagParameters / parsed / required variadic parsed flag / no ANSI color
+   --requiredVariadicParsed...  required variadic parsed flag
+-h --help                       Print help information and exit
+   --                           All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / required variadic parsed flag / with ANSI color
 [97m[39m   [97m--requiredVariadicParsed...[39m  [03mrequired variadic parsed flag[23m
 [97m-h[39m [97m--help[39m                       [03mPrint help information and exit[23m
 [97m[39m   [97m--[39m                           [03mAll subsequent inputs should be interpreted as arguments[23m
-:::: formatDocumentationForFlagParameters / parsed / variadic parsed flag with separator
+:::: formatDocumentationForFlagParameters / parsed / variadic parsed flag with separator / no ANSI color
+   --variadicParsed...  variadic parsed flag with separator                      [separator = ,]
+-h --help               Print help information and exit
+   --                   All subsequent inputs should be interpreted as arguments
+:::: formatDocumentationForFlagParameters / parsed / variadic parsed flag with separator / with ANSI color
 [97m[39m   [97m--variadicParsed...[39m  [03mvariadic parsed flag with separator[23m                      [[90mseparator =[39m ,]
 [97m-h[39m [97m--help[39m               [03mPrint help information and exit[23m
 [97m[39m   [97m--[39m                   [03mAll subsequent inputs should be interpreted as arguments[23m

--- a/packages/core/tests/baselines/reference/parameter/positional/formatting.txt
+++ b/packages/core/tests/baselines/reference/parameter/positional/formatting.txt
@@ -1,19 +1,34 @@
-:::: formatDocumentationForPositionalParameters / homogenous array of positional parameters
+:::: formatDocumentationForPositionalParameters / homogenous array of positional parameters / no ANSI color
+parsed...  required positional parameter
+:::: formatDocumentationForPositionalParameters / homogenous array of positional parameters / with ANSI color
 [97mparsed...[39m  [3mrequired positional parameter[23m
-:::: formatDocumentationForPositionalParameters / tuple of multiple positional parameters
+:::: formatDocumentationForPositionalParameters / tuple of multiple positional parameters / no ANSI color
+parsed             required positional parameter
+parsedLonger       required positional parameter with longer placeholder
+parsed-kebab-case  required positional parameter with kebab-case placeholder
+:::: formatDocumentationForPositionalParameters / tuple of multiple positional parameters / with ANSI color
 [97mparsed[39m             [3mrequired positional parameter[23m
 [97mparsedLonger[39m       [3mrequired positional parameter with longer placeholder[23m
 [97mparsed-kebab-case[39m  [3mrequired positional parameter with kebab-case placeholder[23m
-:::: formatDocumentationForPositionalParameters / tuple of one optional positional parameter
+:::: formatDocumentationForPositionalParameters / tuple of one optional positional parameter / no ANSI color
+[parsed]  optional positional parameter
+:::: formatDocumentationForPositionalParameters / tuple of one optional positional parameter / with ANSI color
 [97m[parsed][39m  [3moptional positional parameter[23m
-:::: formatDocumentationForPositionalParameters / tuple of one optional positional parameter with default
+:::: formatDocumentationForPositionalParameters / tuple of one optional positional parameter with default / no ANSI color
+[parsed]  optional positional parameter [default = 1001]
+:::: formatDocumentationForPositionalParameters / tuple of one optional positional parameter with default / with ANSI color
 [97m[parsed][39m  [3moptional positional parameter[23m [[90mdefault =[39m 1001]
-:::: formatDocumentationForPositionalParameters / tuple of one positional parameter with default
-[97mparsed[39m  [3mrequired positional parameter[23m [[90mdefault =[39m 1001]
-:::: formatDocumentationForPositionalParameters / tuple of one positional parameter with default, no ansi color
+:::: formatDocumentationForPositionalParameters / tuple of one positional parameter with default / no ANSI color
 parsed  required positional parameter [default = 1001]
-:::: formatDocumentationForPositionalParameters / tuple of one positional parameter with default, with alt text
+:::: formatDocumentationForPositionalParameters / tuple of one positional parameter with default / with ANSI color
+[97mparsed[39m  [3mrequired positional parameter[23m [[90mdefault =[39m 1001]
+:::: formatDocumentationForPositionalParameters / tuple of one positional parameter with default, with alt text / no ANSI color
+parsed  required positional parameter [def = 1001]
+:::: formatDocumentationForPositionalParameters / tuple of one positional parameter with default, with alt text / with ANSI color
 [97mparsed[39m  [3mrequired positional parameter[23m [[90mdef =[39m 1001]
-:::: formatDocumentationForPositionalParameters / tuple of one required positional parameter
+:::: formatDocumentationForPositionalParameters / tuple of one required positional parameter / no ANSI color
+parsed  required positional parameter
+:::: formatDocumentationForPositionalParameters / tuple of one required positional parameter / with ANSI color
 [97mparsed[39m  [3mrequired positional parameter[23m
-:::: formatDocumentationForPositionalParameters / tuple with no positional parameters
+:::: formatDocumentationForPositionalParameters / tuple with no positional parameters / no ANSI color
+:::: formatDocumentationForPositionalParameters / tuple with no positional parameters / with ANSI color

--- a/packages/core/tests/baselines/reference/routing/command.txt
+++ b/packages/core/tests/baselines/reference/routing/command.txt
@@ -1,4 +1,4 @@
-:::: Command / printHelp / mixed parameters
+:::: Command / printHelp / mixed parameters / no ANSI color
 USAGE
   prefix (--alpha value) (--bravo value)... [--charlie c] (--delta) <arg1> [<arg2>]
   prefix --help
@@ -16,7 +16,25 @@ ARGUMENTS
    arg1   first argument brief
   [arg2]  second argument brief
 
-:::: Command / printHelp / mixed parameters with `convert-camel-to-kebab` display case style
+:::: Command / printHelp / mixed parameters / with ANSI color
+[1mUSAGE[22m
+  prefix (--alpha value) (--bravo value)... [--charlie c] (--delta) <arg1> [<arg2>]
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m-a[39m [97m --alpha[39m            [03malpha flag brief[23m
+  [97m[39m   [97m --bravo...[39m         [03mbravo flag brief[23m
+  [97m[39m   [97m[--charlie][39m         [03mcharlie flag brief[23m
+  [97m-d[39m [97m --delta/--noDelta[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
+
+[1mARGUMENTS[22m
+  [97m arg1[39m   [3mfirst argument brief[23m
+  [97m[arg2][39m  [3msecond argument brief[23m
+
+:::: Command / printHelp / mixed parameters with `convert-camel-to-kebab` display case style / no ANSI color
 USAGE
   prefix (--alpha-flag value) (--bravo-flag value)... [--charlie-flag c] (--delta-flag) <arg1> [<arg2>]
   prefix --help
@@ -34,7 +52,25 @@ ARGUMENTS
    arg1   first argument brief
   [arg2]  second argument brief
 
-:::: Command / printHelp / mixed parameters with `convert-camel-to-kebab` display case style, only required in usage line
+:::: Command / printHelp / mixed parameters with `convert-camel-to-kebab` display case style / with ANSI color
+[1mUSAGE[22m
+  prefix (--alpha-flag value) (--bravo-flag value)... [--charlie-flag c] (--delta-flag) <arg1> [<arg2>]
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m-a[39m [97m --alpha-flag[39m                  [03malpha flag brief[23m
+  [97m[39m   [97m --bravo-flag...[39m               [03mbravo flag brief[23m
+  [97m[39m   [97m[--charlie-flag][39m               [03mcharlie flag brief[23m
+  [97m-d[39m [97m --delta-flag/--no-delta-flag[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m --help[39m                        [03mPrint help information and exit[23m
+
+[1mARGUMENTS[22m
+  [97m arg1[39m   [3mfirst argument brief[23m
+  [97m[arg2][39m  [3msecond argument brief[23m
+
+:::: Command / printHelp / mixed parameters with `convert-camel-to-kebab` display case style, only required in usage line / no ANSI color
 USAGE
   prefix (--alpha-flag value) (--bravo-flag value)... (--delta-flag) <arg1>
   prefix --help
@@ -52,7 +88,25 @@ ARGUMENTS
    arg1   first argument brief
   [arg2]  second argument brief
 
-:::: Command / printHelp / mixed parameters with `original` display case style
+:::: Command / printHelp / mixed parameters with `convert-camel-to-kebab` display case style, only required in usage line / with ANSI color
+[1mUSAGE[22m
+  prefix (--alpha-flag value) (--bravo-flag value)... (--delta-flag) <arg1>
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m-a[39m [97m --alpha-flag[39m                  [03malpha flag brief[23m
+  [97m[39m   [97m --bravo-flag...[39m               [03mbravo flag brief[23m
+  [97m[39m   [97m[--charlie-flag][39m               [03mcharlie flag brief[23m
+  [97m-d[39m [97m --delta-flag/--no-delta-flag[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m --help[39m                        [03mPrint help information and exit[23m
+
+[1mARGUMENTS[22m
+  [97m arg1[39m   [3mfirst argument brief[23m
+  [97m[arg2][39m  [3msecond argument brief[23m
+
+:::: Command / printHelp / mixed parameters with `original` display case style / no ANSI color
 USAGE
   prefix (--alphaFlag value) (--bravoFlag value)... [--charlieFlag c] (--deltaFlag) <arg1> [<arg2>]
   prefix --help
@@ -70,7 +124,25 @@ ARGUMENTS
    arg1   first argument brief
   [arg2]  second argument brief
 
-:::: Command / printHelp / mixed parameters with `original` display case style, only required in usage line
+:::: Command / printHelp / mixed parameters with `original` display case style / with ANSI color
+[1mUSAGE[22m
+  prefix (--alphaFlag value) (--bravoFlag value)... [--charlieFlag c] (--deltaFlag) <arg1> [<arg2>]
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m-a[39m [97m --alphaFlag[39m                [03malpha flag brief[23m
+  [97m[39m   [97m --bravoFlag...[39m             [03mbravo flag brief[23m
+  [97m[39m   [97m[--charlieFlag][39m             [03mcharlie flag brief[23m
+  [97m-d[39m [97m --deltaFlag/--noDeltaFlag[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m --help[39m                     [03mPrint help information and exit[23m
+
+[1mARGUMENTS[22m
+  [97m arg1[39m   [3mfirst argument brief[23m
+  [97m[arg2][39m  [3msecond argument brief[23m
+
+:::: Command / printHelp / mixed parameters with `original` display case style, only required in usage line / no ANSI color
 USAGE
   prefix (--alphaFlag value) (--bravoFlag value)... (--deltaFlag) <arg1>
   prefix --help
@@ -88,7 +160,25 @@ ARGUMENTS
    arg1   first argument brief
   [arg2]  second argument brief
 
-:::: Command / printHelp / mixed parameters with aliases
+:::: Command / printHelp / mixed parameters with `original` display case style, only required in usage line / with ANSI color
+[1mUSAGE[22m
+  prefix (--alphaFlag value) (--bravoFlag value)... (--deltaFlag) <arg1>
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m-a[39m [97m --alphaFlag[39m                [03malpha flag brief[23m
+  [97m[39m   [97m --bravoFlag...[39m             [03mbravo flag brief[23m
+  [97m[39m   [97m[--charlieFlag][39m             [03mcharlie flag brief[23m
+  [97m-d[39m [97m --deltaFlag/--noDeltaFlag[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m --help[39m                     [03mPrint help information and exit[23m
+
+[1mARGUMENTS[22m
+  [97m arg1[39m   [3mfirst argument brief[23m
+  [97m[arg2][39m  [3msecond argument brief[23m
+
+:::: Command / printHelp / mixed parameters with aliases / no ANSI color
 USAGE
   cli route (--alpha value) (--bravo value)... [--charlie c] (--delta) <arg1> [<arg2>]
   cli route --help
@@ -112,7 +202,7 @@ ARGUMENTS
    arg1   first argument brief
   [arg2]  second argument brief
 
-:::: Command / printHelp / mixed parameters with aliases, ansi color
+:::: Command / printHelp / mixed parameters with aliases / with ANSI color
 [1mUSAGE[22m
   cli route (--alpha value) (--bravo value)... [--charlie c] (--delta) <arg1> [<arg2>]
   cli route --help
@@ -136,7 +226,7 @@ brief
   [97m arg1[39m   [3mfirst argument brief[23m
   [97m[arg2][39m  [3msecond argument brief[23m
 
-:::: Command / printHelp / mixed parameters with aliases, only required in usage line
+:::: Command / printHelp / mixed parameters with aliases, only required in usage line / no ANSI color
 USAGE
   cli route (--alpha value) (--bravo value)... (--delta) <arg1>
   cli route --help
@@ -160,7 +250,31 @@ ARGUMENTS
    arg1   first argument brief
   [arg2]  second argument brief
 
-:::: Command / printHelp / mixed parameters with custom headers
+:::: Command / printHelp / mixed parameters with aliases, only required in usage line / with ANSI color
+[1mUSAGE[22m
+  cli route (--alpha value) (--bravo value)... (--delta) <arg1>
+  cli route --help
+  cli route --version
+
+brief
+
+[1mALIASES[22m
+  cli alias1
+  cli alias2
+
+[1mFLAGS[22m
+  [97m-a[39m [97m --alpha[39m            [03malpha flag brief[23m
+  [97m[39m   [97m --bravo...[39m         [03mbravo flag brief[23m
+  [97m[39m   [97m[--charlie][39m         [03mcharlie flag brief[23m
+  [97m-d[39m [97m --delta/--noDelta[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
+  [97m-v[39m [97m --version[39m          [03mPrint version information and exit[23m
+
+[1mARGUMENTS[22m
+  [97m arg1[39m   [3mfirst argument brief[23m
+  [97m[arg2][39m  [3msecond argument brief[23m
+
+:::: Command / printHelp / mixed parameters with custom headers / no ANSI color
 Usage:
   cli route (--alpha value) (--bravo value)... [--charlie c] (--delta) <arg1> [<arg2>]
   cli route --help
@@ -184,7 +298,31 @@ Arguments:
    arg1   first argument brief
   [arg2]  second argument brief
 
-:::: Command / printHelp / mixed parameters with custom headers, only required in usage line
+:::: Command / printHelp / mixed parameters with custom headers / with ANSI color
+[1mUsage:[22m
+  cli route (--alpha value) (--bravo value)... [--charlie c] (--delta) <arg1> [<arg2>]
+  cli route --help
+  cli route --version
+
+brief
+
+[1mAliases:[22m
+  cli alias1
+  cli alias2
+
+[1mFlags:[22m
+  [97m-a[39m [97m --alpha[39m            [03malpha flag brief[23m
+  [97m[39m   [97m --bravo...[39m         [03mbravo flag brief[23m
+  [97m[39m   [97m[--charlie][39m         [03mcharlie flag brief[23m
+  [97m-d[39m [97m --delta/--noDelta[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
+  [97m-v[39m [97m --version[39m          [03mPrint version information and exit[23m
+
+[1mArguments:[22m
+  [97m arg1[39m   [3mfirst argument brief[23m
+  [97m[arg2][39m  [3msecond argument brief[23m
+
+:::: Command / printHelp / mixed parameters with custom headers, only required in usage line / no ANSI color
 Usage:
   cli route (--alpha value) (--bravo value)... (--delta) <arg1>
   cli route --help
@@ -208,7 +346,31 @@ Arguments:
    arg1   first argument brief
   [arg2]  second argument brief
 
-:::: Command / printHelp / mixed parameters with version available
+:::: Command / printHelp / mixed parameters with custom headers, only required in usage line / with ANSI color
+[1mUsage:[22m
+  cli route (--alpha value) (--bravo value)... (--delta) <arg1>
+  cli route --help
+  cli route --version
+
+brief
+
+[1mAliases:[22m
+  cli alias1
+  cli alias2
+
+[1mFlags:[22m
+  [97m-a[39m [97m --alpha[39m            [03malpha flag brief[23m
+  [97m[39m   [97m --bravo...[39m         [03mbravo flag brief[23m
+  [97m[39m   [97m[--charlie][39m         [03mcharlie flag brief[23m
+  [97m-d[39m [97m --delta/--noDelta[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
+  [97m-v[39m [97m --version[39m          [03mPrint version information and exit[23m
+
+[1mArguments:[22m
+  [97m arg1[39m   [3mfirst argument brief[23m
+  [97m[arg2][39m  [3msecond argument brief[23m
+
+:::: Command / printHelp / mixed parameters with version available / no ANSI color
 USAGE
   prefix (--alpha value) (--bravo value)... [--charlie c] (--delta) <arg1> [<arg2>]
   prefix --help
@@ -228,7 +390,27 @@ ARGUMENTS
    arg1   first argument brief
   [arg2]  second argument brief
 
-:::: Command / printHelp / mixed parameters with version available, only required in usage line
+:::: Command / printHelp / mixed parameters with version available / with ANSI color
+[1mUSAGE[22m
+  prefix (--alpha value) (--bravo value)... [--charlie c] (--delta) <arg1> [<arg2>]
+  prefix --help
+  prefix --version
+
+brief
+
+[1mFLAGS[22m
+  [97m-a[39m [97m --alpha[39m            [03malpha flag brief[23m
+  [97m[39m   [97m --bravo...[39m         [03mbravo flag brief[23m
+  [97m[39m   [97m[--charlie][39m         [03mcharlie flag brief[23m
+  [97m-d[39m [97m --delta/--noDelta[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
+  [97m-v[39m [97m --version[39m          [03mPrint version information and exit[23m
+
+[1mARGUMENTS[22m
+  [97m arg1[39m   [3mfirst argument brief[23m
+  [97m[arg2][39m  [3msecond argument brief[23m
+
+:::: Command / printHelp / mixed parameters with version available, only required in usage line / no ANSI color
 USAGE
   prefix (--alpha value) (--bravo value)... (--delta) <arg1>
   prefix --help
@@ -248,7 +430,27 @@ ARGUMENTS
    arg1   first argument brief
   [arg2]  second argument brief
 
-:::: Command / printHelp / mixed parameters, custom usage
+:::: Command / printHelp / mixed parameters with version available, only required in usage line / with ANSI color
+[1mUSAGE[22m
+  prefix (--alpha value) (--bravo value)... (--delta) <arg1>
+  prefix --help
+  prefix --version
+
+brief
+
+[1mFLAGS[22m
+  [97m-a[39m [97m --alpha[39m            [03malpha flag brief[23m
+  [97m[39m   [97m --bravo...[39m         [03mbravo flag brief[23m
+  [97m[39m   [97m[--charlie][39m         [03mcharlie flag brief[23m
+  [97m-d[39m [97m --delta/--noDelta[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
+  [97m-v[39m [97m --version[39m          [03mPrint version information and exit[23m
+
+[1mARGUMENTS[22m
+  [97m arg1[39m   [3mfirst argument brief[23m
+  [97m[arg2][39m  [3msecond argument brief[23m
+
+:::: Command / printHelp / mixed parameters, custom usage / no ANSI color
 USAGE
   prefix custom usage line #1
   prefix custom usage line #2
@@ -266,7 +468,25 @@ FLAGS
 ARGUMENTS
   args...  string array brief
 
-:::: Command / printHelp / mixed parameters, enhanced custom usage
+:::: Command / printHelp / mixed parameters, custom usage / with ANSI color
+[1mUSAGE[22m
+  prefix custom usage line #1
+  prefix custom usage line #2
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m-a[39m [97m --alpha[39m            [03malpha flag brief[23m
+  [97m[39m   [97m --bravo...[39m         [03mbravo flag brief[23m
+  [97m[39m   [97m[--charlie][39m         [03mcharlie flag brief[23m
+  [97m-d[39m [97m --delta/--noDelta[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
+
+[1mARGUMENTS[22m
+  [97margs...[39m  [3mstring array brief[23m
+
+:::: Command / printHelp / mixed parameters, enhanced custom usage / no ANSI color
 USAGE
   prefix -a 1
     enhanced usage line #1
@@ -286,7 +506,27 @@ FLAGS
 ARGUMENTS
   args...  string array brief
 
-:::: Command / printHelp / mixed parameters, force include hidden
+:::: Command / printHelp / mixed parameters, enhanced custom usage / with ANSI color
+[1mUSAGE[22m
+  prefix -a 1
+    [3menhanced usage line #1[23m
+  prefix -a 2 -d
+    [3menhanced usage line #2[23m
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m-a[39m [97m --alpha[39m            [03malpha flag brief[23m
+  [97m[39m   [97m --bravo...[39m         [03mbravo flag brief[23m
+  [97m[39m   [97m[--charlie][39m         [03mcharlie flag brief[23m
+  [97m-d[39m [97m --delta/--noDelta[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
+
+[1mARGUMENTS[22m
+  [97margs...[39m  [3mstring array brief[23m
+
+:::: Command / printHelp / mixed parameters, force include hidden / no ANSI color
 USAGE
   prefix (--alpha value) (--delta) <args>...
   prefix --help
@@ -303,7 +543,24 @@ FLAGS
 ARGUMENTS
   args...  string array brief
 
-:::: Command / printHelp / mixed parameters, full description
+:::: Command / printHelp / mixed parameters, force include hidden / with ANSI color
+[1mUSAGE[22m
+  prefix (--alpha value) (--delta) <args>...
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m-a[39m [97m --alpha[39m            [03malpha flag brief[23m
+  [90m[39m   [90m --bravo...[39m         [90mbravo flag brief[39m
+  [90m[39m   [90m[--charlie][39m         [90mcharlie flag brief[39m
+  [97m-d[39m [97m --delta/--noDelta[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
+
+[1mARGUMENTS[22m
+  [97margs...[39m  [3mstring array brief[23m
+
+:::: Command / printHelp / mixed parameters, full description / no ANSI color
 USAGE
   prefix (--alpha value) (--bravo value)... [--charlie c] (--delta) <args>...
   prefix --help
@@ -320,7 +577,24 @@ FLAGS
 ARGUMENTS
   args...  string array brief
 
-:::: Command / printHelp / mixed parameters, full description, only required in usage line
+:::: Command / printHelp / mixed parameters, full description / with ANSI color
+[1mUSAGE[22m
+  prefix (--alpha value) (--bravo value)... [--charlie c] (--delta) <args>...
+  prefix --help
+
+Longer description of this command's behavior, only printed during --help
+
+[1mFLAGS[22m
+  [97m-a[39m [97m --alpha[39m            [03malpha flag brief[23m
+  [97m[39m   [97m --bravo...[39m         [03mbravo flag brief[23m
+  [97m[39m   [97m[--charlie][39m         [03mcharlie flag brief[23m
+  [97m-d[39m [97m --delta/--noDelta[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
+
+[1mARGUMENTS[22m
+  [97margs...[39m  [3mstring array brief[23m
+
+:::: Command / printHelp / mixed parameters, full description, only required in usage line / no ANSI color
 USAGE
   prefix (--alpha value) (--bravo value)... (--delta) <args>...
   prefix --help
@@ -337,7 +611,24 @@ FLAGS
 ARGUMENTS
   args...  string array brief
 
-:::: Command / printHelp / mixed parameters, help all, force alias in usage line
+:::: Command / printHelp / mixed parameters, full description, only required in usage line / with ANSI color
+[1mUSAGE[22m
+  prefix (--alpha value) (--bravo value)... (--delta) <args>...
+  prefix --help
+
+Longer description of this command's behavior, only printed during --help
+
+[1mFLAGS[22m
+  [97m-a[39m [97m --alpha[39m            [03malpha flag brief[23m
+  [97m[39m   [97m --bravo...[39m         [03mbravo flag brief[23m
+  [97m[39m   [97m[--charlie][39m         [03mcharlie flag brief[23m
+  [97m-d[39m [97m --delta/--noDelta[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
+
+[1mARGUMENTS[22m
+  [97margs...[39m  [3mstring array brief[23m
+
+:::: Command / printHelp / mixed parameters, help all, force alias in usage line / no ANSI color
 USAGE
   prefix (-a value) (--bravo value)... [--charlie c] (-d) <args>...
   prefix -h
@@ -356,7 +647,26 @@ FLAGS
 ARGUMENTS
   args...  string array brief
 
-:::: Command / printHelp / mixed parameters, mixed custom usage
+:::: Command / printHelp / mixed parameters, help all, force alias in usage line / with ANSI color
+[1mUSAGE[22m
+  prefix (-a value) (--bravo value)... [--charlie c] (-d) <args>...
+  prefix -h
+  prefix -H
+
+brief
+
+[1mFLAGS[22m
+  [97m-a[39m [97m --alpha[39m            [03malpha flag brief[23m
+  [97m[39m   [97m --bravo...[39m         [03mbravo flag brief[23m
+  [97m[39m   [97m[--charlie][39m         [03mcharlie flag brief[23m
+  [97m-d[39m [97m --delta/--noDelta[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
+  [90m-H[39m [90m --helpAll[39m          [90mPrint help information (including hidden commands/flags) and exit[39m
+
+[1mARGUMENTS[22m
+  [97margs...[39m  [3mstring array brief[23m
+
+:::: Command / printHelp / mixed parameters, mixed custom usage / no ANSI color
 USAGE
   prefix -a 1
     enhanced usage line #1
@@ -380,7 +690,31 @@ FLAGS
 ARGUMENTS
   args...  string array brief
 
-:::: Command / printHelp / mixed parameters, only required in usage line
+:::: Command / printHelp / mixed parameters, mixed custom usage / with ANSI color
+[1mUSAGE[22m
+  prefix -a 1
+    [3menhanced usage line #1[23m
+  prefix normal custom usage A
+  prefix normal custom usage B
+  prefix -a 2 -d
+    [3menhanced usage line #2[23m
+  prefix normal custom usage C
+  prefix normal custom usage D
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m-a[39m [97m --alpha[39m            [03malpha flag brief[23m
+  [97m[39m   [97m --bravo...[39m         [03mbravo flag brief[23m
+  [97m[39m   [97m[--charlie][39m         [03mcharlie flag brief[23m
+  [97m-d[39m [97m --delta/--noDelta[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
+
+[1mARGUMENTS[22m
+  [97margs...[39m  [3mstring array brief[23m
+
+:::: Command / printHelp / mixed parameters, only required in usage line / no ANSI color
 USAGE
   prefix (--alpha value) (--bravo value)... (--delta) <arg1>
   prefix --help
@@ -398,7 +732,25 @@ ARGUMENTS
    arg1   first argument brief
   [arg2]  second argument brief
 
-:::: Command / printHelp / mixed parameters, skips hidden
+:::: Command / printHelp / mixed parameters, only required in usage line / with ANSI color
+[1mUSAGE[22m
+  prefix (--alpha value) (--bravo value)... (--delta) <arg1>
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m-a[39m [97m --alpha[39m            [03malpha flag brief[23m
+  [97m[39m   [97m --bravo...[39m         [03mbravo flag brief[23m
+  [97m[39m   [97m[--charlie][39m         [03mcharlie flag brief[23m
+  [97m-d[39m [97m --delta/--noDelta[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m --help[39m             [03mPrint help information and exit[23m
+
+[1mARGUMENTS[22m
+  [97m arg1[39m   [3mfirst argument brief[23m
+  [97m[arg2][39m  [3msecond argument brief[23m
+
+:::: Command / printHelp / mixed parameters, skips hidden / no ANSI color
 USAGE
   prefix (--alpha value) (--delta) <args>...
   prefix --help
@@ -413,7 +765,22 @@ FLAGS
 ARGUMENTS
   args...  string array brief
 
-:::: Command / printHelp / multiple boolean flags
+:::: Command / printHelp / mixed parameters, skips hidden / with ANSI color
+[1mUSAGE[22m
+  prefix (--alpha value) (--delta) <args>...
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m-a[39m [97m--alpha[39m            [03malpha flag brief[23m
+  [97m-d[39m [97m--delta/--noDelta[39m  [03mdelta flag brief[23m
+  [97m-h[39m [97m--help[39m             [03mPrint help information and exit[23m
+
+[1mARGUMENTS[22m
+  [97margs...[39m  [3mstring array brief[23m
+
+:::: Command / printHelp / multiple boolean flags / no ANSI color
 USAGE
   prefix (--alpha) [--bravo] (--charlie)
   prefix --help
@@ -426,7 +793,20 @@ FLAGS
   -c  --charlie/--noCharlie  charlie flag brief
   -h  --help                 Print help information and exit
 
-:::: Command / printHelp / multiple boolean flags, kebab-case
+:::: Command / printHelp / multiple boolean flags / with ANSI color
+[1mUSAGE[22m
+  prefix (--alpha) [--bravo] (--charlie)
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m[39m   [97m --alpha/--noAlpha[39m      [03malpha flag brief[23m
+  [97m[39m   [97m[--bravo/--noBravo][39m     [03mbravo flag brief[23m
+  [97m-c[39m [97m --charlie/--noCharlie[39m  [03mcharlie flag brief[23m
+  [97m-h[39m [97m --help[39m                 [03mPrint help information and exit[23m
+
+:::: Command / printHelp / multiple boolean flags, kebab-case / no ANSI color
 USAGE
   prefix (--alpha) [--bravo] (--charlie)
   prefix --help
@@ -439,7 +819,20 @@ FLAGS
   -c  --charlie/--no-charlie  charlie flag brief
   -h  --help                  Print help information and exit
 
-:::: Command / printHelp / multiple boolean flags, kebab-case, only required in usage line
+:::: Command / printHelp / multiple boolean flags, kebab-case / with ANSI color
+[1mUSAGE[22m
+  prefix (--alpha) [--bravo] (--charlie)
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m[39m   [97m --alpha/--no-alpha[39m      [03malpha flag brief[23m
+  [97m[39m   [97m[--bravo/--no-bravo][39m     [03mbravo flag brief[23m
+  [97m-c[39m [97m --charlie/--no-charlie[39m  [03mcharlie flag brief[23m
+  [97m-h[39m [97m --help[39m                  [03mPrint help information and exit[23m
+
+:::: Command / printHelp / multiple boolean flags, kebab-case, only required in usage line / no ANSI color
 USAGE
   prefix (--alpha) (--charlie)
   prefix --help
@@ -452,7 +845,20 @@ FLAGS
   -c  --charlie/--no-charlie  charlie flag brief
   -h  --help                  Print help information and exit
 
-:::: Command / printHelp / multiple boolean flags, only required in usage line
+:::: Command / printHelp / multiple boolean flags, kebab-case, only required in usage line / with ANSI color
+[1mUSAGE[22m
+  prefix (--alpha) (--charlie)
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m[39m   [97m --alpha/--no-alpha[39m      [03malpha flag brief[23m
+  [97m[39m   [97m[--bravo/--no-bravo][39m     [03mbravo flag brief[23m
+  [97m-c[39m [97m --charlie/--no-charlie[39m  [03mcharlie flag brief[23m
+  [97m-h[39m [97m --help[39m                  [03mPrint help information and exit[23m
+
+:::: Command / printHelp / multiple boolean flags, only required in usage line / no ANSI color
 USAGE
   prefix (--alpha) (--charlie)
   prefix --help
@@ -465,7 +871,20 @@ FLAGS
   -c  --charlie/--noCharlie  charlie flag brief
   -h  --help                 Print help information and exit
 
-:::: Command / printHelp / no parameters
+:::: Command / printHelp / multiple boolean flags, only required in usage line / with ANSI color
+[1mUSAGE[22m
+  prefix (--alpha) (--charlie)
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m[39m   [97m --alpha/--noAlpha[39m      [03malpha flag brief[23m
+  [97m[39m   [97m[--bravo/--noBravo][39m     [03mbravo flag brief[23m
+  [97m-c[39m [97m --charlie/--noCharlie[39m  [03mcharlie flag brief[23m
+  [97m-h[39m [97m --help[39m                 [03mPrint help information and exit[23m
+
+:::: Command / printHelp / no parameters / no ANSI color
 USAGE
   prefix
   prefix --help
@@ -475,7 +894,17 @@ brief
 FLAGS
   -h --help  Print help information and exit
 
-:::: Command / printHelp / no parameters, dropped empty flag spec
+:::: Command / printHelp / no parameters / with ANSI color
+[1mUSAGE[22m
+  prefix
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m-h[39m [97m--help[39m  [03mPrint help information and exit[23m
+
+:::: Command / printHelp / no parameters, dropped empty flag spec / no ANSI color
 USAGE
   prefix
   prefix --help
@@ -485,7 +914,17 @@ brief
 FLAGS
   -h --help  Print help information and exit
 
-:::: Command / printHelp / no parameters, dropped empty positional spec
+:::: Command / printHelp / no parameters, dropped empty flag spec / with ANSI color
+[1mUSAGE[22m
+  prefix
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m-h[39m [97m--help[39m  [03mPrint help information and exit[23m
+
+:::: Command / printHelp / no parameters, dropped empty positional spec / no ANSI color
 USAGE
   prefix
   prefix --help
@@ -495,7 +934,17 @@ brief
 FLAGS
   -h --help  Print help information and exit
 
-:::: Command / printHelp / no parameters, dropped empty specs
+:::: Command / printHelp / no parameters, dropped empty positional spec / with ANSI color
+[1mUSAGE[22m
+  prefix
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m-h[39m [97m--help[39m  [03mPrint help information and exit[23m
+
+:::: Command / printHelp / no parameters, dropped empty specs / no ANSI color
 USAGE
   prefix
   prefix --help
@@ -505,7 +954,17 @@ brief
 FLAGS
   -h --help  Print help information and exit
 
-:::: Command / printHelp / no parameters, help all, force alias in usage line
+:::: Command / printHelp / no parameters, dropped empty specs / with ANSI color
+[1mUSAGE[22m
+  prefix
+  prefix --help
+
+brief
+
+[1mFLAGS[22m
+  [97m-h[39m [97m--help[39m  [03mPrint help information and exit[23m
+
+:::: Command / printHelp / no parameters, help all, force alias in usage line / no ANSI color
 USAGE
   prefix
   prefix -h
@@ -516,6 +975,18 @@ brief
 FLAGS
   -h --help     Print help information and exit
   -H --helpAll  Print help information (including hidden commands/flags) and exit
+
+:::: Command / printHelp / no parameters, help all, force alias in usage line / with ANSI color
+[1mUSAGE[22m
+  prefix
+  prefix -h
+  prefix -H
+
+brief
+
+[1mFLAGS[22m
+  [97m-h[39m [97m--help[39m     [03mPrint help information and exit[23m
+  [90m-H[39m [90m--helpAll[39m  [90mPrint help information (including hidden commands/flags) and exit[39m
 
 :::: Command / run / command function returns error / with custom exit code
 ExitCode=Unknown(10)

--- a/packages/core/tests/baselines/reference/routing/route-map.txt
+++ b/packages/core/tests/baselines/reference/routing/route-map.txt
@@ -1,4 +1,4 @@
-:::: RouteMap / printHelp / aliased nested route map with aliases
+:::: RouteMap / printHelp / aliased nested route map with aliases / no ANSI color
 USAGE
   cli alias1 doNothing
   cli alias1 sub doNothing1|doNothing2 ...
@@ -19,7 +19,28 @@ COMMANDS
   doNothing  top command brief
   sub        sub route map brief
 
-:::: RouteMap / printHelp / nested route map
+:::: RouteMap / printHelp / aliased nested route map with aliases / with ANSI color
+[1mUSAGE[22m
+  cli alias1 doNothing
+  cli alias1 sub doNothing1|doNothing2 ...
+  cli alias1 --help
+  cli alias1 --version
+
+route map brief
+
+[1mALIASES[22m
+  cli route
+  cli alias2
+
+[1mFLAGS[22m
+  [97m-h[39m [97m--help[39m     [03mPrint help information and exit[23m
+  [97m-v[39m [97m--version[39m  [03mPrint version information and exit[23m
+
+[1mCOMMANDS[22m
+  [97mdoNothing[39m  [03mtop command brief[23m
+  [97msub[39m        [03msub route map brief[23m
+
+:::: RouteMap / printHelp / nested route map / no ANSI color
 USAGE
   prefix doNothing
   prefix sub doNothing1|doNothing2 ...
@@ -34,7 +55,22 @@ COMMANDS
   doNothing  top command brief
   sub        sub route map brief
 
-:::: RouteMap / printHelp / nested route map force include hidden routes
+:::: RouteMap / printHelp / nested route map / with ANSI color
+[1mUSAGE[22m
+  prefix doNothing
+  prefix sub doNothing1|doNothing2 ...
+  prefix --help
+
+route map brief
+
+[1mFLAGS[22m
+  [97m-h[39m [97m--help[39m  [03mPrint help information and exit[23m
+
+[1mCOMMANDS[22m
+  [97mdoNothing[39m  [03mtop command brief[23m
+  [97msub[39m        [03msub route map brief[23m
+
+:::: RouteMap / printHelp / nested route map force include hidden routes / no ANSI color
 USAGE
   prefix doNothing
   prefix sub doNothing1|doNothing2 ...
@@ -51,7 +87,24 @@ COMMANDS
   doNothing  top command brief
   sub        sub route map brief
 
-:::: RouteMap / printHelp / nested route map with `convert-camel-to-kebab` display case style
+:::: RouteMap / printHelp / nested route map force include hidden routes / with ANSI color
+[1mUSAGE[22m
+  prefix doNothing
+  prefix sub doNothing1|doNothing2 ...
+  prefix --help
+  prefix --version
+
+route map brief
+
+[1mFLAGS[22m
+  [97m-h[39m [97m--help[39m     [03mPrint help information and exit[23m
+  [97m-v[39m [97m--version[39m  [03mPrint version information and exit[23m
+
+[1mCOMMANDS[22m
+  [97mdoNothing[39m  [03mtop command brief[23m
+  [90msub[39m        [90msub route map brief[39m
+
+:::: RouteMap / printHelp / nested route map with `convert-camel-to-kebab` display case style / no ANSI color
 USAGE
   prefix do-nothing
   prefix sub do-nothing1|do-nothing2 ...
@@ -68,7 +121,24 @@ COMMANDS
   do-nothing  top command brief
   sub         sub route map brief
 
-:::: RouteMap / printHelp / nested route map with aliases
+:::: RouteMap / printHelp / nested route map with `convert-camel-to-kebab` display case style / with ANSI color
+[1mUSAGE[22m
+  prefix do-nothing
+  prefix sub do-nothing1|do-nothing2 ...
+  prefix --help
+  prefix --version
+
+Longer description of this route map's behavior, only printed during --help
+
+[1mFLAGS[22m
+  [97m-h[39m [97m--help[39m     [03mPrint help information and exit[23m
+  [97m-v[39m [97m--version[39m  [03mPrint version information and exit[23m
+
+[1mCOMMANDS[22m
+  [97mdo-nothing[39m  [03mtop command brief[23m
+  [97msub[39m         [03msub route map brief[23m
+
+:::: RouteMap / printHelp / nested route map with aliases / no ANSI color
 USAGE
   cli route doNothing
   cli route sub doNothing1|doNothing2 ...
@@ -89,7 +159,7 @@ COMMANDS
   doNothing  top command brief
   sub        sub route map brief
 
-:::: RouteMap / printHelp / nested route map with aliases, ansi color
+:::: RouteMap / printHelp / nested route map with aliases / with ANSI color
 [1mUSAGE[22m
   cli route doNothing
   cli route sub doNothing1|doNothing2 ...
@@ -110,7 +180,7 @@ route map brief
   [97mdoNothing[39m  [03mtop command brief[23m
   [97msub[39m        [03msub route map brief[23m
 
-:::: RouteMap / printHelp / nested route map with hidden routes
+:::: RouteMap / printHelp / nested route map with hidden routes / no ANSI color
 USAGE
   prefix doNothing
   prefix --help
@@ -125,7 +195,22 @@ FLAGS
 COMMANDS
   doNothing  top command brief
 
-:::: RouteMap / printHelp / nested route map with version available
+:::: RouteMap / printHelp / nested route map with hidden routes / with ANSI color
+[1mUSAGE[22m
+  prefix doNothing
+  prefix --help
+  prefix --version
+
+route map brief
+
+[1mFLAGS[22m
+  [97m-h[39m [97m--help[39m     [03mPrint help information and exit[23m
+  [97m-v[39m [97m--version[39m  [03mPrint version information and exit[23m
+
+[1mCOMMANDS[22m
+  [97mdoNothing[39m  [03mtop command brief[23m
+
+:::: RouteMap / printHelp / nested route map with version available / no ANSI color
 USAGE
   prefix doNothing
   prefix sub doNothing1|doNothing2 ...
@@ -142,7 +227,24 @@ COMMANDS
   doNothing  top command brief
   sub        sub route map brief
 
-:::: RouteMap / printHelp / nested route maps with custom header text
+:::: RouteMap / printHelp / nested route map with version available / with ANSI color
+[1mUSAGE[22m
+  prefix doNothing
+  prefix sub doNothing1|doNothing2 ...
+  prefix --help
+  prefix --version
+
+Longer description of this route map's behavior, only printed during --help
+
+[1mFLAGS[22m
+  [97m-h[39m [97m--help[39m     [03mPrint help information and exit[23m
+  [97m-v[39m [97m--version[39m  [03mPrint version information and exit[23m
+
+[1mCOMMANDS[22m
+  [97mdoNothing[39m  [03mtop command brief[23m
+  [97msub[39m        [03msub route map brief[23m
+
+:::: RouteMap / printHelp / nested route maps with custom header text / no ANSI color
 Usage:
   cli route doNothing
   cli route sub doNothing1|doNothing2 ...
@@ -162,3 +264,24 @@ Flags:
 Commands:
   doNothing  top command brief
   sub        sub route map brief
+
+:::: RouteMap / printHelp / nested route maps with custom header text / with ANSI color
+[1mUsage:[22m
+  cli route doNothing
+  cli route sub doNothing1|doNothing2 ...
+  cli route --help
+  cli route --version
+
+route map brief
+
+[1mAliases:[22m
+  cli alias1
+  cli alias2
+
+[1mFlags:[22m
+  [97m-h[39m [97m--help[39m     [03mPrint help information and exit[23m
+  [97m-v[39m [97m--version[39m  [03mPrint version information and exit[23m
+
+[1mCommands:[22m
+  [97mdoNothing[39m  [03mtop command brief[23m
+  [97msub[39m        [03msub route map brief[23m

--- a/packages/core/tests/routing/command.spec.ts
+++ b/packages/core/tests/routing/command.spec.ts
@@ -91,6 +91,46 @@ const CommandRunResultBaselineFormat: BaselineFormat<CommandRunResult> = {
     },
 };
 
+function compareHelpTextToBaseline(command: Command<CommandContext>, args: Omit<HelpFormattingArguments, "ansiColor">) {
+    it("with ANSI color", function () {
+        // WHEN
+        const helpText = command.formatHelp({
+            ...args,
+            ansiColor: true,
+        });
+
+        // THEN
+        compareToBaseline(this, StringArrayBaselineFormat, helpText.split("\n"));
+    });
+
+    it("no ANSI color", function () {
+        // WHEN
+        const helpText = command.formatHelp({
+            ...args,
+            ansiColor: false,
+        });
+
+        // THEN
+        compareToBaseline(this, StringArrayBaselineFormat, helpText.split("\n"));
+    });
+
+    it("text with ANSI matches text without ANSI", function () {
+        // WHEN
+        const helpTextWithAnsiColor = command.formatHelp({
+            ...args,
+            ansiColor: true,
+        });
+        const helpTextWithAnsiColorStrippedOut = helpTextWithAnsiColor.replace(/\x1B\[[0-9;]*m/g, "");
+        const helpTextWithoutAnsiColor = command.formatHelp({
+            ...args,
+            ansiColor: false,
+        });
+
+        // THEN
+        expect(helpTextWithAnsiColorStrippedOut).to.deep.equal(helpTextWithoutAnsiColor);
+    });
+}
+
 describe("Command", function () {
     describe("buildCommand", function () {
         it("fails with reserved flag --help", function () {
@@ -293,7 +333,7 @@ describe("Command", function () {
             ansiColor: false,
         };
 
-        it("no parameters", function () {
+        describe("no parameters", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -311,14 +351,10 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp(defaultArgs);
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
+            compareHelpTextToBaseline(command, defaultArgs);
         });
 
-        it("no parameters, dropped empty flag spec", function () {
+        describe("no parameters, dropped empty flag spec", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -335,14 +371,10 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp(defaultArgs);
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
+            compareHelpTextToBaseline(command, defaultArgs);
         });
 
-        it("no parameters, dropped empty positional spec", function () {
+        describe("no parameters, dropped empty positional spec", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -354,14 +386,10 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp(defaultArgs);
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
+            compareHelpTextToBaseline(command, defaultArgs);
         });
 
-        it("no parameters, dropped empty specs", function () {
+        describe("no parameters, dropped empty specs", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -373,14 +401,10 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp(defaultArgs);
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
+            compareHelpTextToBaseline(command, defaultArgs);
         });
 
-        it("no parameters, help all, force alias in usage line", function () {
+        describe("no parameters, help all, force alias in usage line", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -392,8 +416,7 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp({
+            compareHelpTextToBaseline(command, {
                 ...defaultArgs,
                 includeHelpAllFlag: true,
                 config: {
@@ -401,12 +424,9 @@ describe("Command", function () {
                     useAliasInUsageLine: true,
                 },
             });
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
         });
 
-        it("mixed parameters", function () {
+        describe("mixed parameters", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -465,14 +485,10 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp(defaultArgs);
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
+            compareHelpTextToBaseline(command, defaultArgs);
         });
 
-        it("mixed parameters, only required in usage line", function () {
+        describe("mixed parameters, only required in usage line", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -531,20 +547,16 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp({
+            compareHelpTextToBaseline(command, {
                 ...defaultArgs,
                 config: {
                     ...defaultArgs.config,
                     onlyRequiredInUsageLine: true,
                 },
             });
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
         });
 
-        it("mixed parameters with version available", function () {
+        describe("mixed parameters with version available", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -603,14 +615,10 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp({ ...defaultArgs, includeVersionFlag: true });
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
+            compareHelpTextToBaseline(command, { ...defaultArgs, includeVersionFlag: true });
         });
 
-        it("mixed parameters with version available, only required in usage line", function () {
+        describe("mixed parameters with version available, only required in usage line", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -669,8 +677,7 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp({
+            compareHelpTextToBaseline(command, {
                 ...defaultArgs,
                 includeVersionFlag: true,
                 config: {
@@ -678,12 +685,9 @@ describe("Command", function () {
                     onlyRequiredInUsageLine: true,
                 },
             });
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
         });
 
-        it("mixed parameters with aliases", function () {
+        describe("mixed parameters with aliases", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -742,19 +746,15 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp({
+            compareHelpTextToBaseline(command, {
                 ...defaultArgs,
                 prefix: ["cli", "route"],
                 includeVersionFlag: true,
                 aliases: ["alias1", "alias2"],
             });
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
         });
 
-        it("mixed parameters with aliases, ansi color", function () {
+        describe("mixed parameters with aliases, only required in usage line", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -813,80 +813,7 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp({
-                ...defaultArgs,
-                ansiColor: true,
-                prefix: ["cli", "route"],
-                includeVersionFlag: true,
-                aliases: ["alias1", "alias2"],
-            });
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
-        });
-
-        it("mixed parameters with aliases, only required in usage line", function () {
-            // GIVEN
-            const command = buildCommand({
-                loader: async () => {
-                    return {
-                        default: (
-                            flags: { alpha: number; bravo: number[]; charlie?: number; delta: boolean },
-                            arg0: string,
-                            arg1?: number,
-                        ) => {},
-                    };
-                },
-                parameters: {
-                    positional: {
-                        kind: "tuple",
-                        parameters: [
-                            {
-                                brief: "first argument brief",
-                                parse: (x) => x,
-                            },
-                            {
-                                brief: "second argument brief",
-                                optional: true,
-                                parse: numberParser,
-                            },
-                        ],
-                    },
-                    flags: {
-                        alpha: {
-                            brief: "alpha flag brief",
-                            kind: "parsed",
-                            parse: numberParser,
-                        },
-                        bravo: {
-                            brief: "bravo flag brief",
-                            kind: "parsed",
-                            variadic: true,
-                            parse: numberParser,
-                        },
-                        charlie: {
-                            brief: "charlie flag brief",
-                            placeholder: "c",
-                            kind: "parsed",
-                            optional: true,
-                            parse: numberParser,
-                        },
-                        delta: {
-                            brief: "delta flag brief",
-                            kind: "boolean",
-                        },
-                    },
-                    aliases: {
-                        a: "alpha",
-                        d: "delta",
-                    },
-                },
-                docs: { brief: "brief" },
-            });
-
-            // WHEN
-            const helpString = command.formatHelp({
+            compareHelpTextToBaseline(command, {
                 ...defaultArgs,
                 prefix: ["cli", "route"],
                 includeVersionFlag: true,
@@ -896,12 +823,9 @@ describe("Command", function () {
                     onlyRequiredInUsageLine: true,
                 },
             });
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
         });
 
-        it("multiple boolean flags", function () {
+        describe("multiple boolean flags", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -936,14 +860,10 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp(defaultArgs);
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
+            compareHelpTextToBaseline(command, defaultArgs);
         });
 
-        it("multiple boolean flags, only required in usage line", function () {
+        describe("multiple boolean flags, only required in usage line", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -978,20 +898,16 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp({
+            compareHelpTextToBaseline(command, {
                 ...defaultArgs,
                 config: {
                     ...defaultArgs.config,
                     onlyRequiredInUsageLine: true,
                 },
             });
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
         });
 
-        it("multiple boolean flags, kebab-case", function () {
+        describe("multiple boolean flags, kebab-case", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -1026,20 +942,16 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp({
+            compareHelpTextToBaseline(command, {
                 ...defaultArgs,
                 config: {
                     ...defaultArgs.config,
                     caseStyle: "convert-camel-to-kebab",
                 },
             });
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
         });
 
-        it("multiple boolean flags, kebab-case, only required in usage line", function () {
+        describe("multiple boolean flags, kebab-case, only required in usage line", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -1074,8 +986,7 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp({
+            compareHelpTextToBaseline(command, {
                 ...defaultArgs,
                 config: {
                     ...defaultArgs.config,
@@ -1083,12 +994,9 @@ describe("Command", function () {
                     onlyRequiredInUsageLine: true,
                 },
             });
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
         });
 
-        it("mixed parameters, full description", function () {
+        describe("mixed parameters, full description", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -1142,14 +1050,10 @@ describe("Command", function () {
                 },
             });
 
-            // WHEN
-            const helpString = command.formatHelp(defaultArgs);
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
+            compareHelpTextToBaseline(command, defaultArgs);
         });
 
-        it("mixed parameters, full description, only required in usage line", function () {
+        describe("mixed parameters, full description, only required in usage line", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -1203,20 +1107,16 @@ describe("Command", function () {
                 },
             });
 
-            // WHEN
-            const helpString = command.formatHelp({
+            compareHelpTextToBaseline(command, {
                 ...defaultArgs,
                 config: {
                     ...defaultArgs.config,
                     onlyRequiredInUsageLine: true,
                 },
             });
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
         });
 
-        it("mixed parameters, custom usage", function () {
+        describe("mixed parameters, custom usage", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -1270,14 +1170,10 @@ describe("Command", function () {
                 },
             });
 
-            // WHEN
-            const helpString = command.formatHelp(defaultArgs);
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
+            compareHelpTextToBaseline(command, defaultArgs);
         });
 
-        it("mixed parameters, enhanced custom usage", function () {
+        describe("mixed parameters, enhanced custom usage", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -1340,14 +1236,10 @@ describe("Command", function () {
                 },
             });
 
-            // WHEN
-            const helpString = command.formatHelp(defaultArgs);
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
+            compareHelpTextToBaseline(command, defaultArgs);
         });
 
-        it("mixed parameters, mixed custom usage", function () {
+        describe("mixed parameters, mixed custom usage", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -1414,14 +1306,10 @@ describe("Command", function () {
                 },
             });
 
-            // WHEN
-            const helpString = command.formatHelp(defaultArgs);
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
+            compareHelpTextToBaseline(command, defaultArgs);
         });
 
-        it("mixed parameters with `original` display case style", function () {
+        describe("mixed parameters with `original` display case style", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -1480,14 +1368,10 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp(defaultArgs);
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
+            compareHelpTextToBaseline(command, defaultArgs);
         });
 
-        it("mixed parameters with `original` display case style, only required in usage line", function () {
+        describe("mixed parameters with `original` display case style, only required in usage line", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -1546,20 +1430,16 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp({
+            compareHelpTextToBaseline(command, {
                 ...defaultArgs,
                 config: {
                     ...defaultArgs.config,
                     onlyRequiredInUsageLine: true,
                 },
             });
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
         });
 
-        it("mixed parameters with `convert-camel-to-kebab` display case style", function () {
+        describe("mixed parameters with `convert-camel-to-kebab` display case style", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -1618,20 +1498,16 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp({
+            compareHelpTextToBaseline(command, {
                 ...defaultArgs,
                 config: {
                     ...defaultArgs.config,
                     caseStyle: "convert-camel-to-kebab",
                 },
             });
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
         });
 
-        it("mixed parameters with `convert-camel-to-kebab` display case style, only required in usage line", function () {
+        describe("mixed parameters with `convert-camel-to-kebab` display case style, only required in usage line", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -1690,8 +1566,7 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp({
+            compareHelpTextToBaseline(command, {
                 ...defaultArgs,
                 config: {
                     ...defaultArgs.config,
@@ -1699,12 +1574,9 @@ describe("Command", function () {
                     onlyRequiredInUsageLine: true,
                 },
             });
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
         });
 
-        it("mixed parameters with custom headers", function () {
+        describe("mixed parameters with custom headers", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -1763,8 +1635,7 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp({
+            compareHelpTextToBaseline(command, {
                 ...defaultArgs,
                 prefix: ["cli", "route"],
                 includeVersionFlag: true,
@@ -1780,12 +1651,9 @@ describe("Command", function () {
                     },
                 },
             });
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
         });
 
-        it("mixed parameters with custom headers, only required in usage line", function () {
+        describe("mixed parameters with custom headers, only required in usage line", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -1844,8 +1712,7 @@ describe("Command", function () {
                 docs: { brief: "brief" },
             });
 
-            // WHEN
-            const helpString = command.formatHelp({
+            compareHelpTextToBaseline(command, {
                 ...defaultArgs,
                 prefix: ["cli", "route"],
                 includeVersionFlag: true,
@@ -1865,12 +1732,9 @@ describe("Command", function () {
                     onlyRequiredInUsageLine: true,
                 },
             });
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
         });
 
-        it("mixed parameters, skips hidden", function () {
+        describe("mixed parameters, skips hidden", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -1925,14 +1789,10 @@ describe("Command", function () {
                 },
             });
 
-            // WHEN
-            const helpString = command.formatHelp(defaultArgs);
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
+            compareHelpTextToBaseline(command, defaultArgs);
         });
 
-        it("mixed parameters, force include hidden", function () {
+        describe("mixed parameters, force include hidden", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -1987,17 +1847,13 @@ describe("Command", function () {
                 },
             });
 
-            // WHEN
-            const helpString = command.formatHelp({
+            compareHelpTextToBaseline(command, {
                 ...defaultArgs,
                 includeHidden: true,
             });
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
         });
 
-        it("mixed parameters, help all, force alias in usage line", function () {
+        describe("mixed parameters, help all, force alias in usage line", function () {
             // GIVEN
             const command = buildCommand({
                 loader: async () => {
@@ -2050,8 +1906,7 @@ describe("Command", function () {
                 },
             });
 
-            // WHEN
-            const helpString = command.formatHelp({
+            compareHelpTextToBaseline(command, {
                 ...defaultArgs,
                 includeHelpAllFlag: true,
                 config: {
@@ -2059,9 +1914,6 @@ describe("Command", function () {
                     useAliasInUsageLine: true,
                 },
             });
-
-            // THEN
-            compareToBaseline(this, StringArrayBaselineFormat, helpString.split("\n"));
         });
     });
 


### PR DESCRIPTION
**Describe your changes**
We have baseline tests for the formatting of certain outputs. These outputs can be formatted with or without ANSI colors/styling. Previously, the tests had to pick whether to turn ANSI colors on or off and then could only test that one setting. To test all cases, the test suite now invokes each formatting function twice, once with ANSI and once without ANSI. These are saved as two separate baselines (and also compared to each other, so that the version without ANSI is the same as the one with ANSI if all of the ANSI-specific characters are stripped out).

This also improves the readability of the baselines that were previously ANSI-only.

**Testing performed**
These are changes to the test suite only.
