### PR TITLE
chore: remove old workaround in the constraint of `buildCommand`'s `FLAGS`

### DIFF
--- a/packages/core/src/routing/command/builder.ts
+++ b/packages/core/src/routing/command/builder.ts
@@ -95,10 +95,7 @@ function checkForInvalidVariadicSeparators(flags: Record<string, FlagParameter<C
  * Build command from loader or local function as action with associated parameters and documentation.
  */
 export function buildCommand<
-    // Normally FLAGS would extend BaseFlags, but when it does there are some unexpected and confusing failures with the
-    // type inference for this function. Check out tests/type-inference.spec.ts for examples where this fails.
-    // Thanks to @dragomirtitian for concocting this fix.
-    const FLAGS extends Readonly<Partial<Record<keyof FLAGS, unknown>>>,
+    const FLAGS extends BaseFlags,
     const ARGS extends BaseArgs,
     const CONTEXT extends CommandContext = CommandContext,
 >(builderArgs: CommandBuilderArguments<FLAGS, ARGS, CONTEXT>): Command<CONTEXT> {


### PR DESCRIPTION
This comment caught my attention. I couldn't repro the mentioned problem though. That leads me to believe it's no longer relevant.