### PR TITLE
fix: expose additional types for command module

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,22 +34,23 @@ export type { FlagParametersForType, TypedFlagParameter } from "./parameter/flag
 export { booleanParser, looseBooleanParser } from "./parameter/parser/boolean";
 export { buildChoiceParser } from "./parameter/parser/choice";
 export { numberParser } from "./parameter/parser/number";
-export type { TypedPositionalParameter, TypedPositionalParameters } from "./parameter/positional/types";
+export type { BaseArgs, TypedPositionalParameter, TypedPositionalParameters } from "./parameter/positional/types";
 export {
     AliasNotFoundError,
     ArgumentParseError,
     ArgumentScannerError,
     EnumValidationError,
     FlagNotFoundError,
+    formatMessageForArgumentScannerError,
     InvalidNegatedFlagSyntaxError,
     UnexpectedFlagError,
     UnexpectedPositionalError,
     UnsatisfiedFlagError,
     UnsatisfiedPositionalError,
-    formatMessageForArgumentScannerError,
 } from "./parameter/scanner";
 export type {
     Aliases,
+    BaseFlags,
     InputParser,
     TypedCommandFlagParameters,
     TypedCommandParameters,
@@ -57,7 +58,7 @@ export type {
 } from "./parameter/types";
 export { buildCommand } from "./routing/command/builder";
 export type { CommandBuilderArguments } from "./routing/command/builder";
-export type { Command } from "./routing/command/types";
+export type { Command, CommandFunction, CommandFunctionLoader, CommandModule } from "./routing/command/types";
 export { buildRouteMap } from "./routing/route-map/builder";
 export type { RouteMapBuilderArguments } from "./routing/route-map/builder";
 export type { RouteMap } from "./routing/route-map/types";

--- a/packages/core/src/parameter/positional/types.ts
+++ b/packages/core/src/parameter/positional/types.ts
@@ -60,6 +60,10 @@ interface PositionalParameterTuple<T> {
     readonly parameters: T;
 }
 
+/**
+ * Root constraint for all positional argument type parameters.
+ * This is used to ensure that positional parameters are always defined as an array or tuple.
+ */
 export type BaseArgs = readonly unknown[];
 
 /**

--- a/packages/core/src/parameter/types.ts
+++ b/packages/core/src/parameter/types.ts
@@ -59,6 +59,9 @@ export type AvailableAlias = Exclude<LowercaseLetter | UppercaseLetter, Reserved
 
 export type Aliases<T> = Readonly<Partial<Record<AvailableAlias, T>>>;
 
+/**
+ * Root constraint for all flag type parameters.
+ */
 export type BaseFlags = Readonly<Record<string, unknown>>;
 
 interface TypedCommandFlagParameters_<FLAGS extends BaseFlags, CONTEXT extends CommandContext> {


### PR DESCRIPTION
**Describe your changes**
These types can be useful when constructing commands piecemeal and there is a case to separately define `CommandModule` or one of the related types.
