### PR TITLE
chore(release): 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.2 (2025-10-14)
+
+This was a version bump only, there were no code changes.
+
 ## 1.2.1 (2025-10-13)
 
 ### 🩹 Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -23344,10 +23344,10 @@
         },
         "packages/auto-complete": {
             "name": "@stricli/auto-complete",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "license": "Apache-2.0",
             "dependencies": {
-                "@stricli/core": "^1.2.1"
+                "@stricli/core": "^1.2.2"
             },
             "bin": {
                 "auto-complete": "dist/bin/cli.js"
@@ -23365,7 +23365,7 @@
         },
         "packages/core": {
             "name": "@stricli/core",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/chai": "^4.3.11",
@@ -24173,11 +24173,11 @@
         },
         "packages/create-app": {
             "name": "@stricli/create-app",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "license": "Apache-2.0",
             "dependencies": {
-                "@stricli/auto-complete": "^1.2.1",
-                "@stricli/core": "^1.2.1"
+                "@stricli/auto-complete": "^1.2.2",
+                "@stricli/core": "^1.2.2"
             },
             "bin": {
                 "create-app": "dist/cli.js"

--- a/packages/auto-complete/package.json
+++ b/packages/auto-complete/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stricli/auto-complete",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Common utilities for enhancing Stricli applications with autocomplete",
     "license": "Apache-2.0",
     "repository": {
@@ -52,6 +52,6 @@
         "typescript": "5.6.x"
     },
     "dependencies": {
-        "@stricli/core": "^1.2.1"
+        "@stricli/core": "^1.2.2"
     }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stricli/core",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Build complex CLIs with type safety and no dependencies",
     "license": "Apache-2.0",
     "repository": {

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stricli/create-app",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Generate a new Stricli application",
     "license": "Apache-2.0",
     "repository": {
@@ -56,8 +56,8 @@
         "minify": true
     },
     "dependencies": {
-        "@stricli/auto-complete": "^1.2.1",
-        "@stricli/core": "^1.2.1"
+        "@stricli/auto-complete": "^1.2.2",
+        "@stricli/core": "^1.2.2"
     },
     "devDependencies": {
         "@types/chai": "^4.3.16",


### PR DESCRIPTION
**Describe your changes**
Ran `npx nx release patch --skip-publish` to bump version and generate changelog. New versions of packages will be published when this PR is merged to main.

This is the first release to exercise the changes from #100 