### PR TITLE
fix: run tsup with --silent to suppress unwanted stdout

### DIFF
--- a/packages/auto-complete/package.json
+++ b/packages/auto-complete/package.json
@@ -24,7 +24,7 @@
         "lint": "eslint src",
         "lint:fix": "eslint src --fix",
         "typecheck": "tsc -p tsconfig.json --noEmit",
-        "build": "tsup",
+        "build": "tsup --silent",
         "prepublishOnly": "npm run build"
     },
     "tsup": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
         "test:clear-baseline": "node scripts/clear_baseline",
         "test:accept-baseline": "node scripts/accept_baseline",
         "coverage": "c8 npm test",
-        "build": "tsup",
+        "build": "tsup --silent",
         "prepublishOnly": "npm run build"
     },
     "mocha": {

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -28,7 +28,7 @@
         "test:clear-baseline": "node scripts/clear_baseline",
         "test:accept-baseline": "node scripts/accept_baseline",
         "coverage": "c8 npm test",
-        "build": "tsup",
+        "build": "tsup --silent",
         "prepublishOnly": "npm run build"
     },
     "mocha": {

--- a/packages/create-app/src/impl.ts
+++ b/packages/create-app/src/impl.ts
@@ -60,7 +60,7 @@ function buildPackageJson(
         },
         scripts: {
             prebuild: "tsc -p src/tsconfig.json",
-            build: "tsup",
+            build: "tsup --silent",
             prepublishOnly: "npm run build",
         },
         tsup: {

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/node version logic/exact version exists for types.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/node version logic/exact version exists for types.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "node-version-test install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/node version logic/major version does not exist in registry, picks highest even major.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/node version logic/major version does not exist in registry, picks highest even major.txt
@@ -53,7 +53,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "node-version-test install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/node version logic/major version exists in registry.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/node version logic/major version exists in registry.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "node-version-test install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/node version logic/version discovery skipped when --node-version is provided.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/node version logic/version discovery skipped when --node-version is provided.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "node-version-test install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/no check for safe major version.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/no check for safe major version.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "node-version-test install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/reads registry direct from NPM_CONFIG_REGISTRY, URL ends with slash.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/reads registry direct from NPM_CONFIG_REGISTRY, URL ends with slash.txt
@@ -53,7 +53,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "node-version-test install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/reads registry direct from NPM_CONFIG_REGISTRY.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/reads registry direct from NPM_CONFIG_REGISTRY.txt
@@ -53,7 +53,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "node-version-test install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/registry data has no versions.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/registry data has no versions.txt
@@ -53,7 +53,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "node-version-test install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/unable to discover registry from process.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/unable to discover registry from process.txt
@@ -53,7 +53,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "node-version-test install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/uses NPM_EXECPATH to get registry config value.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/checks for @types__node/registry logic/uses NPM_EXECPATH to get registry config value.txt
@@ -53,7 +53,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "node-version-test install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/additional features/without auto-complete.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/additional features/without auto-complete.txt
@@ -51,7 +51,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build"
   },
   "tsup": {

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom bin command.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "test-cli install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom metadata.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom metadata.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "test install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom name and bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom name and bin command.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "test-cli install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom name.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/package properties/custom name.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "@org/test-cli install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/with default flags.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/commonjs/with default flags.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "test install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/additional features/without auto-complete.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/additional features/without auto-complete.txt
@@ -51,7 +51,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build"
   },
   "tsup": {

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom bin command.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "test-cli install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom metadata.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom metadata.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "test install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom name and bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom name and bin command.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "test-cli install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom name.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/package properties/custom name.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "@org/test-cli install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/with default flags.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/multi-command/module [default]/with default flags.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "test install"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/additional features/without auto-complete.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/additional features/without auto-complete.txt
@@ -51,7 +51,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build"
   },
   "tsup": {

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom bin command.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "npx @stricli/auto-complete@latest install test-cli --bash __test-cli_bash_complete"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom metadata.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom metadata.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "npx @stricli/auto-complete@latest install test --bash __test_bash_complete"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom name and bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom name and bin command.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "npx @stricli/auto-complete@latest install test-cli --bash __test-cli_bash_complete"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom name.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/package properties/custom name.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "npx @stricli/auto-complete@latest install @org/test-cli --bash __@org/test-cli_bash_complete"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/with default flags.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/commonjs/with default flags.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "npx @stricli/auto-complete@latest install test --bash __test_bash_complete"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/additional features/without auto-complete.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/additional features/without auto-complete.txt
@@ -51,7 +51,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build"
   },
   "tsup": {

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom bin command.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "npx @stricli/auto-complete@latest install test-cli --bash __test-cli_bash_complete"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom metadata.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom metadata.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "npx @stricli/auto-complete@latest install test --bash __test_bash_complete"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom name and bin command.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom name and bin command.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "npx @stricli/auto-complete@latest install test-cli --bash __test-cli_bash_complete"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom name.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/package properties/custom name.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "npx @stricli/auto-complete@latest install @org/test-cli --bash __@org/test-cli_bash_complete"
   },

--- a/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/with default flags.txt
+++ b/packages/create-app/tests/baselines/reference/app/creates new application/single-command/module [default]/with default flags.txt
@@ -52,7 +52,7 @@ dist
   },
   "scripts": {
     "prebuild": "tsc -p src/tsconfig.json",
-    "build": "tsup",
+    "build": "tsup --silent",
     "prepublishOnly": "npm run build",
     "postinstall": "npx @stricli/auto-complete@latest install test --bash __test_bash_complete"
   },


### PR DESCRIPTION
**Describe your changes**
Fixes [publish failure](https://github.com/bloomberg/stricli/actions/runs/18505557652) when using the latest version of `npm` with the `nx-release-publish` task. The underlying issue is that `nx-release-publish` invokes `npm` and that calls the `build` script. By default `tsup` writes logs to stdout which is not expected by `nx-release-publish` (it parses stdout as a JSON object).

**Testing performed**
Reproduced error locally with latest version of npm, then applied change and confirmed issue no longer occurring.

**Additional context**
Applied the fix for all of the new project templates as well.
