### PR TITLE
Safer literals, as `const` preserves route keys and reduces accidental mutation. 

### DIFF
--- a/examples/deno/src/app.ts
+++ b/examples/deno/src/app.ts
@@ -1,30 +1,52 @@
 import { buildApplication, buildRouteMap } from "npm:@stricli/core";
 import { command as echo } from "./commands/echo.ts";
-import { buildUnaryMathCommand, buildBinaryMathCommand, buildVariadicMathCommand } from "./commands/math.ts";
+import {
+  buildUnaryMathCommand,
+  buildBinaryMathCommand,
+  buildVariadicMathCommand,
+} from "./commands/math.ts";
 
-const math = buildRouteMap({
+const math = buildRouteMap(
+  {
     routes: {
-        log: buildUnaryMathCommand("log"),
-        sqrt: buildUnaryMathCommand("sqrt"),
-        pow: buildBinaryMathCommand("pow"),
-        max: buildVariadicMathCommand("max"),
-        min: buildVariadicMathCommand("min"),
-    },
+      log: buildUnaryMathCommand("log"),
+      ln: buildUnaryMathCommand("log"),
+      sqrt: buildUnaryMathCommand("sqrt"),
+      "√": buildUnaryMathCommand("sqrt"),
+      pow: buildBinaryMathCommand("pow"),
+      max: buildVariadicMathCommand("max"),
+      min: buildVariadicMathCommand("min"),
+    } as const,
     docs: {
-        brief: "Various math operations",
+      brief: "Various math operations",
+      description:
+        "Math utilities: unary (log, sqrt), binary (pow), and variadic (max, min).",
+      examples: [
+        "math ln 10",
+        "math sqrt 144",
+        "math pow 2 10",
+        "math max 3 9 4 7",
+        "math min 3 9 4 7",
+      ],
     },
-});
+  } as const
+);
 
-const root = buildRouteMap({
+const root = buildRouteMap(
+  {
     routes: {
-        echo,
-        math,
-    },
+      echo,
+      math,
+    } as const,
     docs: {
-        brief: "All available example commands",
+      brief: "All available example commands",
+      description:
+        "A small showcase CLI featuring an echo utility and a math toolbox.",
+      examples: ["echo hello world", "math sqrt 16", "math max 1 2 3 4"],
     },
-});
+  } as const
+);
 
 export const app = buildApplication(root, {
-    name: "stricli-deno-example",
-});
+  name: "stricli-deno-example",
+} as const);


### PR DESCRIPTION
Safer literals, as `const` preserves route keys and reduces accidental mutation. 
