### PR TITLE
feat: expose fullDescription to DocumentedTarget

### DIFF
--- a/packages/core/src/routing/command/builder.ts
+++ b/packages/core/src/routing/command/builder.ts
@@ -120,6 +120,9 @@ export function buildCommand<
         get brief(): string {
             return builderArgs.docs.brief;
         },
+        get fullDescription(): string | undefined {
+            return builderArgs.docs.fullDescription;
+        },
         formatUsageLine: (args) => {
             return formatUsageLineForParameters(builderArgs.parameters as CommandParameters, args);
         },

--- a/packages/core/src/routing/route-map/builder.ts
+++ b/packages/core/src/routing/route-map/builder.ts
@@ -79,6 +79,9 @@ export function buildRouteMap<R extends string, CONTEXT extends CommandContext =
         get brief(): string {
             return docs.brief;
         },
+        get fullDescription(): string | undefined {
+            return docs.fullDescription;
+        },
         formatUsageLine(args) {
             const routeNames = this.getAllEntries()
                 .filter((entry) => !entry.hidden)

--- a/packages/core/src/routing/types.ts
+++ b/packages/core/src/routing/types.ts
@@ -17,6 +17,7 @@ export interface HelpFormattingArguments extends UsageFormattingArguments {
 
 export interface DocumentedTarget {
     readonly brief: string;
+    readonly fullDescription: string | undefined;
     readonly formatUsageLine: (args: UsageFormattingArguments) => string;
     readonly formatHelp: (args: HelpFormattingArguments) => string;
 }


### PR DESCRIPTION
*Issue number of the reported bug or feature request: N/A*

## Feature request

When composing route maps, it’s common for `mycli x` to delegate to a default subcommand `mycli x a`. In other words, `mycli x` effectively acts as an alias for `mycli x a`. In this case, I’d like `xRouteMap.docs` to point to `aCommand.brief` and `aCommand.fullDescription`:

For example:

```ts
export const xRouteMap = buildRouteMap({
  routes: {
    a: aCommand,
  },
  docs: {
    brief: aCommand.brief,
    fullDescription: aCommand.fullDescription, // not exposed currently! this pr exposes this
  },
  defaultCommand: 'a',
});
```

However, this is not currently possible because `fullDescription` is not exposed to the built command.

It would be helpful if `fullDescription` were available on the built command so that route maps can forward the documentation of their default subcommand.

## Describe your changes

Expose `fullDescription` to DocumentedTarget.

## Testing performed
- Tested locally with pnpm patch.

## Additional context
N/A