### PR TITLE
fix: lazily load command context for completions

### DIFF
--- a/packages/core/src/application/propose-completions.ts
+++ b/packages/core/src/application/propose-completions.ts
@@ -40,22 +40,10 @@ export async function proposeCompletionsForApplication<CONTEXT extends CommandCo
         return [];
     }
 
-    let commandContext: CONTEXT;
-    if ("forCommand" in context) {
-        try {
-            commandContext = await context.forCommand({ prefix: result.prefix });
-        } catch {
-            return [];
-        }
-    } else {
-        commandContext = context;
-    }
-
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const partial = rawInputs[rawInputs.length - 1]!;
     if (result.target.kind === RouteMapSymbol) {
         return proposeCompletionsForRouteMap(result.target, {
-            context: commandContext,
             partial,
             scannerConfig: config.scanner,
             completionConfig: config.completion,
@@ -63,7 +51,13 @@ export async function proposeCompletionsForApplication<CONTEXT extends CommandCo
     }
 
     return proposeCompletionsForCommand(result.target, {
-        context: commandContext,
+        loadCommandContext: async () => {
+            if ("forCommand" in context) {
+                return context.forCommand({ prefix: result.prefix });
+            } else {
+                return context;
+            }
+        },
         inputs: result.unprocessedInputs,
         partial,
         scannerConfig: config.scanner,

--- a/packages/core/src/routing/route-map/propose-completions.ts
+++ b/packages/core/src/routing/route-map/propose-completions.ts
@@ -6,8 +6,7 @@ import { CommandSymbol } from "../command/types";
 import type { RoutingTargetCompletion } from "../types";
 import type { RouteMap } from "./types";
 
-export interface RouteMapCompletionArguments<CONTEXT extends CommandContext> {
-    readonly context: CONTEXT;
+export interface RouteMapCompletionArguments {
     readonly partial: string;
     readonly scannerConfig: ScannerConfiguration;
     readonly completionConfig: CompletionConfiguration;
@@ -15,7 +14,7 @@ export interface RouteMapCompletionArguments<CONTEXT extends CommandContext> {
 
 export async function proposeCompletionsForRouteMap<CONTEXT extends CommandContext>(
     routeMap: RouteMap<CONTEXT>,
-    { partial, scannerConfig, completionConfig }: RouteMapCompletionArguments<CONTEXT>,
+    { partial, scannerConfig, completionConfig }: RouteMapCompletionArguments,
 ): Promise<readonly RoutingTargetCompletion[]> {
     let entries = routeMap.getAllEntries();
     if (!completionConfig.includeHiddenRoutes) {

--- a/packages/core/tests/parameter/flag/scanner/parsed.spec.ts
+++ b/packages/core/tests/parameter/flag/scanner/parsed.spec.ts
@@ -4620,6 +4620,7 @@ describe("ArgumentScanner (parsed flags)", () => {
 
             await testCompletions<Flags, Positional>({
                 parameters,
+                context: {} as CommandContext,
                 inputs: ["--foo"],
                 partial: "",
                 scannerConfig: defaultScannerConfig,
@@ -4631,6 +4632,7 @@ describe("ArgumentScanner (parsed flags)", () => {
             });
             await testCompletions<Flags, Positional>({
                 parameters,
+                context: {} as CommandContext,
                 inputs: ["--foo"],
                 partial: "1",
                 scannerConfig: defaultScannerConfig,
@@ -4761,6 +4763,7 @@ describe("ArgumentScanner (parsed flags)", () => {
 
                 await testCompletions<Flags, Positional>({
                     parameters: parametersWithAlias,
+                    context: {} as CommandContext,
                     inputs: ["-f"],
                     partial: "",
                     scannerConfig: defaultScannerConfig,
@@ -4772,6 +4775,7 @@ describe("ArgumentScanner (parsed flags)", () => {
                 });
                 await testCompletions<Flags, Positional>({
                     parameters: parametersWithAlias,
+                    context: {} as CommandContext,
                     inputs: ["-f"],
                     partial: "1",
                     scannerConfig: defaultScannerConfig,
@@ -4826,6 +4830,64 @@ describe("ArgumentScanner (parsed flags)", () => {
                         { kind: "argument:flag", completion: "--baz", brief: "baz" },
                     ],
                 });
+            });
+        });
+    });
+
+    describe("with custom completions (using command context)", () => {
+        type Positional = [];
+        type Flags = {
+            readonly project: string;
+        };
+        type CustomContext = CommandContext & {
+            getUserProjects(): readonly string[];
+        };
+
+        const parameters: TypedCommandParameters<Flags, Positional, CustomContext> = {
+            flags: {
+                project: {
+                    kind: "parsed",
+                    parse: String,
+                    brief: "project",
+                    proposeCompletions(this: CustomContext, partial: string) {
+                        return this.getUserProjects().filter((project) => project.startsWith(partial));
+                    },
+                },
+            },
+            positional: { kind: "tuple", parameters: [] },
+        };
+
+        const context = {
+            getUserProjects() {
+                return ["my-project-a", "my-project-b", "extra-project"];
+            },
+        } as unknown as CustomContext;
+
+        it("proposeCompletions", async () => {
+            await testCompletions<Flags, Positional, CustomContext>({
+                parameters,
+                context,
+                inputs: ["--project"],
+                partial: "",
+                scannerConfig: defaultScannerConfig,
+                completionConfig: defaultCompletionConfig,
+                expected: [
+                    { kind: "argument:value", completion: "my-project-a", brief: "project" },
+                    { kind: "argument:value", completion: "my-project-b", brief: "project" },
+                    { kind: "argument:value", completion: "extra-project", brief: "project" },
+                ],
+            });
+            await testCompletions<Flags, Positional, CustomContext>({
+                parameters,
+                context,
+                inputs: ["--project"],
+                partial: "my",
+                scannerConfig: defaultScannerConfig,
+                completionConfig: defaultCompletionConfig,
+                expected: [
+                    { kind: "argument:value", completion: "my-project-a", brief: "project" },
+                    { kind: "argument:value", completion: "my-project-b", brief: "project" },
+                ],
             });
         });
     });

--- a/packages/core/tests/parameter/positional/scanner.spec.ts
+++ b/packages/core/tests/parameter/positional/scanner.spec.ts
@@ -623,6 +623,7 @@ describe("ArgumentScanner (positional)", () => {
         it("proposeCompletions", async () => {
             await testCompletions<Flags, Positional>({
                 parameters,
+                context: {} as CommandContext,
                 inputs: [],
                 partial: "",
                 scannerConfig: defaultScannerConfig,
@@ -634,6 +635,7 @@ describe("ArgumentScanner (positional)", () => {
             });
             await testCompletions<Flags, Positional>({
                 parameters,
+                context: {} as CommandContext,
                 inputs: [],
                 partial: "1",
                 scannerConfig: defaultScannerConfig,
@@ -645,6 +647,7 @@ describe("ArgumentScanner (positional)", () => {
             });
             await testCompletions<Flags, Positional>({
                 parameters,
+                context: {} as CommandContext,
                 inputs: ["1"],
                 partial: "2",
                 scannerConfig: defaultScannerConfig,
@@ -693,6 +696,7 @@ describe("ArgumentScanner (positional)", () => {
         it("proposeCompletions", async () => {
             await testCompletions<Flags, Positional>({
                 parameters,
+                context: {} as CommandContext,
                 inputs: [],
                 partial: "",
                 scannerConfig: defaultScannerConfig,
@@ -704,6 +708,7 @@ describe("ArgumentScanner (positional)", () => {
             });
             await testCompletions<Flags, Positional>({
                 parameters,
+                context: {} as CommandContext,
                 inputs: [],
                 partial: "1",
                 scannerConfig: defaultScannerConfig,
@@ -715,6 +720,7 @@ describe("ArgumentScanner (positional)", () => {
             });
             await testCompletions<Flags, Positional>({
                 parameters,
+                context: {} as CommandContext,
                 inputs: ["1"],
                 partial: "2",
                 scannerConfig: defaultScannerConfig,

--- a/packages/core/tests/parameter/scanner.ts
+++ b/packages/core/tests/parameter/scanner.ts
@@ -99,7 +99,9 @@ export function testCompletionError<FLAGS extends BaseFlags, ARGS extends BaseAr
                 partial,
                 completionConfig,
                 text,
-                context: { process },
+                async loadCommandContext() {
+                    throw new Error("Did not expect test to require command context to propose completions");
+                },
                 includeVersionFlag: false,
             });
         } catch (exc) {
@@ -189,10 +191,15 @@ export async function testArgumentScannerParse<FLAGS extends BaseFlags, ARGS ext
     }
 }
 
-async function proposeCompletionsForPartial<FLAGS extends BaseFlags, ARGS extends BaseArgs>(
-    parameters: TypedCommandParameters<FLAGS, ARGS, CommandContext>,
+async function proposeCompletionsForPartial<
+    FLAGS extends BaseFlags,
+    ARGS extends BaseArgs,
+    CONTEXT extends CommandContext,
+>(
+    parameters: TypedCommandParameters<FLAGS, ARGS, CONTEXT>,
     scannerConfig: ScannerConfiguration,
     completionConfig: CompletionConfiguration,
+    loadCommandContext: () => Promise<CONTEXT>,
     inputs: string[],
     partial: string,
 ) {
@@ -205,13 +212,18 @@ async function proposeCompletionsForPartial<FLAGS extends BaseFlags, ARGS extend
         partial,
         completionConfig,
         text,
-        context: { process },
+        loadCommandContext,
         includeVersionFlag: false,
     });
 }
 
-interface ArgumentScannerCompletionTestArguments<FLAGS extends BaseFlags, ARGS extends BaseArgs> {
-    readonly parameters: TypedCommandParameters<FLAGS, ARGS, CommandContext>;
+interface ArgumentScannerCompletionTestArguments<
+    FLAGS extends BaseFlags,
+    ARGS extends BaseArgs,
+    CONTEXT extends CommandContext,
+> {
+    readonly parameters: TypedCommandParameters<FLAGS, ARGS, CONTEXT>;
+    readonly context?: CONTEXT;
     readonly inputs: string[];
     readonly partial: string;
     readonly scannerConfig: ScannerConfiguration;
@@ -219,22 +231,39 @@ interface ArgumentScannerCompletionTestArguments<FLAGS extends BaseFlags, ARGS e
     readonly expected: readonly ArgumentCompletion[];
 }
 
-export async function testCompletions<FLAGS extends BaseFlags, ARGS extends BaseArgs>({
+export async function testCompletions<
+    FLAGS extends BaseFlags,
+    ARGS extends BaseArgs,
+    CONTEXT extends CommandContext = CommandContext,
+>({
     parameters,
+    context,
     inputs,
     partial,
     scannerConfig,
     completionConfig,
     expected,
-}: ArgumentScannerCompletionTestArguments<FLAGS, ARGS>): Promise<void> {
-    const completions = await proposeCompletionsForPartial<FLAGS, ARGS>(
+}: ArgumentScannerCompletionTestArguments<FLAGS, ARGS, CONTEXT>): Promise<void> {
+    let contextLoaded: boolean = false;
+    const completions = await proposeCompletionsForPartial<FLAGS, ARGS, CONTEXT>(
         parameters,
         scannerConfig,
         completionConfig,
+        async () => {
+            if (!context) {
+                throw new Error("Did not expect test to require command context to propose completions");
+            }
+            contextLoaded = true;
+            return context;
+        },
         inputs,
         partial,
     );
     expect(completions).to.have.deep.members(expected);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (context && !contextLoaded) {
+        throw new Error("Custom command context was provided, but never loaded by test");
+    }
 }
 
 export const defaultScannerConfig: ScannerConfiguration = {


### PR DESCRIPTION
**Describe your changes**
The logic that proposes completions for the autocomplete feature works largely without the need for a context. Only if the flags/parameters have provided their own `proposeCompletions` implementation does the context need to be loaded. This method may not actually need to use the context, but it is bound to `this` by the signature so must be loaded at this point. However, if no flags/parameters customize this behavior, the default behavior does not use the context at all.

To take advantage of this, the implementation was changed from always loading the command context to instead passing an async callback that is only called when the context is needed. The result of this change is that the process of proposing completions for autocomplete should be much faster for most use cases as it does not need to load the customized context (via `forCommand`).

**Testing performed**
Existing test cases that used a custom `proposeCompletions` method were updated. As well, additional tests were added to exercise a `proposeCompletions` implementation that use a customized command context for additional information.
