### PR TITLE
fix: remove all color codes from ANSI styling

### DIFF
--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -226,8 +226,16 @@ a.button {
     filter: drop-shadow(0 0 0.1rem color-mix(in srgb, currentColor 50%, transparent));
 }
 
+.ansi-dim {
+    opacity: 40%;
+}
+
 .ansi-italic {
     font-style: italic;
+}
+
+.ansi-underline {
+    text-decoration: underline;
 }
 
 .ansi-black {

--- a/packages/core/src/parameter/flag/formatting.ts
+++ b/packages/core/src/parameter/flag/formatting.ts
@@ -122,8 +122,8 @@ export function formatDocumentationForFlagParameters(
                 return [row.aliases, row.flagName, row.brief, row.suffix ?? ""];
             }
             return [
-                row.hidden ? `\x1B[90m${row.aliases}\x1B[39m` : `\x1B[36m${row.aliases}\x1B[39m`,
-                row.hidden ? `\x1B[90m${row.flagName}\x1B[39m` : `\x1B[36m${row.flagName}\x1B[39m`,
+                row.hidden ? `\x1B[90m${row.aliases}\x1B[39m` : `\x1B[01m${row.aliases}\x1B[22m`,
+                row.hidden ? `\x1B[90m${row.flagName}\x1B[39m` : `\x1B[01m${row.flagName}\x1B[22m`,
                 row.hidden ? `\x1B[90m${row.brief}\x1B[39m` : `\x1B[03m${row.brief}\x1B[23m`,
                 row.suffix ?? "",
             ];

--- a/packages/core/src/parameter/flag/formatting.ts
+++ b/packages/core/src/parameter/flag/formatting.ts
@@ -124,7 +124,7 @@ export function formatDocumentationForFlagParameters(
             return [
                 row.hidden ? `\x1B[2m${row.aliases}\x1B[22m` : `\x1B[1m${row.aliases}\x1B[22m`,
                 row.hidden ? `\x1B[2m${row.flagName}\x1B[22m` : `\x1B[1m${row.flagName}\x1B[22m`,
-                row.hidden ? `\x1B[2;3m${row.brief}\x1B[22;23m` : `\x1B[003m${row.brief}\x1B[00023m`,
+                row.hidden ? `\x1B[2;3m${row.brief}\x1B[22;23m` : `\x1B[;;3m${row.brief}\x1B[;;;23m`,
                 row.suffix ?? "",
             ];
         }),

--- a/packages/core/src/parameter/flag/formatting.ts
+++ b/packages/core/src/parameter/flag/formatting.ts
@@ -58,7 +58,7 @@ export function formatDocumentationForFlagParameters(
             suffixParts.push(choices);
         }
         if (hasDefault(flag)) {
-            const defaultKeyword = args.ansiColor ? `\x1B[90m${keywords.default}\x1B[39m` : keywords.default;
+            const defaultKeyword = args.ansiColor ? `\x1B[2m${keywords.default}\x1B[22m` : keywords.default;
             let defaultValue: string;
             if (Array.isArray(flag.default)) {
                 // Format array defaults
@@ -75,7 +75,7 @@ export function formatDocumentationForFlagParameters(
             suffixParts.push(`${defaultKeyword} ${defaultValue}`);
         }
         if ("variadic" in flag && typeof flag.variadic === "string") {
-            const separatorKeyword = args.ansiColor ? `\x1B[90m${keywords.separator}\x1B[39m` : keywords.separator;
+            const separatorKeyword = args.ansiColor ? `\x1B[2m${keywords.separator}\x1B[22m` : keywords.separator;
             suffixParts.push(`${separatorKeyword} ${flag.variadic}`);
         }
         const suffix = suffixParts.length > 0 ? `[${suffixParts.join(", ")}]` : void 0;
@@ -122,9 +122,9 @@ export function formatDocumentationForFlagParameters(
                 return [row.aliases, row.flagName, row.brief, row.suffix ?? ""];
             }
             return [
-                row.hidden ? `\x1B[90m${row.aliases}\x1B[39m` : `\x1B[01m${row.aliases}\x1B[22m`,
-                row.hidden ? `\x1B[90m${row.flagName}\x1B[39m` : `\x1B[01m${row.flagName}\x1B[22m`,
-                row.hidden ? `\x1B[90m${row.brief}\x1B[39m` : `\x1B[03m${row.brief}\x1B[23m`,
+                row.hidden ? `\x1B[2m${row.aliases}\x1B[22m` : `\x1B[1m${row.aliases}\x1B[22m`,
+                row.hidden ? `\x1B[2m${row.flagName}\x1B[22m` : `\x1B[1m${row.flagName}\x1B[22m`,
+                row.hidden ? `\x1B[2;3m${row.brief}\x1B[22;23m` : `\x1B[003m${row.brief}\x1B[00023m`,
                 row.suffix ?? "",
             ];
         }),

--- a/packages/core/src/parameter/positional/formatting.ts
+++ b/packages/core/src/parameter/positional/formatting.ts
@@ -13,7 +13,7 @@ export function formatDocumentationForPositionalParameters(
 ): readonly string[] {
     if (positional.kind === "array") {
         const name = positional.parameter.placeholder ?? "args";
-        const argName = args.ansiColor ? `\x1B[36m${name}...\x1B[39m` : `${name}...`;
+        const argName = args.ansiColor ? `\x1B[01m${name}...\x1B[22m` : `${name}...`;
         const brief = args.ansiColor ? `\x1B[3m${positional.parameter.brief}\x1B[23m` : positional.parameter.brief;
         return formatRowsWithColumns([[argName, brief]], ["  "]);
     }
@@ -33,7 +33,7 @@ export function formatDocumentationForPositionalParameters(
                 suffix = `[${defaultKeyword} ${def.default}]`;
             }
             return [
-                args.ansiColor ? `\x1B[36m${name}\x1B[39m` : name,
+                args.ansiColor ? `\x1B[1m${name}\x1B[22m` : name,
                 args.ansiColor ? `\x1B[3m${def.brief}\x1B[23m` : def.brief,
                 suffix ?? "",
             ];

--- a/packages/core/src/parameter/positional/formatting.ts
+++ b/packages/core/src/parameter/positional/formatting.ts
@@ -13,7 +13,7 @@ export function formatDocumentationForPositionalParameters(
 ): readonly string[] {
     if (positional.kind === "array") {
         const name = positional.parameter.placeholder ?? "args";
-        const argName = args.ansiColor ? `\x1B[01m${name}...\x1B[22m` : `${name}...`;
+        const argName = args.ansiColor ? `\x1B[1m${name}...\x1B[22m` : `${name}...`;
         const brief = args.ansiColor ? `\x1B[3m${positional.parameter.brief}\x1B[23m` : positional.parameter.brief;
         return formatRowsWithColumns([[argName, brief]], ["  "]);
     }
@@ -29,7 +29,7 @@ export function formatDocumentationForPositionalParameters(
                 name = ` ${name}`;
             }
             if (def.default) {
-                const defaultKeyword = args.ansiColor ? `\x1B[90m${keywords.default}\x1B[39m` : keywords.default;
+                const defaultKeyword = args.ansiColor ? `\x1B[2m${keywords.default}\x1B[22m` : keywords.default;
                 suffix = `[${defaultKeyword} ${def.default}]`;
             }
             return [

--- a/packages/core/src/routing/command/documentation.ts
+++ b/packages/core/src/routing/command/documentation.ts
@@ -37,7 +37,7 @@ export function* generateCommandHelpLines(
     const { brief, fullDescription, customUsage } = docs;
     const { headers } = args.text;
     const prefix = args.prefix.join(" ");
-    yield args.ansiColor ? `\x1B[1m${headers.usage}\x1B[22m` : headers.usage;
+    yield args.ansiColor ? `\x1B[4m${headers.usage}\x1B[24m` : headers.usage;
     if (customUsage) {
         for (const usage of customUsage) {
             if (typeof usage === "string") {
@@ -58,20 +58,20 @@ export function* generateCommandHelpLines(
     if (args.aliases && args.aliases.length > 0) {
         const aliasPrefix = args.prefix.slice(0, -1).join(" ");
         yield "";
-        yield args.ansiColor ? `\x1B[1m${headers.aliases}\x1B[22m` : headers.aliases;
+        yield args.ansiColor ? `\x1B[4m${headers.aliases}\x1B[24m` : headers.aliases;
         for (const alias of args.aliases) {
             yield `  ${aliasPrefix} ${alias}`;
         }
     }
     yield "";
-    yield args.ansiColor ? `\x1B[1m${headers.flags}\x1B[22m` : headers.flags;
+    yield args.ansiColor ? `\x1B[4m${headers.flags}\x1B[24m` : headers.flags;
     for (const line of formatDocumentationForFlagParameters(parameters.flags ?? {}, parameters.aliases ?? {}, args)) {
         yield `  ${line}`;
     }
     const positional = parameters.positional ?? { kind: "tuple", parameters: [] };
     if (positional.kind === "array" || positional.parameters.length > 0) {
         yield "";
-        yield args.ansiColor ? `\x1B[1m${headers.arguments}\x1B[22m` : headers.arguments;
+        yield args.ansiColor ? `\x1B[4m${headers.arguments}\x1B[24m` : headers.arguments;
         for (const line of formatDocumentationForPositionalParameters(positional, args)) {
             yield `  ${line}`;
         }

--- a/packages/core/src/routing/route-map/documentation.ts
+++ b/packages/core/src/routing/route-map/documentation.ts
@@ -92,8 +92,8 @@ export function* generateRouteMapHelpLines<CONTEXT extends CommandContext>(
                 return [row.routeName, row.brief];
             }
             return [
-                row.hidden ? `\x1B[90m${row.routeName}\x1B[39m` : `\x1B[01m${row.routeName}\x1B[32m`,
-                row.hidden ? `\x1B[90m${row.brief}\x1B[39m` : `\x1B[03m${row.brief}\x1B[23m`,
+                row.hidden ? `\x1B[2m${row.routeName}\x1B[22m` : `\x1B[1m${row.routeName}\x1B[32m`,
+                row.hidden ? `\x1B[2;3m${row.brief}\x1B[22;23m` : `\x1B[003m${row.brief}\x1B[00023m`,
             ];
         }),
         ["  "],

--- a/packages/core/src/routing/route-map/documentation.ts
+++ b/packages/core/src/routing/route-map/documentation.ts
@@ -92,7 +92,7 @@ export function* generateRouteMapHelpLines<CONTEXT extends CommandContext>(
                 return [row.routeName, row.brief];
             }
             return [
-                row.hidden ? `\x1B[90m${row.routeName}\x1B[39m` : `\x1B[36m${row.routeName}\x1B[39m`,
+                row.hidden ? `\x1B[90m${row.routeName}\x1B[39m` : `\x1B[01m${row.routeName}\x1B[32m`,
                 row.hidden ? `\x1B[90m${row.brief}\x1B[39m` : `\x1B[03m${row.brief}\x1B[23m`,
             ];
         }),

--- a/packages/core/src/routing/route-map/documentation.ts
+++ b/packages/core/src/routing/route-map/documentation.ts
@@ -42,7 +42,7 @@ export function* generateRouteMapHelpLines<CONTEXT extends CommandContext>(
 ): Generator<string> {
     const { brief, fullDescription, hideRoute } = docs;
     const { headers } = args.text;
-    yield args.ansiColor ? `\x1B[1m${headers.usage}\x1B[22m` : headers.usage;
+    yield args.ansiColor ? `\x1B[4m${headers.usage}\x1B[24m` : headers.usage;
     for (const [name, route] of Object.entries(routes)) {
         if (!hideRoute || !hideRoute[name] || args.includeHidden) {
             const externalRouteName =
@@ -62,19 +62,19 @@ export function* generateRouteMapHelpLines<CONTEXT extends CommandContext>(
     if (args.aliases && args.aliases.length > 0) {
         const aliasPrefix = args.prefix.slice(0, -1).join(" ");
         yield "";
-        yield args.ansiColor ? `\x1B[1m${headers.aliases}\x1B[22m` : headers.aliases;
+        yield args.ansiColor ? `\x1B[4m${headers.aliases}\x1B[24m` : headers.aliases;
         for (const alias of args.aliases) {
             yield `  ${aliasPrefix} ${alias}`;
         }
     }
     yield "";
-    yield args.ansiColor ? `\x1B[1m${headers.flags}\x1B[22m` : headers.flags;
+    yield args.ansiColor ? `\x1B[4m${headers.flags}\x1B[24m` : headers.flags;
     // Print "empty" parameters to document built-in flags
     for (const line of formatDocumentationForFlagParameters({}, {}, args)) {
         yield `  ${line}`;
     }
     yield "";
-    yield args.ansiColor ? `\x1B[1m${headers.commands}\x1B[22m` : headers.commands;
+    yield args.ansiColor ? `\x1B[4m${headers.commands}\x1B[24m` : headers.commands;
     const visibleRoutes = Object.entries(routes).filter(
         ([name]) => !hideRoute || !hideRoute[name] || args.includeHidden,
     );

--- a/packages/core/src/routing/route-map/documentation.ts
+++ b/packages/core/src/routing/route-map/documentation.ts
@@ -93,7 +93,7 @@ export function* generateRouteMapHelpLines<CONTEXT extends CommandContext>(
             }
             return [
                 row.hidden ? `\x1B[2m${row.routeName}\x1B[22m` : `\x1B[1m${row.routeName}\x1B[32m`,
-                row.hidden ? `\x1B[2;3m${row.brief}\x1B[22;23m` : `\x1B[003m${row.brief}\x1B[00023m`,
+                row.hidden ? `\x1B[2;3m${row.brief}\x1B[22;23m` : `\x1B[;;3m${row.brief}\x1B[;;;23m`,
             ];
         }),
         ["  "],

--- a/packages/core/tests/__snapshots__/application.spec.ts.snap
+++ b/packages/core/tests/__snapshots__/application.spec.ts.snap
@@ -173,7 +173,7 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 :: STDERR
 
@@ -189,7 +189,7 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 :: STDERR
 
@@ -221,7 +221,7 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 :: STDERR
 
@@ -292,7 +292,7 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 :: STDERR
 
@@ -309,7 +309,7 @@ This is a full description
 of this command's behavior.
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 :: STDERR
 
@@ -325,7 +325,7 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 :: STDERR
 
@@ -351,8 +351,8 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-v[22m [1m--version[22m  [;;3mPrint version information and exit[;;;23m
 
 :: STDERR
 [1m[33mLatest available version is 1.1.0 (currently running 1.0.0)[39m[22m
@@ -380,8 +380,8 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-v[22m [1m--version[22m  [;;3mPrint version information and exit[;;;23m
 
 :: STDERR
 [1m[33mLatest available version is 1.1.0 (currently running 1.0.0)[39m[22m
@@ -474,10 +474,10 @@ ExitCode=Success
 root
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -493,10 +493,10 @@ ExitCode=Success
 root
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -512,10 +512,10 @@ ExitCode=Success
 root
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -531,7 +531,7 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 :: STDERR
 
@@ -547,7 +547,7 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 :: STDERR
 
@@ -662,10 +662,10 @@ This is a full description
 of this route map's behavior.
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -682,11 +682,11 @@ ExitCode=Success
 root
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-v[22m [1m--version[22m  [;;3mPrint version information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 [1m[33mLatest available version is 1.1.0 (currently running 1.0.0), upgrade with "<upgrade-command>"[39m[22m
@@ -703,7 +703,7 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 :: STDERR
 [1m[33mLatest available version is 1.1.0 (currently running 1.0.0), upgrade with "<upgrade-command>"[39m[22m
@@ -750,11 +750,11 @@ ExitCode=Success
 root
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-v[22m [1m--version[22m  [;;3mPrint version information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 [1m[33mLatest available version is 1.1.0 (currently running 1.0.0)[39m[22m
@@ -771,7 +771,7 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 :: STDERR
 [1m[33mLatest available version is 1.1.0 (currently running 1.0.0)[39m[22m
@@ -799,11 +799,11 @@ ExitCode=Success
 root
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-v[22m [1m--version[22m  [;;3mPrint version information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -878,10 +878,10 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1msub[32m  [003msub[00023m
+  [1msub[32m  [;;3msub[;;;23m
 
 :: STDERR
 
@@ -897,10 +897,10 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1msub[32m  [003msub[00023m
+  [1msub[32m  [;;3msub[;;;23m
 
 :: STDERR
 
@@ -916,10 +916,10 @@ ExitCode=Success
 sub
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -935,10 +935,10 @@ ExitCode=Success
 sub
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -972,10 +972,10 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1msub[32m  [003msub[00023m
+  [1msub[32m  [;;3msub[;;;23m
 
 :: STDERR
 
@@ -991,10 +991,10 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1msub[32m  [003msub[00023m
+  [1msub[32m  [;;3msub[;;;23m
 
 :: STDERR
 
@@ -1014,10 +1014,10 @@ sub
   cli alias-bar
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -1037,10 +1037,10 @@ sub
   cli alias-bar
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -1060,10 +1060,10 @@ sub
   cli alias-bar
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -1083,10 +1083,10 @@ sub
   cli alias-bar
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -1106,10 +1106,10 @@ sub
   cli alias-bar
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -1152,10 +1152,10 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1msub[32m  [003msub[00023m
+  [1msub[32m  [;;3msub[;;;23m
 
 :: STDERR
 
@@ -1171,10 +1171,10 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1msub[32m  [003msub[00023m
+  [1msub[32m  [;;3msub[;;;23m
 
 :: STDERR
 
@@ -1192,11 +1192,11 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
   [2m-H[22m [2m--helpAll[22m  [2;3mPrint help information (including hidden commands/flags) and exit[22;23m
 
 [4mCOMMANDS[24m
-  [1msub[32m        [003msub[00023m
+  [1msub[32m        [;;3msub[;;;23m
   [2msubHidden[22m  [2;3msubHidden[22;23m
 
 :: STDERR
@@ -1213,10 +1213,10 @@ ExitCode=Success
 subHidden
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -1232,10 +1232,10 @@ ExitCode=Success
 subHidden
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -1270,11 +1270,11 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-H[22m [1m--helpAll[22m  [;;3mPrint help information (including hidden commands/flags) and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1msub[32m  [003msub[00023m
+  [1msub[32m  [;;3msub[;;;23m
 
 :: STDERR
 
@@ -1291,11 +1291,11 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-H[22m [1m--helpAll[22m  [;;3mPrint help information (including hidden commands/flags) and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1msub[32m  [003msub[00023m
+  [1msub[32m  [;;3msub[;;;23m
 
 :: STDERR
 
@@ -1313,11 +1313,11 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-H[22m [1m--helpAll[22m  [;;3mPrint help information (including hidden commands/flags) and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1msub[32m        [003msub[00023m
+  [1msub[32m        [;;3msub[;;;23m
   [2msubHidden[22m  [2;3msubHidden[22;23m
 
 :: STDERR
@@ -1335,11 +1335,11 @@ ExitCode=Success
 subHidden
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-H[22m [1m--helpAll[22m  [;;3mPrint help information (including hidden commands/flags) and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -1356,11 +1356,11 @@ ExitCode=Success
 subHidden
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-H[22m [1m--helpAll[22m  [;;3mPrint help information (including hidden commands/flags) and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -1395,11 +1395,11 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-H[22m [1m--helpAll[22m  [;;3mPrint help information (including hidden commands/flags) and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1msub[32m  [003msub[00023m
+  [1msub[32m  [;;3msub[;;;23m
 
 :: STDERR
 
@@ -1416,11 +1416,11 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-H[22m [1m--helpAll[22m  [;;3mPrint help information (including hidden commands/flags) and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1msub[32m  [003msub[00023m
+  [1msub[32m  [;;3msub[;;;23m
 
 :: STDERR
 
@@ -1438,11 +1438,11 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-H[22m [1m--helpAll[22m  [;;3mPrint help information (including hidden commands/flags) and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1msub[32m        [003msub[00023m
+  [1msub[32m        [;;3msub[;;;23m
   [2msubHidden[22m  [2;3msubHidden[22;23m
 
 :: STDERR
@@ -1460,11 +1460,11 @@ ExitCode=Success
 subHidden
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-H[22m [1m--helpAll[22m  [;;3mPrint help information (including hidden commands/flags) and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -1481,11 +1481,11 @@ ExitCode=Success
 subHidden
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-H[22m [1m--helpAll[22m  [;;3mPrint help information (including hidden commands/flags) and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -1519,10 +1519,10 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1msub[32m  [003msub[00023m
+  [1msub[32m  [;;3msub[;;;23m
 
 :: STDERR
 
@@ -1538,10 +1538,10 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1msub[32m  [003msub[00023m
+  [1msub[32m  [;;3msub[;;;23m
 
 :: STDERR
 
@@ -1560,10 +1560,10 @@ sub
   cli sub
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -1582,10 +1582,10 @@ sub
   cli sub
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -1604,10 +1604,10 @@ sub
   cli alias
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -1651,11 +1651,11 @@ ExitCode=Success
 route map with default command brief
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mdefault[32m    [003mbasic command[00023m
-  [1malternate[32m  [003mbasic command[00023m
+  [1mdefault[32m    [;;3mbasic command[;;;23m
+  [1malternate[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -1672,11 +1672,11 @@ ExitCode=Success
 route map with default command brief
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mdefault[32m    [003mbasic command[00023m
-  [1malternate[32m  [003mbasic command[00023m
+  [1mdefault[32m    [;;3mbasic command[;;;23m
+  [1malternate[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 
@@ -1695,7 +1695,7 @@ basic command
   cli 
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 :: STDERR
 
@@ -1714,7 +1714,7 @@ basic command
   cli 
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 :: STDERR
 
@@ -1792,10 +1792,10 @@ This is a full description
 of this route map's behavior.
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mcommand[32m  [003mbasic command[00023m
+  [1mcommand[32m  [;;3mbasic command[;;;23m
 
 :: STDERR
 

--- a/packages/core/tests/__snapshots__/application.spec.ts.snap
+++ b/packages/core/tests/__snapshots__/application.spec.ts.snap
@@ -166,13 +166,13 @@ FLAGS
 exports[`Application > run > basic command at root > display help text for root (with flag alias) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli
   cli --help
 
 basic command
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
@@ -182,13 +182,13 @@ basic command
 exports[`Application > run > basic command at root > display help text for root 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli
   cli --help
 
 basic command
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
@@ -214,13 +214,13 @@ FLAGS
 exports[`Application > run > basic command at root > display help text for root, color depth > 4 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli
   cli --help
 
 basic command
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
@@ -282,7 +282,7 @@ ExitCode=Success
 exports[`Application > run > basic command at root > with custom usage > display help text for root 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli custom usage 1
   cli custom-two
     [3menhanced custom usage 2[23m
@@ -291,7 +291,7 @@ ExitCode=Success
 
 basic command
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
@@ -301,14 +301,14 @@ basic command
 exports[`Application > run > basic command at root > with full description > display help text for root 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli
   cli --help
 
 This is a full description
 of this command's behavior.
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
@@ -318,13 +318,13 @@ of this command's behavior.
 exports[`Application > run > basic command at root > with missing latest version info > display help text for root 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli
   cli --help
 
 basic command
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
@@ -343,14 +343,14 @@ ExitCode=Success
 exports[`Application > run > basic command at root > with outdated version info (as async callback) > display help text for root, warn on outdated version 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli
   cli --help
   cli --version
 
 basic command
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
@@ -372,14 +372,14 @@ ExitCode=Success
 exports[`Application > run > basic command at root > with outdated version info (as static string) > display help text for root, warn on outdated version 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli
   cli --help
   cli --version
 
 basic command
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
@@ -467,16 +467,16 @@ ExitCode=Success
 exports[`Application > run > basic route map at root > display help text for root (implicit) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli command
   cli --help
 
 root
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -486,16 +486,16 @@ root
 exports[`Application > run > basic route map at root > display help text for root (with flag alias) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli command
   cli --help
 
 root
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -505,16 +505,16 @@ root
 exports[`Application > run > basic route map at root > display help text for root 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli command
   cli --help
 
 root
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -524,13 +524,13 @@ root
 exports[`Application > run > basic route map at root > displays help text for subcommand (with flag alias) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli command
   cli command --help
 
 basic command
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
@@ -540,13 +540,13 @@ basic command
 exports[`Application > run > basic route map at root > displays help text for subcommand 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli command
   cli command --help
 
 basic command
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
@@ -654,17 +654,17 @@ ExitCode=UnknownCommand
 exports[`Application > run > basic route map at root > with full description > display help text for root 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli command
   cli --help
 
 This is a full description
 of this route map's behavior.
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -674,18 +674,18 @@ of this route map's behavior.
 exports[`Application > run > basic route map at root > with outdated version info > and upgrade command > display help text for root, warn on outdated version 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli command
   cli --help
   cli --version
 
 root
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -696,13 +696,13 @@ root
 exports[`Application > run > basic route map at root > with outdated version info > and upgrade command > display help text for subcommand, warn on outdated version 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli command
   cli command --help
 
 basic command
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
@@ -742,18 +742,18 @@ ExitCode=Success
 exports[`Application > run > basic route map at root > with outdated version info > display help text for root, warn on outdated version 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli command
   cli --help
   cli --version
 
 root
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -764,13 +764,13 @@ root
 exports[`Application > run > basic route map at root > with outdated version info > display help text for subcommand, warn on outdated version 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli command
   cli command --help
 
 basic command
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
@@ -791,18 +791,18 @@ ExitCode=Success
 exports[`Application > run > basic route map at root > with up-to-date version info > display help text for root, no warning 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli command
   cli --help
   cli --version
 
 root
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -871,16 +871,16 @@ ExitCode=Success
 exports[`Application > run > nested basic route map at root > display help text for root (implicit) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command ...
   cli --help
 
 root route map
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01msub[32m  [03msub[23m
 
 :: STDERR
@@ -890,16 +890,16 @@ root route map
 exports[`Application > run > nested basic route map at root > display help text for root 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command ...
   cli --help
 
 root route map
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01msub[32m  [03msub[23m
 
 :: STDERR
@@ -909,16 +909,16 @@ root route map
 exports[`Application > run > nested basic route map at root > displays help text for nested route map (implicit) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command
   cli sub --help
 
 sub
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -928,16 +928,16 @@ sub
 exports[`Application > run > nested basic route map at root > displays help text for nested route map 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command
   cli sub --help
 
 sub
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -965,16 +965,16 @@ ExitCode=UnknownCommand
 exports[`Application > run > nested basic route map with camelCase route aliases at root > display help text for root (implicit) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command ...
   cli --help
 
 root route map
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01msub[32m  [03msub[23m
 
 :: STDERR
@@ -984,16 +984,16 @@ root route map
 exports[`Application > run > nested basic route map with camelCase route aliases at root > display help text for root 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command ...
   cli --help
 
 root route map
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01msub[32m  [03msub[23m
 
 :: STDERR
@@ -1003,20 +1003,20 @@ root route map
 exports[`Application > run > nested basic route map with camelCase route aliases at root > displays help text for nested route map via route alias (implicit) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli aliasFoo command
   cli aliasFoo --help
 
 sub
 
-[1mALIASES[22m
+[4mALIASES[24m
   cli sub
   cli alias-bar
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -1026,20 +1026,20 @@ sub
 exports[`Application > run > nested basic route map with camelCase route aliases at root > displays help text for nested route map via route alias 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli aliasFoo command
   cli aliasFoo --help
 
 sub
 
-[1mALIASES[22m
+[4mALIASES[24m
   cli sub
   cli alias-bar
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -1049,20 +1049,20 @@ sub
 exports[`Application > run > nested basic route map with camelCase route aliases at root > displays help text for nested route map via route alias kebab-case version (implicit) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli alias-foo command
   cli alias-foo --help
 
 sub
 
-[1mALIASES[22m
+[4mALIASES[24m
   cli sub
   cli alias-bar
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -1072,20 +1072,20 @@ sub
 exports[`Application > run > nested basic route map with camelCase route aliases at root > displays help text for nested route map via route alias kebab-case version 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli alias-foo command
   cli alias-foo --help
 
 sub
 
-[1mALIASES[22m
+[4mALIASES[24m
   cli sub
   cli alias-bar
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -1095,20 +1095,20 @@ sub
 exports[`Application > run > nested basic route map with camelCase route aliases at root > displays help text for nested route map with route alias 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command
   cli sub --help
 
 sub
 
-[1mALIASES[22m
+[4mALIASES[24m
   cli alias-foo
   cli alias-bar
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -1145,16 +1145,16 @@ ExitCode=UnknownCommand
 exports[`Application > run > nested basic route map with hidden routes > display help text for root (implicit) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command ...
   cli --help
 
 root route map
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01msub[32m  [03msub[23m
 
 :: STDERR
@@ -1164,16 +1164,16 @@ root route map
 exports[`Application > run > nested basic route map with hidden routes > display help text for root 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command ...
   cli --help
 
 root route map
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01msub[32m  [03msub[23m
 
 :: STDERR
@@ -1183,7 +1183,7 @@ root route map
 exports[`Application > run > nested basic route map with hidden routes > display help text for root including hidden 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command ...
   cli subHidden command ...
   cli --help
@@ -1191,11 +1191,11 @@ ExitCode=Success
 
 root route map
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [90m-H[39m [90m--helpAll[39m  [90mPrint help information (including hidden commands/flags) and exit[39m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01msub[32m        [03msub[23m
   [90msubHidden[39m  [90msubHidden[39m
 
@@ -1206,16 +1206,16 @@ root route map
 exports[`Application > run > nested basic route map with hidden routes > displays help text for nested hidden route map (implicit) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli subHidden command
   cli subHidden --help
 
 subHidden
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -1225,16 +1225,16 @@ subHidden
 exports[`Application > run > nested basic route map with hidden routes > displays help text for nested hidden route map 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli subHidden command
   cli subHidden --help
 
 subHidden
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -1262,18 +1262,18 @@ ExitCode=UnknownCommand
 exports[`Application > run > nested basic route map with hidden routes, always show help-all (alias) > display help text for root (implicit) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command ...
   cli -h
   cli -H
 
 root route map
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01msub[32m  [03msub[23m
 
 :: STDERR
@@ -1283,18 +1283,18 @@ root route map
 exports[`Application > run > nested basic route map with hidden routes, always show help-all (alias) > display help text for root 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command ...
   cli -h
   cli -H
 
 root route map
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01msub[32m  [03msub[23m
 
 :: STDERR
@@ -1304,7 +1304,7 @@ root route map
 exports[`Application > run > nested basic route map with hidden routes, always show help-all (alias) > display help text for root including hidden 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command ...
   cli subHidden command ...
   cli -h
@@ -1312,11 +1312,11 @@ ExitCode=Success
 
 root route map
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01msub[32m        [03msub[23m
   [90msubHidden[39m  [90msubHidden[39m
 
@@ -1327,18 +1327,18 @@ root route map
 exports[`Application > run > nested basic route map with hidden routes, always show help-all (alias) > displays help text for nested hidden route map (implicit) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli subHidden command
   cli subHidden -h
   cli subHidden -H
 
 subHidden
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -1348,18 +1348,18 @@ subHidden
 exports[`Application > run > nested basic route map with hidden routes, always show help-all (alias) > displays help text for nested hidden route map 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli subHidden command
   cli subHidden -h
   cli subHidden -H
 
 subHidden
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -1387,18 +1387,18 @@ ExitCode=UnknownCommand
 exports[`Application > run > nested basic route map with hidden routes, always show help-all > display help text for root (implicit) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command ...
   cli --help
   cli --helpAll
 
 root route map
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01msub[32m  [03msub[23m
 
 :: STDERR
@@ -1408,18 +1408,18 @@ root route map
 exports[`Application > run > nested basic route map with hidden routes, always show help-all > display help text for root 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command ...
   cli --help
   cli --helpAll
 
 root route map
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01msub[32m  [03msub[23m
 
 :: STDERR
@@ -1429,7 +1429,7 @@ root route map
 exports[`Application > run > nested basic route map with hidden routes, always show help-all > display help text for root including hidden 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command ...
   cli subHidden command ...
   cli --help
@@ -1437,11 +1437,11 @@ ExitCode=Success
 
 root route map
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01msub[32m        [03msub[23m
   [90msubHidden[39m  [90msubHidden[39m
 
@@ -1452,18 +1452,18 @@ root route map
 exports[`Application > run > nested basic route map with hidden routes, always show help-all > displays help text for nested hidden route map (implicit) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli subHidden command
   cli subHidden --help
   cli subHidden --helpAll
 
 subHidden
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -1473,18 +1473,18 @@ subHidden
 exports[`Application > run > nested basic route map with hidden routes, always show help-all > displays help text for nested hidden route map 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli subHidden command
   cli subHidden --help
   cli subHidden --helpAll
 
 subHidden
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -1512,16 +1512,16 @@ ExitCode=UnknownCommand
 exports[`Application > run > nested basic route map with route alias at root > display help text for root (implicit) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command ...
   cli --help
 
 root route map
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01msub[32m  [03msub[23m
 
 :: STDERR
@@ -1531,16 +1531,16 @@ root route map
 exports[`Application > run > nested basic route map with route alias at root > display help text for root 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command ...
   cli --help
 
 root route map
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01msub[32m  [03msub[23m
 
 :: STDERR
@@ -1550,19 +1550,19 @@ root route map
 exports[`Application > run > nested basic route map with route alias at root > displays help text for nested route map via route alias (implicit) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli alias command
   cli alias --help
 
 sub
 
-[1mALIASES[22m
+[4mALIASES[24m
   cli sub
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -1572,19 +1572,19 @@ sub
 exports[`Application > run > nested basic route map with route alias at root > displays help text for nested route map via route alias 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli alias command
   cli alias --help
 
 sub
 
-[1mALIASES[22m
+[4mALIASES[24m
   cli sub
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -1594,19 +1594,19 @@ sub
 exports[`Application > run > nested basic route map with route alias at root > displays help text for nested route map with route alias 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli sub command
   cli sub --help
 
 sub
 
-[1mALIASES[22m
+[4mALIASES[24m
   cli alias
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
@@ -1643,17 +1643,17 @@ ExitCode=UnknownCommand
 exports[`Application > run > route map with default command at root > display help text for root (with flag alias) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli default
   cli alternate
   cli --help
 
 route map with default command brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mdefault[32m    [03mbasic command[23m
   [01malternate[32m  [03mbasic command[23m
 
@@ -1664,17 +1664,17 @@ route map with default command brief
 exports[`Application > run > route map with default command at root > display help text for root 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli default
   cli alternate
   cli --help
 
 route map with default command brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mdefault[32m    [03mbasic command[23m
   [01malternate[32m  [03mbasic command[23m
 
@@ -1685,16 +1685,16 @@ route map with default command brief
 exports[`Application > run > route map with default command at root > displays help text for default command (with flag alias) 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli default
   cli default --help
 
 basic command
 
-[1mALIASES[22m
+[4mALIASES[24m
   cli 
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
@@ -1704,16 +1704,16 @@ basic command
 exports[`Application > run > route map with default command at root > displays help text for default command 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli default
   cli default --help
 
 basic command
 
-[1mALIASES[22m
+[4mALIASES[24m
   cli 
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
@@ -1784,17 +1784,17 @@ ExitCode=Success
 exports[`Application > run > route map with default command at root > with full description > display help text for root 1`] = `
 ExitCode=Success
 :: STDOUT
-[1mUSAGE[22m
+[4mUSAGE[24m
   cli command
   cli --help
 
 This is a full description
 of this route map's behavior.
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR

--- a/packages/core/tests/__snapshots__/application.spec.ts.snap
+++ b/packages/core/tests/__snapshots__/application.spec.ts.snap
@@ -173,7 +173,7 @@ ExitCode=Success
 basic command
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
 
@@ -189,7 +189,7 @@ ExitCode=Success
 basic command
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
 
@@ -221,7 +221,7 @@ ExitCode=Success
 basic command
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
 
@@ -292,7 +292,7 @@ ExitCode=Success
 basic command
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
 
@@ -309,7 +309,7 @@ This is a full description
 of this command's behavior.
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
 
@@ -325,7 +325,7 @@ ExitCode=Success
 basic command
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
 
@@ -351,8 +351,8 @@ ExitCode=Success
 basic command
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-v[39m [36m--version[39m  [03mPrint version information and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
 :: STDERR
 [1m[33mLatest available version is 1.1.0 (currently running 1.0.0)[39m[22m
@@ -380,8 +380,8 @@ ExitCode=Success
 basic command
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-v[39m [36m--version[39m  [03mPrint version information and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
 :: STDERR
 [1m[33mLatest available version is 1.1.0 (currently running 1.0.0)[39m[22m
@@ -474,10 +474,10 @@ ExitCode=Success
 root
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -493,10 +493,10 @@ ExitCode=Success
 root
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -512,10 +512,10 @@ ExitCode=Success
 root
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -531,7 +531,7 @@ ExitCode=Success
 basic command
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
 
@@ -547,7 +547,7 @@ ExitCode=Success
 basic command
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
 
@@ -662,10 +662,10 @@ This is a full description
 of this route map's behavior.
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -682,11 +682,11 @@ ExitCode=Success
 root
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-v[39m [36m--version[39m  [03mPrint version information and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 [1m[33mLatest available version is 1.1.0 (currently running 1.0.0), upgrade with "<upgrade-command>"[39m[22m
@@ -703,7 +703,7 @@ ExitCode=Success
 basic command
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
 [1m[33mLatest available version is 1.1.0 (currently running 1.0.0), upgrade with "<upgrade-command>"[39m[22m
@@ -750,11 +750,11 @@ ExitCode=Success
 root
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-v[39m [36m--version[39m  [03mPrint version information and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 [1m[33mLatest available version is 1.1.0 (currently running 1.0.0)[39m[22m
@@ -771,7 +771,7 @@ ExitCode=Success
 basic command
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
 [1m[33mLatest available version is 1.1.0 (currently running 1.0.0)[39m[22m
@@ -799,11 +799,11 @@ ExitCode=Success
 root
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-v[39m [36m--version[39m  [03mPrint version information and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -878,10 +878,10 @@ ExitCode=Success
 root route map
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36msub[39m  [03msub[23m
+  [01msub[32m  [03msub[23m
 
 :: STDERR
 
@@ -897,10 +897,10 @@ ExitCode=Success
 root route map
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36msub[39m  [03msub[23m
+  [01msub[32m  [03msub[23m
 
 :: STDERR
 
@@ -916,10 +916,10 @@ ExitCode=Success
 sub
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -935,10 +935,10 @@ ExitCode=Success
 sub
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -972,10 +972,10 @@ ExitCode=Success
 root route map
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36msub[39m  [03msub[23m
+  [01msub[32m  [03msub[23m
 
 :: STDERR
 
@@ -991,10 +991,10 @@ ExitCode=Success
 root route map
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36msub[39m  [03msub[23m
+  [01msub[32m  [03msub[23m
 
 :: STDERR
 
@@ -1014,10 +1014,10 @@ sub
   cli alias-bar
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -1037,10 +1037,10 @@ sub
   cli alias-bar
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -1060,10 +1060,10 @@ sub
   cli alias-bar
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -1083,10 +1083,10 @@ sub
   cli alias-bar
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -1106,10 +1106,10 @@ sub
   cli alias-bar
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -1152,10 +1152,10 @@ ExitCode=Success
 root route map
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36msub[39m  [03msub[23m
+  [01msub[32m  [03msub[23m
 
 :: STDERR
 
@@ -1171,10 +1171,10 @@ ExitCode=Success
 root route map
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36msub[39m  [03msub[23m
+  [01msub[32m  [03msub[23m
 
 :: STDERR
 
@@ -1192,11 +1192,11 @@ ExitCode=Success
 root route map
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [90m-H[39m [90m--helpAll[39m  [90mPrint help information (including hidden commands/flags) and exit[39m
 
 [1mCOMMANDS[22m
-  [36msub[39m        [03msub[23m
+  [01msub[32m        [03msub[23m
   [90msubHidden[39m  [90msubHidden[39m
 
 :: STDERR
@@ -1213,10 +1213,10 @@ ExitCode=Success
 subHidden
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -1232,10 +1232,10 @@ ExitCode=Success
 subHidden
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -1270,11 +1270,11 @@ ExitCode=Success
 root route map
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-H[39m [36m--helpAll[39m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
 [1mCOMMANDS[22m
-  [36msub[39m  [03msub[23m
+  [01msub[32m  [03msub[23m
 
 :: STDERR
 
@@ -1291,11 +1291,11 @@ ExitCode=Success
 root route map
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-H[39m [36m--helpAll[39m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
 [1mCOMMANDS[22m
-  [36msub[39m  [03msub[23m
+  [01msub[32m  [03msub[23m
 
 :: STDERR
 
@@ -1313,11 +1313,11 @@ ExitCode=Success
 root route map
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-H[39m [36m--helpAll[39m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
 [1mCOMMANDS[22m
-  [36msub[39m        [03msub[23m
+  [01msub[32m        [03msub[23m
   [90msubHidden[39m  [90msubHidden[39m
 
 :: STDERR
@@ -1335,11 +1335,11 @@ ExitCode=Success
 subHidden
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-H[39m [36m--helpAll[39m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -1356,11 +1356,11 @@ ExitCode=Success
 subHidden
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-H[39m [36m--helpAll[39m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -1395,11 +1395,11 @@ ExitCode=Success
 root route map
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-H[39m [36m--helpAll[39m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
 [1mCOMMANDS[22m
-  [36msub[39m  [03msub[23m
+  [01msub[32m  [03msub[23m
 
 :: STDERR
 
@@ -1416,11 +1416,11 @@ ExitCode=Success
 root route map
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-H[39m [36m--helpAll[39m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
 [1mCOMMANDS[22m
-  [36msub[39m  [03msub[23m
+  [01msub[32m  [03msub[23m
 
 :: STDERR
 
@@ -1438,11 +1438,11 @@ ExitCode=Success
 root route map
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-H[39m [36m--helpAll[39m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
 [1mCOMMANDS[22m
-  [36msub[39m        [03msub[23m
+  [01msub[32m        [03msub[23m
   [90msubHidden[39m  [90msubHidden[39m
 
 :: STDERR
@@ -1460,11 +1460,11 @@ ExitCode=Success
 subHidden
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-H[39m [36m--helpAll[39m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -1481,11 +1481,11 @@ ExitCode=Success
 subHidden
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-H[39m [36m--helpAll[39m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -1519,10 +1519,10 @@ ExitCode=Success
 root route map
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36msub[39m  [03msub[23m
+  [01msub[32m  [03msub[23m
 
 :: STDERR
 
@@ -1538,10 +1538,10 @@ ExitCode=Success
 root route map
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36msub[39m  [03msub[23m
+  [01msub[32m  [03msub[23m
 
 :: STDERR
 
@@ -1560,10 +1560,10 @@ sub
   cli sub
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -1582,10 +1582,10 @@ sub
   cli sub
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -1604,10 +1604,10 @@ sub
   cli alias
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -1651,11 +1651,11 @@ ExitCode=Success
 route map with default command brief
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mdefault[39m    [03mbasic command[23m
-  [36malternate[39m  [03mbasic command[23m
+  [01mdefault[32m    [03mbasic command[23m
+  [01malternate[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -1672,11 +1672,11 @@ ExitCode=Success
 route map with default command brief
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mdefault[39m    [03mbasic command[23m
-  [36malternate[39m  [03mbasic command[23m
+  [01mdefault[32m    [03mbasic command[23m
+  [01malternate[32m  [03mbasic command[23m
 
 :: STDERR
 
@@ -1695,7 +1695,7 @@ basic command
   cli 
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
 
@@ -1714,7 +1714,7 @@ basic command
   cli 
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 :: STDERR
 
@@ -1792,10 +1792,10 @@ This is a full description
 of this route map's behavior.
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mcommand[39m  [03mbasic command[23m
+  [01mcommand[32m  [03mbasic command[23m
 
 :: STDERR
 

--- a/packages/core/tests/__snapshots__/application.spec.ts.snap
+++ b/packages/core/tests/__snapshots__/application.spec.ts.snap
@@ -173,7 +173,7 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 :: STDERR
 
@@ -189,7 +189,7 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 :: STDERR
 
@@ -221,7 +221,7 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 :: STDERR
 
@@ -292,7 +292,7 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 :: STDERR
 
@@ -309,7 +309,7 @@ This is a full description
 of this command's behavior.
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 :: STDERR
 
@@ -325,7 +325,7 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 :: STDERR
 
@@ -351,8 +351,8 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
 
 :: STDERR
 [1m[33mLatest available version is 1.1.0 (currently running 1.0.0)[39m[22m
@@ -380,8 +380,8 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
 
 :: STDERR
 [1m[33mLatest available version is 1.1.0 (currently running 1.0.0)[39m[22m
@@ -474,10 +474,10 @@ ExitCode=Success
 root
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -493,10 +493,10 @@ ExitCode=Success
 root
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -512,10 +512,10 @@ ExitCode=Success
 root
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -531,7 +531,7 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 :: STDERR
 
@@ -547,7 +547,7 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 :: STDERR
 
@@ -662,10 +662,10 @@ This is a full description
 of this route map's behavior.
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -682,11 +682,11 @@ ExitCode=Success
 root
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 [1m[33mLatest available version is 1.1.0 (currently running 1.0.0), upgrade with "<upgrade-command>"[39m[22m
@@ -703,7 +703,7 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 :: STDERR
 [1m[33mLatest available version is 1.1.0 (currently running 1.0.0), upgrade with "<upgrade-command>"[39m[22m
@@ -750,11 +750,11 @@ ExitCode=Success
 root
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 [1m[33mLatest available version is 1.1.0 (currently running 1.0.0)[39m[22m
@@ -771,7 +771,7 @@ ExitCode=Success
 basic command
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 :: STDERR
 [1m[33mLatest available version is 1.1.0 (currently running 1.0.0)[39m[22m
@@ -799,11 +799,11 @@ ExitCode=Success
 root
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -878,10 +878,10 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01msub[32m  [03msub[23m
+  [1msub[32m  [003msub[00023m
 
 :: STDERR
 
@@ -897,10 +897,10 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01msub[32m  [03msub[23m
+  [1msub[32m  [003msub[00023m
 
 :: STDERR
 
@@ -916,10 +916,10 @@ ExitCode=Success
 sub
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -935,10 +935,10 @@ ExitCode=Success
 sub
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -972,10 +972,10 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01msub[32m  [03msub[23m
+  [1msub[32m  [003msub[00023m
 
 :: STDERR
 
@@ -991,10 +991,10 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01msub[32m  [03msub[23m
+  [1msub[32m  [003msub[00023m
 
 :: STDERR
 
@@ -1014,10 +1014,10 @@ sub
   cli alias-bar
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -1037,10 +1037,10 @@ sub
   cli alias-bar
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -1060,10 +1060,10 @@ sub
   cli alias-bar
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -1083,10 +1083,10 @@ sub
   cli alias-bar
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -1106,10 +1106,10 @@ sub
   cli alias-bar
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -1152,10 +1152,10 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01msub[32m  [03msub[23m
+  [1msub[32m  [003msub[00023m
 
 :: STDERR
 
@@ -1171,10 +1171,10 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01msub[32m  [03msub[23m
+  [1msub[32m  [003msub[00023m
 
 :: STDERR
 
@@ -1192,12 +1192,12 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [90m-H[39m [90m--helpAll[39m  [90mPrint help information (including hidden commands/flags) and exit[39m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [2m-H[22m [2m--helpAll[22m  [2;3mPrint help information (including hidden commands/flags) and exit[22;23m
 
 [4mCOMMANDS[24m
-  [01msub[32m        [03msub[23m
-  [90msubHidden[39m  [90msubHidden[39m
+  [1msub[32m        [003msub[00023m
+  [2msubHidden[22m  [2;3msubHidden[22;23m
 
 :: STDERR
 
@@ -1213,10 +1213,10 @@ ExitCode=Success
 subHidden
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -1232,10 +1232,10 @@ ExitCode=Success
 subHidden
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -1270,11 +1270,11 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
 
 [4mCOMMANDS[24m
-  [01msub[32m  [03msub[23m
+  [1msub[32m  [003msub[00023m
 
 :: STDERR
 
@@ -1291,11 +1291,11 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
 
 [4mCOMMANDS[24m
-  [01msub[32m  [03msub[23m
+  [1msub[32m  [003msub[00023m
 
 :: STDERR
 
@@ -1313,12 +1313,12 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
 
 [4mCOMMANDS[24m
-  [01msub[32m        [03msub[23m
-  [90msubHidden[39m  [90msubHidden[39m
+  [1msub[32m        [003msub[00023m
+  [2msubHidden[22m  [2;3msubHidden[22;23m
 
 :: STDERR
 
@@ -1335,11 +1335,11 @@ ExitCode=Success
 subHidden
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -1356,11 +1356,11 @@ ExitCode=Success
 subHidden
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -1395,11 +1395,11 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
 
 [4mCOMMANDS[24m
-  [01msub[32m  [03msub[23m
+  [1msub[32m  [003msub[00023m
 
 :: STDERR
 
@@ -1416,11 +1416,11 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
 
 [4mCOMMANDS[24m
-  [01msub[32m  [03msub[23m
+  [1msub[32m  [003msub[00023m
 
 :: STDERR
 
@@ -1438,12 +1438,12 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
 
 [4mCOMMANDS[24m
-  [01msub[32m        [03msub[23m
-  [90msubHidden[39m  [90msubHidden[39m
+  [1msub[32m        [003msub[00023m
+  [2msubHidden[22m  [2;3msubHidden[22;23m
 
 :: STDERR
 
@@ -1460,11 +1460,11 @@ ExitCode=Success
 subHidden
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -1481,11 +1481,11 @@ ExitCode=Success
 subHidden
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-H[22m [01m--helpAll[22m  [03mPrint help information (including hidden commands/flags) and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-H[22m [1m--helpAll[22m  [003mPrint help information (including hidden commands/flags) and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -1519,10 +1519,10 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01msub[32m  [03msub[23m
+  [1msub[32m  [003msub[00023m
 
 :: STDERR
 
@@ -1538,10 +1538,10 @@ ExitCode=Success
 root route map
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01msub[32m  [03msub[23m
+  [1msub[32m  [003msub[00023m
 
 :: STDERR
 
@@ -1560,10 +1560,10 @@ sub
   cli sub
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -1582,10 +1582,10 @@ sub
   cli sub
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -1604,10 +1604,10 @@ sub
   cli alias
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -1651,11 +1651,11 @@ ExitCode=Success
 route map with default command brief
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mdefault[32m    [03mbasic command[23m
-  [01malternate[32m  [03mbasic command[23m
+  [1mdefault[32m    [003mbasic command[00023m
+  [1malternate[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -1672,11 +1672,11 @@ ExitCode=Success
 route map with default command brief
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mdefault[32m    [03mbasic command[23m
-  [01malternate[32m  [03mbasic command[23m
+  [1mdefault[32m    [003mbasic command[00023m
+  [1malternate[32m  [003mbasic command[00023m
 
 :: STDERR
 
@@ -1695,7 +1695,7 @@ basic command
   cli 
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 :: STDERR
 
@@ -1714,7 +1714,7 @@ basic command
   cli 
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 :: STDERR
 
@@ -1792,10 +1792,10 @@ This is a full description
 of this route map's behavior.
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mcommand[32m  [03mbasic command[23m
+  [1mcommand[32m  [003mbasic command[00023m
 
 :: STDERR
 

--- a/packages/core/tests/parameter/flag/__snapshots__/formatting.spec.ts.snap
+++ b/packages/core/tests/parameter/flag/__snapshots__/formatting.spec.ts.snap
@@ -9,8 +9,8 @@ exports[`formatDocumentationForFlagParameters > boolean > hidden optional boolea
 
 exports[`formatDocumentationForFlagParameters > boolean > hidden optional boolean flag > with ANSI color 1`] = `
 [
-  "[36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m",
-  "[36m[39m   [36m--[39m      [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m",
+  "[01m[22m   [01m--[22m      [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -25,8 +25,8 @@ exports[`formatDocumentationForFlagParameters > boolean > hidden optional boolea
 exports[`formatDocumentationForFlagParameters > boolean > hidden optional boolean flag, help all > with ANSI color 1`] = `
 [
   "[90m[39m   [90m[--optionalBoolean/--noOptionalBoolean][39m  [90moptional boolean flag[39m",
-  "[36m-h[39m [36m --help[39m                                  [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m                                      [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m-h[22m [01m --help[22m                                  [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m                                      [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -40,9 +40,9 @@ exports[`formatDocumentationForFlagParameters > boolean > optional boolean flag 
 
 exports[`formatDocumentationForFlagParameters > boolean > optional boolean flag > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m[--optionalBoolean/--noOptionalBoolean][39m  [03moptional boolean flag[23m",
-  "[36m-h[39m [36m --help[39m                                  [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m                                      [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m[--optionalBoolean/--noOptionalBoolean][22m  [03moptional boolean flag[23m",
+  "[01m-h[22m [01m --help[22m                                  [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m                                      [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -56,9 +56,9 @@ exports[`formatDocumentationForFlagParameters > boolean > required boolean flag 
 
 exports[`formatDocumentationForFlagParameters > boolean > required boolean flag > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m--requiredBoolean/--noRequiredBoolean[39m  [03mrequired boolean flag[23m",
-  "[36m-h[39m [36m--help[39m                                 [03mPrint help information and exit[23m",
-  "[36m[39m   [36m--[39m                                     [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m--requiredBoolean/--noRequiredBoolean[22m  [03mrequired boolean flag[23m",
+  "[01m-h[22m [01m--help[22m                                 [03mPrint help information and exit[23m",
+  "[01m[22m   [01m--[22m                                     [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -72,9 +72,9 @@ exports[`formatDocumentationForFlagParameters > boolean > required boolean flag 
 
 exports[`formatDocumentationForFlagParameters > boolean > required boolean flag with default=false > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m[--requiredBoolean][39m  [03mrequired boolean flag[23m                                    [[90mdefault =[39m false]",
-  "[36m-h[39m [36m --help[39m              [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m                  [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m[--requiredBoolean][22m  [03mrequired boolean flag[23m                                    [[90mdefault =[39m false]",
+  "[01m-h[22m [01m --help[22m              [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m                  [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -88,9 +88,9 @@ exports[`formatDocumentationForFlagParameters > boolean > required boolean flag 
 
 exports[`formatDocumentationForFlagParameters > boolean > required boolean flag with default=true > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m[--requiredBoolean/--noRequiredBoolean][39m  [03mrequired boolean flag[23m                                    [[90mdefault =[39m true]",
-  "[36m-h[39m [36m --help[39m                                  [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m                                      [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m[--requiredBoolean/--noRequiredBoolean][22m  [03mrequired boolean flag[23m                                    [[90mdefault =[39m true]",
+  "[01m-h[22m [01m --help[22m                                  [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m                                      [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -104,9 +104,9 @@ exports[`formatDocumentationForFlagParameters > boolean > required boolean flag 
 
 exports[`formatDocumentationForFlagParameters > boolean > required boolean flag with default=true and withNegated=false > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m[--requiredBoolean][39m  [03mrequired boolean flag[23m                                    [[90mdefault =[39m true]",
-  "[36m-h[39m [36m --help[39m              [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m                  [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m[--requiredBoolean][22m  [03mrequired boolean flag[23m                                    [[90mdefault =[39m true]",
+  "[01m-h[22m [01m --help[22m              [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m                  [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -120,9 +120,9 @@ exports[`formatDocumentationForFlagParameters > enum > optional enum flag > no A
 
 exports[`formatDocumentationForFlagParameters > enum > optional enum flag > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m[--optionalEnum][39m  [03moptional enum flag[23m                                       [a|b|c]",
-  "[36m-h[39m [36m --help[39m           [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m               [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m[--optionalEnum][22m  [03moptional enum flag[23m                                       [a|b|c]",
+  "[01m-h[22m [01m --help[22m           [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m               [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -136,9 +136,9 @@ exports[`formatDocumentationForFlagParameters > enum > optional enum flag with d
 
 exports[`formatDocumentationForFlagParameters > enum > optional enum flag with default > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m[--optionalEnum][39m  [03moptional enum flag[23m                                       [a|b|c, [90mdefault =[39m b]",
-  "[36m-h[39m [36m --help[39m           [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m               [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m[--optionalEnum][22m  [03moptional enum flag[23m                                       [a|b|c, [90mdefault =[39m b]",
+  "[01m-h[22m [01m --help[22m           [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m               [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -152,9 +152,9 @@ exports[`formatDocumentationForFlagParameters > enum > required enum flag > no A
 
 exports[`formatDocumentationForFlagParameters > enum > required enum flag > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m--requiredEnum[39m  [03mrequired enum flag[23m                                       [a|b|c]",
-  "[36m-h[39m [36m--help[39m          [03mPrint help information and exit[23m",
-  "[36m[39m   [36m--[39m              [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m--requiredEnum[22m  [03mrequired enum flag[23m                                       [a|b|c]",
+  "[01m-h[22m [01m--help[22m          [03mPrint help information and exit[23m",
+  "[01m[22m   [01m--[22m              [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -168,9 +168,9 @@ exports[`formatDocumentationForFlagParameters > enum > required enum flag with d
 
 exports[`formatDocumentationForFlagParameters > enum > required enum flag with default > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m[--requiredEnum][39m  [03mrequired enum flag[23m                                       [a|b|c, [90mdefault =[39m b]",
-  "[36m-h[39m [36m --help[39m           [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m               [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m[--requiredEnum][22m  [03mrequired enum flag[23m                                       [a|b|c, [90mdefault =[39m b]",
+  "[01m-h[22m [01m --help[22m           [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m               [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -184,9 +184,9 @@ exports[`formatDocumentationForFlagParameters > enum > variadic enum flag with s
 
 exports[`formatDocumentationForFlagParameters > enum > variadic enum flag with separator and default > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m[--format][39m  [03mOutput format(s)[23m                                         [json|xml|yaml, [90mdefault =[39m json+yaml, [90mseparator =[39m +]",
-  "[36m-h[39m [36m --help[39m     [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m         [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m[--format][22m  [03mOutput format(s)[23m                                         [json|xml|yaml, [90mdefault =[39m json+yaml, [90mseparator =[39m +]",
+  "[01m-h[22m [01m --help[22m     [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m         [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -200,9 +200,9 @@ exports[`formatDocumentationForFlagParameters > enum > variadic enum flag withou
 
 exports[`formatDocumentationForFlagParameters > enum > variadic enum flag without separator and with default > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m[--format][39m  [03mOutput format(s)[23m                                         [json|xml|yaml, [90mdefault =[39m json yaml]",
-  "[36m-h[39m [36m --help[39m     [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m         [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m[--format][22m  [03mOutput format(s)[23m                                         [json|xml|yaml, [90mdefault =[39m json yaml]",
+  "[01m-h[22m [01m --help[22m     [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m         [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -215,8 +215,8 @@ exports[`formatDocumentationForFlagParameters > no flags > no ANSI color 1`] = `
 
 exports[`formatDocumentationForFlagParameters > no flags > with ANSI color 1`] = `
 [
-  "[36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m",
-  "[36m[39m   [36m--[39m      [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m",
+  "[01m[22m   [01m--[22m      [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -230,9 +230,9 @@ exports[`formatDocumentationForFlagParameters > parsed > flag with nonstandard c
 
 exports[`formatDocumentationForFlagParameters > parsed > flag with nonstandard character > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m--a.b.c_10[39m  [03mrequired parsed flag[23m",
-  "[36m-h[39m [36m--help[39m      [03mPrint help information and exit[23m",
-  "[36m[39m   [36m--[39m          [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m--a.b.c_10[22m  [03mrequired parsed flag[23m",
+  "[01m-h[22m [01m--help[22m      [03mPrint help information and exit[23m",
+  "[01m[22m   [01m--[22m          [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -246,9 +246,9 @@ exports[`formatDocumentationForFlagParameters > parsed > multipart flag > no ANS
 
 exports[`formatDocumentationForFlagParameters > parsed > multipart flag > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m--multi.part[39m  [03mrequired parsed flag[23m",
-  "[36m-h[39m [36m--help[39m        [03mPrint help information and exit[23m",
-  "[36m[39m   [36m--[39m            [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m--multi.part[22m  [03mrequired parsed flag[23m",
+  "[01m-h[22m [01m--help[22m        [03mPrint help information and exit[23m",
+  "[01m[22m   [01m--[22m            [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -264,11 +264,11 @@ exports[`formatDocumentationForFlagParameters > parsed > multiple parsed flags >
 
 exports[`formatDocumentationForFlagParameters > parsed > multiple parsed flags > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m--requiredParsed[39m                        [03mrequired parsed flag[23m",
-  "[36m[39m   [36m--requiredParsedWithLongerName[39m          [03mrequired parsed flag with longer name[23m",
-  "[36m[39m   [36m--required-parsed-with-kebab-case-name[39m  [03mrequired parsed flag with kebab-case name[23m",
-  "[36m-h[39m [36m--help[39m                                  [03mPrint help information and exit[23m",
-  "[36m[39m   [36m--[39m                                      [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m--requiredParsed[22m                        [03mrequired parsed flag[23m",
+  "[01m[22m   [01m--requiredParsedWithLongerName[22m          [03mrequired parsed flag with longer name[23m",
+  "[01m[22m   [01m--required-parsed-with-kebab-case-name[22m  [03mrequired parsed flag with kebab-case name[23m",
+  "[01m-h[22m [01m--help[22m                                  [03mPrint help information and exit[23m",
+  "[01m[22m   [01m--[22m                                      [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -282,9 +282,9 @@ exports[`formatDocumentationForFlagParameters > parsed > optional array parsed f
 
 exports[`formatDocumentationForFlagParameters > parsed > optional array parsed flag > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m[--optionalArrayParsed][39m  [03moptional array parsed flag[23m",
-  "[36m-h[39m [36m --help[39m                  [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m                      [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m[--optionalArrayParsed][22m  [03moptional array parsed flag[23m",
+  "[01m-h[22m [01m --help[22m                  [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m                      [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -298,9 +298,9 @@ exports[`formatDocumentationForFlagParameters > parsed > optional parsed flag > 
 
 exports[`formatDocumentationForFlagParameters > parsed > optional parsed flag > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m[--optionalParsed][39m  [03moptional parsed flag[23m",
-  "[36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m                 [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m[--optionalParsed][22m  [03moptional parsed flag[23m",
+  "[01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m                 [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -314,9 +314,9 @@ exports[`formatDocumentationForFlagParameters > parsed > optional parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > optional parsed flag with alias > with ANSI color 1`] = `
 [
-  "[36m-p[39m [36m[--optionalParsed][39m  [03moptional parsed flag[23m",
-  "[36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m                 [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m-p[22m [01m[--optionalParsed][22m  [03moptional parsed flag[23m",
+  "[01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m                 [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -330,9 +330,9 @@ exports[`formatDocumentationForFlagParameters > parsed > optional variadic parse
 
 exports[`formatDocumentationForFlagParameters > parsed > optional variadic parsed flag > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m[--optionalVariadicParsed]...[39m  [03moptional variadic parsed flag[23m",
-  "[36m-h[39m [36m --help[39m                        [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m                            [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m[--optionalVariadicParsed]...[22m  [03moptional variadic parsed flag[23m",
+  "[01m-h[22m [01m --help[22m                        [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m                            [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -346,9 +346,9 @@ exports[`formatDocumentationForFlagParameters > parsed > optional variadic parse
 
 exports[`formatDocumentationForFlagParameters > parsed > optional variadic parsed flag with default > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m[--variadicParsed]...[39m  [03moptional variadic parsed flag with default[23m               [[90mdefault =[39m foo bar]",
-  "[36m-h[39m [36m --help[39m                [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m                    [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m[--variadicParsed]...[22m  [03moptional variadic parsed flag with default[23m               [[90mdefault =[39m foo bar]",
+  "[01m-h[22m [01m --help[22m                [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m                    [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -362,9 +362,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required array parsed f
 
 exports[`formatDocumentationForFlagParameters > parsed > required array parsed flag > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m--requiredArrayParsed[39m  [03mrequired array parsed flag[23m",
-  "[36m-h[39m [36m--help[39m                 [03mPrint help information and exit[23m",
-  "[36m[39m   [36m--[39m                     [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m--requiredArrayParsed[22m  [03mrequired array parsed flag[23m",
+  "[01m-h[22m [01m--help[22m                 [03mPrint help information and exit[23m",
+  "[01m[22m   [01m--[22m                     [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -378,9 +378,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required parsed flag > 
 
 exports[`formatDocumentationForFlagParameters > parsed > required parsed flag > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m--requiredParsed[39m  [03mrequired parsed flag[23m",
-  "[36m-h[39m [36m--help[39m            [03mPrint help information and exit[23m",
-  "[36m[39m   [36m--[39m                [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m--requiredParsed[22m  [03mrequired parsed flag[23m",
+  "[01m-h[22m [01m--help[22m            [03mPrint help information and exit[23m",
+  "[01m[22m   [01m--[22m                [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -394,9 +394,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > required parsed flag with alias > with ANSI color 1`] = `
 [
-  "[36m-p[39m [36m--requiredParsed[39m  [03mrequired parsed flag[23m",
-  "[36m-h[39m [36m--help[39m            [03mPrint help information and exit[23m",
-  "[36m[39m   [36m--[39m                [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m-p[22m [01m--requiredParsed[22m  [03mrequired parsed flag[23m",
+  "[01m-h[22m [01m--help[22m            [03mPrint help information and exit[23m",
+  "[01m[22m   [01m--[22m                [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -410,9 +410,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > required parsed flag with default > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m[--requiredParsed][39m  [03mrequired parsed flag[23m                                     [[90mdefault =[39m ""]",
-  "[36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m                 [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m[--requiredParsed][22m  [03mrequired parsed flag[23m                                     [[90mdefault =[39m ""]",
+  "[01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m                 [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -425,8 +425,8 @@ exports[`formatDocumentationForFlagParameters > parsed > required parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > required parsed flag with default [hidden] > with ANSI color 1`] = `
 [
-  "[36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m",
-  "[36m[39m   [36m--[39m      [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m",
+  "[01m[22m   [01m--[22m      [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -441,8 +441,8 @@ exports[`formatDocumentationForFlagParameters > parsed > required parsed flag wi
 exports[`formatDocumentationForFlagParameters > parsed > required parsed flag with default [hidden], hide all > with ANSI color 1`] = `
 [
   "[90m[39m   [90m[--requiredParsed][39m  [90mrequired parsed flag[39m                                     [[90mdefault =[39m 100]",
-  "[36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m                 [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m                 [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -456,9 +456,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > required parsed flag with default and alias > with ANSI color 1`] = `
 [
-  "[36m-p[39m [36m[--requiredParsed][39m  [03mrequired parsed flag[23m                                     [[90mdefault =[39m 100]",
-  "[36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m                 [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m-p[22m [01m[--requiredParsed][22m  [03mrequired parsed flag[23m                                     [[90mdefault =[39m 100]",
+  "[01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m                 [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -472,9 +472,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required variadic parse
 
 exports[`formatDocumentationForFlagParameters > parsed > required variadic parsed flag > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m--requiredVariadicParsed...[39m  [03mrequired variadic parsed flag[23m",
-  "[36m-h[39m [36m--help[39m                       [03mPrint help information and exit[23m",
-  "[36m[39m   [36m--[39m                           [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m--requiredVariadicParsed...[22m  [03mrequired variadic parsed flag[23m",
+  "[01m-h[22m [01m--help[22m                       [03mPrint help information and exit[23m",
+  "[01m[22m   [01m--[22m                           [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -488,9 +488,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required variadic parse
 
 exports[`formatDocumentationForFlagParameters > parsed > required variadic parsed flag with default (long) > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m[--variadicParsed]...[39m  [03mrequired variadic parsed flag with long default[23m          [[90mdefault =[39m one two three four five]",
-  "[36m-h[39m [36m --help[39m                [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m                    [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m[--variadicParsed]...[22m  [03mrequired variadic parsed flag with long default[23m          [[90mdefault =[39m one two three four five]",
+  "[01m-h[22m [01m --help[22m                [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m                    [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -504,9 +504,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required variadic parse
 
 exports[`formatDocumentationForFlagParameters > parsed > required variadic parsed flag with empty default > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m[--variadicParsed]...[39m  [03mrequired variadic parsed flag with empty default[23m         [[90mdefault =[39m []]",
-  "[36m-h[39m [36m --help[39m                [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m                    [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m[--variadicParsed]...[22m  [03mrequired variadic parsed flag with empty default[23m         [[90mdefault =[39m []]",
+  "[01m-h[22m [01m --help[22m                [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m                    [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -520,9 +520,9 @@ exports[`formatDocumentationForFlagParameters > parsed > variadic parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > variadic parsed flag with separator > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m--variadicParsed...[39m  [03mvariadic parsed flag with separator[23m                      [[90mseparator =[39m ,]",
-  "[36m-h[39m [36m--help[39m               [03mPrint help information and exit[23m",
-  "[36m[39m   [36m--[39m                   [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m--variadicParsed...[22m  [03mvariadic parsed flag with separator[23m                      [[90mseparator =[39m ,]",
+  "[01m-h[22m [01m--help[22m               [03mPrint help information and exit[23m",
+  "[01m[22m   [01m--[22m                   [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;
 
@@ -536,8 +536,8 @@ exports[`formatDocumentationForFlagParameters > parsed > variadic parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > variadic parsed flag with separator and default > with ANSI color 1`] = `
 [
-  "[36m[39m   [36m[--variadicParsed]...[39m  [03mvariadic parsed flag with separator and default[23m          [[90mdefault =[39m json+xml, [90mseparator =[39m +]",
-  "[36m-h[39m [36m --help[39m                [03mPrint help information and exit[23m",
-  "[36m[39m   [36m --[39m                    [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[01m[22m   [01m[--variadicParsed]...[22m  [03mvariadic parsed flag with separator and default[23m          [[90mdefault =[39m json+xml, [90mseparator =[39m +]",
+  "[01m-h[22m [01m --help[22m                [03mPrint help information and exit[23m",
+  "[01m[22m   [01m --[22m                    [03mAll subsequent inputs should be interpreted as arguments[23m",
 ]
 `;

--- a/packages/core/tests/parameter/flag/__snapshots__/formatting.spec.ts.snap
+++ b/packages/core/tests/parameter/flag/__snapshots__/formatting.spec.ts.snap
@@ -9,8 +9,8 @@ exports[`formatDocumentationForFlagParameters > boolean > hidden optional boolea
 
 exports[`formatDocumentationForFlagParameters > boolean > hidden optional boolean flag > with ANSI color 1`] = `
 [
-  "[1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m--[22m      [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m--[22m      [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -25,8 +25,8 @@ exports[`formatDocumentationForFlagParameters > boolean > hidden optional boolea
 exports[`formatDocumentationForFlagParameters > boolean > hidden optional boolean flag, help all > with ANSI color 1`] = `
 [
   "[2m[22m   [2m[--optionalBoolean/--noOptionalBoolean][22m  [2;3moptional boolean flag[22;23m",
-  "[1m-h[22m [1m --help[22m                                  [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m                                      [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m-h[22m [1m --help[22m                                  [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m                                      [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -40,9 +40,9 @@ exports[`formatDocumentationForFlagParameters > boolean > optional boolean flag 
 
 exports[`formatDocumentationForFlagParameters > boolean > optional boolean flag > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m[--optionalBoolean/--noOptionalBoolean][22m  [003moptional boolean flag[00023m",
-  "[1m-h[22m [1m --help[22m                                  [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m                                      [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m[--optionalBoolean/--noOptionalBoolean][22m  [;;3moptional boolean flag[;;;23m",
+  "[1m-h[22m [1m --help[22m                                  [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m                                      [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -56,9 +56,9 @@ exports[`formatDocumentationForFlagParameters > boolean > required boolean flag 
 
 exports[`formatDocumentationForFlagParameters > boolean > required boolean flag > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m--requiredBoolean/--noRequiredBoolean[22m  [003mrequired boolean flag[00023m",
-  "[1m-h[22m [1m--help[22m                                 [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m--[22m                                     [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m--requiredBoolean/--noRequiredBoolean[22m  [;;3mrequired boolean flag[;;;23m",
+  "[1m-h[22m [1m--help[22m                                 [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m--[22m                                     [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -72,9 +72,9 @@ exports[`formatDocumentationForFlagParameters > boolean > required boolean flag 
 
 exports[`formatDocumentationForFlagParameters > boolean > required boolean flag with default=false > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m[--requiredBoolean][22m  [003mrequired boolean flag[00023m                                    [[2mdefault =[22m false]",
-  "[1m-h[22m [1m --help[22m              [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m                  [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m[--requiredBoolean][22m  [;;3mrequired boolean flag[;;;23m                                    [[2mdefault =[22m false]",
+  "[1m-h[22m [1m --help[22m              [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m                  [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -88,9 +88,9 @@ exports[`formatDocumentationForFlagParameters > boolean > required boolean flag 
 
 exports[`formatDocumentationForFlagParameters > boolean > required boolean flag with default=true > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m[--requiredBoolean/--noRequiredBoolean][22m  [003mrequired boolean flag[00023m                                    [[2mdefault =[22m true]",
-  "[1m-h[22m [1m --help[22m                                  [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m                                      [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m[--requiredBoolean/--noRequiredBoolean][22m  [;;3mrequired boolean flag[;;;23m                                    [[2mdefault =[22m true]",
+  "[1m-h[22m [1m --help[22m                                  [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m                                      [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -104,9 +104,9 @@ exports[`formatDocumentationForFlagParameters > boolean > required boolean flag 
 
 exports[`formatDocumentationForFlagParameters > boolean > required boolean flag with default=true and withNegated=false > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m[--requiredBoolean][22m  [003mrequired boolean flag[00023m                                    [[2mdefault =[22m true]",
-  "[1m-h[22m [1m --help[22m              [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m                  [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m[--requiredBoolean][22m  [;;3mrequired boolean flag[;;;23m                                    [[2mdefault =[22m true]",
+  "[1m-h[22m [1m --help[22m              [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m                  [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -120,9 +120,9 @@ exports[`formatDocumentationForFlagParameters > enum > optional enum flag > no A
 
 exports[`formatDocumentationForFlagParameters > enum > optional enum flag > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m[--optionalEnum][22m  [003moptional enum flag[00023m                                       [a|b|c]",
-  "[1m-h[22m [1m --help[22m           [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m               [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m[--optionalEnum][22m  [;;3moptional enum flag[;;;23m                                       [a|b|c]",
+  "[1m-h[22m [1m --help[22m           [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m               [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -136,9 +136,9 @@ exports[`formatDocumentationForFlagParameters > enum > optional enum flag with d
 
 exports[`formatDocumentationForFlagParameters > enum > optional enum flag with default > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m[--optionalEnum][22m  [003moptional enum flag[00023m                                       [a|b|c, [2mdefault =[22m b]",
-  "[1m-h[22m [1m --help[22m           [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m               [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m[--optionalEnum][22m  [;;3moptional enum flag[;;;23m                                       [a|b|c, [2mdefault =[22m b]",
+  "[1m-h[22m [1m --help[22m           [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m               [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -152,9 +152,9 @@ exports[`formatDocumentationForFlagParameters > enum > required enum flag > no A
 
 exports[`formatDocumentationForFlagParameters > enum > required enum flag > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m--requiredEnum[22m  [003mrequired enum flag[00023m                                       [a|b|c]",
-  "[1m-h[22m [1m--help[22m          [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m--[22m              [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m--requiredEnum[22m  [;;3mrequired enum flag[;;;23m                                       [a|b|c]",
+  "[1m-h[22m [1m--help[22m          [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m--[22m              [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -168,9 +168,9 @@ exports[`formatDocumentationForFlagParameters > enum > required enum flag with d
 
 exports[`formatDocumentationForFlagParameters > enum > required enum flag with default > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m[--requiredEnum][22m  [003mrequired enum flag[00023m                                       [a|b|c, [2mdefault =[22m b]",
-  "[1m-h[22m [1m --help[22m           [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m               [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m[--requiredEnum][22m  [;;3mrequired enum flag[;;;23m                                       [a|b|c, [2mdefault =[22m b]",
+  "[1m-h[22m [1m --help[22m           [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m               [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -184,9 +184,9 @@ exports[`formatDocumentationForFlagParameters > enum > variadic enum flag with s
 
 exports[`formatDocumentationForFlagParameters > enum > variadic enum flag with separator and default > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m[--format][22m  [003mOutput format(s)[00023m                                         [json|xml|yaml, [2mdefault =[22m json+yaml, [2mseparator =[22m +]",
-  "[1m-h[22m [1m --help[22m     [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m         [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m[--format][22m  [;;3mOutput format(s)[;;;23m                                         [json|xml|yaml, [2mdefault =[22m json+yaml, [2mseparator =[22m +]",
+  "[1m-h[22m [1m --help[22m     [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m         [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -200,9 +200,9 @@ exports[`formatDocumentationForFlagParameters > enum > variadic enum flag withou
 
 exports[`formatDocumentationForFlagParameters > enum > variadic enum flag without separator and with default > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m[--format][22m  [003mOutput format(s)[00023m                                         [json|xml|yaml, [2mdefault =[22m json yaml]",
-  "[1m-h[22m [1m --help[22m     [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m         [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m[--format][22m  [;;3mOutput format(s)[;;;23m                                         [json|xml|yaml, [2mdefault =[22m json yaml]",
+  "[1m-h[22m [1m --help[22m     [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m         [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -215,8 +215,8 @@ exports[`formatDocumentationForFlagParameters > no flags > no ANSI color 1`] = `
 
 exports[`formatDocumentationForFlagParameters > no flags > with ANSI color 1`] = `
 [
-  "[1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m--[22m      [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m--[22m      [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -230,9 +230,9 @@ exports[`formatDocumentationForFlagParameters > parsed > flag with nonstandard c
 
 exports[`formatDocumentationForFlagParameters > parsed > flag with nonstandard character > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m--a.b.c_10[22m  [003mrequired parsed flag[00023m",
-  "[1m-h[22m [1m--help[22m      [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m--[22m          [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m--a.b.c_10[22m  [;;3mrequired parsed flag[;;;23m",
+  "[1m-h[22m [1m--help[22m      [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m--[22m          [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -246,9 +246,9 @@ exports[`formatDocumentationForFlagParameters > parsed > multipart flag > no ANS
 
 exports[`formatDocumentationForFlagParameters > parsed > multipart flag > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m--multi.part[22m  [003mrequired parsed flag[00023m",
-  "[1m-h[22m [1m--help[22m        [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m--[22m            [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m--multi.part[22m  [;;3mrequired parsed flag[;;;23m",
+  "[1m-h[22m [1m--help[22m        [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m--[22m            [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -264,11 +264,11 @@ exports[`formatDocumentationForFlagParameters > parsed > multiple parsed flags >
 
 exports[`formatDocumentationForFlagParameters > parsed > multiple parsed flags > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m--requiredParsed[22m                        [003mrequired parsed flag[00023m",
-  "[1m[22m   [1m--requiredParsedWithLongerName[22m          [003mrequired parsed flag with longer name[00023m",
-  "[1m[22m   [1m--required-parsed-with-kebab-case-name[22m  [003mrequired parsed flag with kebab-case name[00023m",
-  "[1m-h[22m [1m--help[22m                                  [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m--[22m                                      [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m--requiredParsed[22m                        [;;3mrequired parsed flag[;;;23m",
+  "[1m[22m   [1m--requiredParsedWithLongerName[22m          [;;3mrequired parsed flag with longer name[;;;23m",
+  "[1m[22m   [1m--required-parsed-with-kebab-case-name[22m  [;;3mrequired parsed flag with kebab-case name[;;;23m",
+  "[1m-h[22m [1m--help[22m                                  [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m--[22m                                      [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -282,9 +282,9 @@ exports[`formatDocumentationForFlagParameters > parsed > optional array parsed f
 
 exports[`formatDocumentationForFlagParameters > parsed > optional array parsed flag > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m[--optionalArrayParsed][22m  [003moptional array parsed flag[00023m",
-  "[1m-h[22m [1m --help[22m                  [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m                      [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m[--optionalArrayParsed][22m  [;;3moptional array parsed flag[;;;23m",
+  "[1m-h[22m [1m --help[22m                  [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m                      [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -298,9 +298,9 @@ exports[`formatDocumentationForFlagParameters > parsed > optional parsed flag > 
 
 exports[`formatDocumentationForFlagParameters > parsed > optional parsed flag > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m[--optionalParsed][22m  [003moptional parsed flag[00023m",
-  "[1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m                 [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m[--optionalParsed][22m  [;;3moptional parsed flag[;;;23m",
+  "[1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m                 [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -314,9 +314,9 @@ exports[`formatDocumentationForFlagParameters > parsed > optional parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > optional parsed flag with alias > with ANSI color 1`] = `
 [
-  "[1m-p[22m [1m[--optionalParsed][22m  [003moptional parsed flag[00023m",
-  "[1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m                 [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m-p[22m [1m[--optionalParsed][22m  [;;3moptional parsed flag[;;;23m",
+  "[1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m                 [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -330,9 +330,9 @@ exports[`formatDocumentationForFlagParameters > parsed > optional variadic parse
 
 exports[`formatDocumentationForFlagParameters > parsed > optional variadic parsed flag > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m[--optionalVariadicParsed]...[22m  [003moptional variadic parsed flag[00023m",
-  "[1m-h[22m [1m --help[22m                        [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m                            [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m[--optionalVariadicParsed]...[22m  [;;3moptional variadic parsed flag[;;;23m",
+  "[1m-h[22m [1m --help[22m                        [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m                            [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -346,9 +346,9 @@ exports[`formatDocumentationForFlagParameters > parsed > optional variadic parse
 
 exports[`formatDocumentationForFlagParameters > parsed > optional variadic parsed flag with default > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m[--variadicParsed]...[22m  [003moptional variadic parsed flag with default[00023m               [[2mdefault =[22m foo bar]",
-  "[1m-h[22m [1m --help[22m                [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m                    [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m[--variadicParsed]...[22m  [;;3moptional variadic parsed flag with default[;;;23m               [[2mdefault =[22m foo bar]",
+  "[1m-h[22m [1m --help[22m                [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m                    [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -362,9 +362,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required array parsed f
 
 exports[`formatDocumentationForFlagParameters > parsed > required array parsed flag > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m--requiredArrayParsed[22m  [003mrequired array parsed flag[00023m",
-  "[1m-h[22m [1m--help[22m                 [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m--[22m                     [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m--requiredArrayParsed[22m  [;;3mrequired array parsed flag[;;;23m",
+  "[1m-h[22m [1m--help[22m                 [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m--[22m                     [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -378,9 +378,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required parsed flag > 
 
 exports[`formatDocumentationForFlagParameters > parsed > required parsed flag > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m--requiredParsed[22m  [003mrequired parsed flag[00023m",
-  "[1m-h[22m [1m--help[22m            [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m--[22m                [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m--requiredParsed[22m  [;;3mrequired parsed flag[;;;23m",
+  "[1m-h[22m [1m--help[22m            [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m--[22m                [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -394,9 +394,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > required parsed flag with alias > with ANSI color 1`] = `
 [
-  "[1m-p[22m [1m--requiredParsed[22m  [003mrequired parsed flag[00023m",
-  "[1m-h[22m [1m--help[22m            [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m--[22m                [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m-p[22m [1m--requiredParsed[22m  [;;3mrequired parsed flag[;;;23m",
+  "[1m-h[22m [1m--help[22m            [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m--[22m                [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -410,9 +410,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > required parsed flag with default > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m[--requiredParsed][22m  [003mrequired parsed flag[00023m                                     [[2mdefault =[22m ""]",
-  "[1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m                 [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m[--requiredParsed][22m  [;;3mrequired parsed flag[;;;23m                                     [[2mdefault =[22m ""]",
+  "[1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m                 [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -425,8 +425,8 @@ exports[`formatDocumentationForFlagParameters > parsed > required parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > required parsed flag with default [hidden] > with ANSI color 1`] = `
 [
-  "[1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m--[22m      [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m--[22m      [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -441,8 +441,8 @@ exports[`formatDocumentationForFlagParameters > parsed > required parsed flag wi
 exports[`formatDocumentationForFlagParameters > parsed > required parsed flag with default [hidden], hide all > with ANSI color 1`] = `
 [
   "[2m[22m   [2m[--requiredParsed][22m  [2;3mrequired parsed flag[22;23m                                     [[2mdefault =[22m 100]",
-  "[1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m                 [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m                 [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -456,9 +456,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > required parsed flag with default and alias > with ANSI color 1`] = `
 [
-  "[1m-p[22m [1m[--requiredParsed][22m  [003mrequired parsed flag[00023m                                     [[2mdefault =[22m 100]",
-  "[1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m                 [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m-p[22m [1m[--requiredParsed][22m  [;;3mrequired parsed flag[;;;23m                                     [[2mdefault =[22m 100]",
+  "[1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m                 [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -472,9 +472,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required variadic parse
 
 exports[`formatDocumentationForFlagParameters > parsed > required variadic parsed flag > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m--requiredVariadicParsed...[22m  [003mrequired variadic parsed flag[00023m",
-  "[1m-h[22m [1m--help[22m                       [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m--[22m                           [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m--requiredVariadicParsed...[22m  [;;3mrequired variadic parsed flag[;;;23m",
+  "[1m-h[22m [1m--help[22m                       [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m--[22m                           [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -488,9 +488,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required variadic parse
 
 exports[`formatDocumentationForFlagParameters > parsed > required variadic parsed flag with default (long) > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m[--variadicParsed]...[22m  [003mrequired variadic parsed flag with long default[00023m          [[2mdefault =[22m one two three four five]",
-  "[1m-h[22m [1m --help[22m                [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m                    [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m[--variadicParsed]...[22m  [;;3mrequired variadic parsed flag with long default[;;;23m          [[2mdefault =[22m one two three four five]",
+  "[1m-h[22m [1m --help[22m                [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m                    [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -504,9 +504,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required variadic parse
 
 exports[`formatDocumentationForFlagParameters > parsed > required variadic parsed flag with empty default > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m[--variadicParsed]...[22m  [003mrequired variadic parsed flag with empty default[00023m         [[2mdefault =[22m []]",
-  "[1m-h[22m [1m --help[22m                [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m                    [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m[--variadicParsed]...[22m  [;;3mrequired variadic parsed flag with empty default[;;;23m         [[2mdefault =[22m []]",
+  "[1m-h[22m [1m --help[22m                [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m                    [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -520,9 +520,9 @@ exports[`formatDocumentationForFlagParameters > parsed > variadic parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > variadic parsed flag with separator > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m--variadicParsed...[22m  [003mvariadic parsed flag with separator[00023m                      [[2mseparator =[22m ,]",
-  "[1m-h[22m [1m--help[22m               [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m--[22m                   [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m--variadicParsed...[22m  [;;3mvariadic parsed flag with separator[;;;23m                      [[2mseparator =[22m ,]",
+  "[1m-h[22m [1m--help[22m               [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m--[22m                   [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;
 
@@ -536,8 +536,8 @@ exports[`formatDocumentationForFlagParameters > parsed > variadic parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > variadic parsed flag with separator and default > with ANSI color 1`] = `
 [
-  "[1m[22m   [1m[--variadicParsed]...[22m  [003mvariadic parsed flag with separator and default[00023m          [[2mdefault =[22m json+xml, [2mseparator =[22m +]",
-  "[1m-h[22m [1m --help[22m                [003mPrint help information and exit[00023m",
-  "[1m[22m   [1m --[22m                    [003mAll subsequent inputs should be interpreted as arguments[00023m",
+  "[1m[22m   [1m[--variadicParsed]...[22m  [;;3mvariadic parsed flag with separator and default[;;;23m          [[2mdefault =[22m json+xml, [2mseparator =[22m +]",
+  "[1m-h[22m [1m --help[22m                [;;3mPrint help information and exit[;;;23m",
+  "[1m[22m   [1m --[22m                    [;;3mAll subsequent inputs should be interpreted as arguments[;;;23m",
 ]
 `;

--- a/packages/core/tests/parameter/flag/__snapshots__/formatting.spec.ts.snap
+++ b/packages/core/tests/parameter/flag/__snapshots__/formatting.spec.ts.snap
@@ -9,8 +9,8 @@ exports[`formatDocumentationForFlagParameters > boolean > hidden optional boolea
 
 exports[`formatDocumentationForFlagParameters > boolean > hidden optional boolean flag > with ANSI color 1`] = `
 [
-  "[01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m",
-  "[01m[22m   [01m--[22m      [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m--[22m      [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -24,9 +24,9 @@ exports[`formatDocumentationForFlagParameters > boolean > hidden optional boolea
 
 exports[`formatDocumentationForFlagParameters > boolean > hidden optional boolean flag, help all > with ANSI color 1`] = `
 [
-  "[90m[39m   [90m[--optionalBoolean/--noOptionalBoolean][39m  [90moptional boolean flag[39m",
-  "[01m-h[22m [01m --help[22m                                  [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m                                      [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[2m[22m   [2m[--optionalBoolean/--noOptionalBoolean][22m  [2;3moptional boolean flag[22;23m",
+  "[1m-h[22m [1m --help[22m                                  [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m                                      [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -40,9 +40,9 @@ exports[`formatDocumentationForFlagParameters > boolean > optional boolean flag 
 
 exports[`formatDocumentationForFlagParameters > boolean > optional boolean flag > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m[--optionalBoolean/--noOptionalBoolean][22m  [03moptional boolean flag[23m",
-  "[01m-h[22m [01m --help[22m                                  [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m                                      [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m[--optionalBoolean/--noOptionalBoolean][22m  [003moptional boolean flag[00023m",
+  "[1m-h[22m [1m --help[22m                                  [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m                                      [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -56,9 +56,9 @@ exports[`formatDocumentationForFlagParameters > boolean > required boolean flag 
 
 exports[`formatDocumentationForFlagParameters > boolean > required boolean flag > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m--requiredBoolean/--noRequiredBoolean[22m  [03mrequired boolean flag[23m",
-  "[01m-h[22m [01m--help[22m                                 [03mPrint help information and exit[23m",
-  "[01m[22m   [01m--[22m                                     [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m--requiredBoolean/--noRequiredBoolean[22m  [003mrequired boolean flag[00023m",
+  "[1m-h[22m [1m--help[22m                                 [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m--[22m                                     [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -72,9 +72,9 @@ exports[`formatDocumentationForFlagParameters > boolean > required boolean flag 
 
 exports[`formatDocumentationForFlagParameters > boolean > required boolean flag with default=false > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m[--requiredBoolean][22m  [03mrequired boolean flag[23m                                    [[90mdefault =[39m false]",
-  "[01m-h[22m [01m --help[22m              [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m                  [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m[--requiredBoolean][22m  [003mrequired boolean flag[00023m                                    [[2mdefault =[22m false]",
+  "[1m-h[22m [1m --help[22m              [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m                  [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -88,9 +88,9 @@ exports[`formatDocumentationForFlagParameters > boolean > required boolean flag 
 
 exports[`formatDocumentationForFlagParameters > boolean > required boolean flag with default=true > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m[--requiredBoolean/--noRequiredBoolean][22m  [03mrequired boolean flag[23m                                    [[90mdefault =[39m true]",
-  "[01m-h[22m [01m --help[22m                                  [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m                                      [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m[--requiredBoolean/--noRequiredBoolean][22m  [003mrequired boolean flag[00023m                                    [[2mdefault =[22m true]",
+  "[1m-h[22m [1m --help[22m                                  [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m                                      [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -104,9 +104,9 @@ exports[`formatDocumentationForFlagParameters > boolean > required boolean flag 
 
 exports[`formatDocumentationForFlagParameters > boolean > required boolean flag with default=true and withNegated=false > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m[--requiredBoolean][22m  [03mrequired boolean flag[23m                                    [[90mdefault =[39m true]",
-  "[01m-h[22m [01m --help[22m              [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m                  [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m[--requiredBoolean][22m  [003mrequired boolean flag[00023m                                    [[2mdefault =[22m true]",
+  "[1m-h[22m [1m --help[22m              [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m                  [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -120,9 +120,9 @@ exports[`formatDocumentationForFlagParameters > enum > optional enum flag > no A
 
 exports[`formatDocumentationForFlagParameters > enum > optional enum flag > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m[--optionalEnum][22m  [03moptional enum flag[23m                                       [a|b|c]",
-  "[01m-h[22m [01m --help[22m           [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m               [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m[--optionalEnum][22m  [003moptional enum flag[00023m                                       [a|b|c]",
+  "[1m-h[22m [1m --help[22m           [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m               [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -136,9 +136,9 @@ exports[`formatDocumentationForFlagParameters > enum > optional enum flag with d
 
 exports[`formatDocumentationForFlagParameters > enum > optional enum flag with default > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m[--optionalEnum][22m  [03moptional enum flag[23m                                       [a|b|c, [90mdefault =[39m b]",
-  "[01m-h[22m [01m --help[22m           [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m               [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m[--optionalEnum][22m  [003moptional enum flag[00023m                                       [a|b|c, [2mdefault =[22m b]",
+  "[1m-h[22m [1m --help[22m           [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m               [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -152,9 +152,9 @@ exports[`formatDocumentationForFlagParameters > enum > required enum flag > no A
 
 exports[`formatDocumentationForFlagParameters > enum > required enum flag > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m--requiredEnum[22m  [03mrequired enum flag[23m                                       [a|b|c]",
-  "[01m-h[22m [01m--help[22m          [03mPrint help information and exit[23m",
-  "[01m[22m   [01m--[22m              [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m--requiredEnum[22m  [003mrequired enum flag[00023m                                       [a|b|c]",
+  "[1m-h[22m [1m--help[22m          [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m--[22m              [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -168,9 +168,9 @@ exports[`formatDocumentationForFlagParameters > enum > required enum flag with d
 
 exports[`formatDocumentationForFlagParameters > enum > required enum flag with default > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m[--requiredEnum][22m  [03mrequired enum flag[23m                                       [a|b|c, [90mdefault =[39m b]",
-  "[01m-h[22m [01m --help[22m           [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m               [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m[--requiredEnum][22m  [003mrequired enum flag[00023m                                       [a|b|c, [2mdefault =[22m b]",
+  "[1m-h[22m [1m --help[22m           [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m               [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -184,9 +184,9 @@ exports[`formatDocumentationForFlagParameters > enum > variadic enum flag with s
 
 exports[`formatDocumentationForFlagParameters > enum > variadic enum flag with separator and default > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m[--format][22m  [03mOutput format(s)[23m                                         [json|xml|yaml, [90mdefault =[39m json+yaml, [90mseparator =[39m +]",
-  "[01m-h[22m [01m --help[22m     [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m         [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m[--format][22m  [003mOutput format(s)[00023m                                         [json|xml|yaml, [2mdefault =[22m json+yaml, [2mseparator =[22m +]",
+  "[1m-h[22m [1m --help[22m     [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m         [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -200,9 +200,9 @@ exports[`formatDocumentationForFlagParameters > enum > variadic enum flag withou
 
 exports[`formatDocumentationForFlagParameters > enum > variadic enum flag without separator and with default > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m[--format][22m  [03mOutput format(s)[23m                                         [json|xml|yaml, [90mdefault =[39m json yaml]",
-  "[01m-h[22m [01m --help[22m     [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m         [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m[--format][22m  [003mOutput format(s)[00023m                                         [json|xml|yaml, [2mdefault =[22m json yaml]",
+  "[1m-h[22m [1m --help[22m     [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m         [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -215,8 +215,8 @@ exports[`formatDocumentationForFlagParameters > no flags > no ANSI color 1`] = `
 
 exports[`formatDocumentationForFlagParameters > no flags > with ANSI color 1`] = `
 [
-  "[01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m",
-  "[01m[22m   [01m--[22m      [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m--[22m      [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -230,9 +230,9 @@ exports[`formatDocumentationForFlagParameters > parsed > flag with nonstandard c
 
 exports[`formatDocumentationForFlagParameters > parsed > flag with nonstandard character > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m--a.b.c_10[22m  [03mrequired parsed flag[23m",
-  "[01m-h[22m [01m--help[22m      [03mPrint help information and exit[23m",
-  "[01m[22m   [01m--[22m          [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m--a.b.c_10[22m  [003mrequired parsed flag[00023m",
+  "[1m-h[22m [1m--help[22m      [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m--[22m          [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -246,9 +246,9 @@ exports[`formatDocumentationForFlagParameters > parsed > multipart flag > no ANS
 
 exports[`formatDocumentationForFlagParameters > parsed > multipart flag > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m--multi.part[22m  [03mrequired parsed flag[23m",
-  "[01m-h[22m [01m--help[22m        [03mPrint help information and exit[23m",
-  "[01m[22m   [01m--[22m            [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m--multi.part[22m  [003mrequired parsed flag[00023m",
+  "[1m-h[22m [1m--help[22m        [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m--[22m            [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -264,11 +264,11 @@ exports[`formatDocumentationForFlagParameters > parsed > multiple parsed flags >
 
 exports[`formatDocumentationForFlagParameters > parsed > multiple parsed flags > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m--requiredParsed[22m                        [03mrequired parsed flag[23m",
-  "[01m[22m   [01m--requiredParsedWithLongerName[22m          [03mrequired parsed flag with longer name[23m",
-  "[01m[22m   [01m--required-parsed-with-kebab-case-name[22m  [03mrequired parsed flag with kebab-case name[23m",
-  "[01m-h[22m [01m--help[22m                                  [03mPrint help information and exit[23m",
-  "[01m[22m   [01m--[22m                                      [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m--requiredParsed[22m                        [003mrequired parsed flag[00023m",
+  "[1m[22m   [1m--requiredParsedWithLongerName[22m          [003mrequired parsed flag with longer name[00023m",
+  "[1m[22m   [1m--required-parsed-with-kebab-case-name[22m  [003mrequired parsed flag with kebab-case name[00023m",
+  "[1m-h[22m [1m--help[22m                                  [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m--[22m                                      [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -282,9 +282,9 @@ exports[`formatDocumentationForFlagParameters > parsed > optional array parsed f
 
 exports[`formatDocumentationForFlagParameters > parsed > optional array parsed flag > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m[--optionalArrayParsed][22m  [03moptional array parsed flag[23m",
-  "[01m-h[22m [01m --help[22m                  [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m                      [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m[--optionalArrayParsed][22m  [003moptional array parsed flag[00023m",
+  "[1m-h[22m [1m --help[22m                  [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m                      [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -298,9 +298,9 @@ exports[`formatDocumentationForFlagParameters > parsed > optional parsed flag > 
 
 exports[`formatDocumentationForFlagParameters > parsed > optional parsed flag > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m[--optionalParsed][22m  [03moptional parsed flag[23m",
-  "[01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m                 [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m[--optionalParsed][22m  [003moptional parsed flag[00023m",
+  "[1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m                 [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -314,9 +314,9 @@ exports[`formatDocumentationForFlagParameters > parsed > optional parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > optional parsed flag with alias > with ANSI color 1`] = `
 [
-  "[01m-p[22m [01m[--optionalParsed][22m  [03moptional parsed flag[23m",
-  "[01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m                 [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m-p[22m [1m[--optionalParsed][22m  [003moptional parsed flag[00023m",
+  "[1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m                 [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -330,9 +330,9 @@ exports[`formatDocumentationForFlagParameters > parsed > optional variadic parse
 
 exports[`formatDocumentationForFlagParameters > parsed > optional variadic parsed flag > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m[--optionalVariadicParsed]...[22m  [03moptional variadic parsed flag[23m",
-  "[01m-h[22m [01m --help[22m                        [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m                            [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m[--optionalVariadicParsed]...[22m  [003moptional variadic parsed flag[00023m",
+  "[1m-h[22m [1m --help[22m                        [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m                            [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -346,9 +346,9 @@ exports[`formatDocumentationForFlagParameters > parsed > optional variadic parse
 
 exports[`formatDocumentationForFlagParameters > parsed > optional variadic parsed flag with default > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m[--variadicParsed]...[22m  [03moptional variadic parsed flag with default[23m               [[90mdefault =[39m foo bar]",
-  "[01m-h[22m [01m --help[22m                [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m                    [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m[--variadicParsed]...[22m  [003moptional variadic parsed flag with default[00023m               [[2mdefault =[22m foo bar]",
+  "[1m-h[22m [1m --help[22m                [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m                    [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -362,9 +362,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required array parsed f
 
 exports[`formatDocumentationForFlagParameters > parsed > required array parsed flag > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m--requiredArrayParsed[22m  [03mrequired array parsed flag[23m",
-  "[01m-h[22m [01m--help[22m                 [03mPrint help information and exit[23m",
-  "[01m[22m   [01m--[22m                     [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m--requiredArrayParsed[22m  [003mrequired array parsed flag[00023m",
+  "[1m-h[22m [1m--help[22m                 [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m--[22m                     [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -378,9 +378,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required parsed flag > 
 
 exports[`formatDocumentationForFlagParameters > parsed > required parsed flag > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m--requiredParsed[22m  [03mrequired parsed flag[23m",
-  "[01m-h[22m [01m--help[22m            [03mPrint help information and exit[23m",
-  "[01m[22m   [01m--[22m                [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m--requiredParsed[22m  [003mrequired parsed flag[00023m",
+  "[1m-h[22m [1m--help[22m            [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m--[22m                [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -394,9 +394,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > required parsed flag with alias > with ANSI color 1`] = `
 [
-  "[01m-p[22m [01m--requiredParsed[22m  [03mrequired parsed flag[23m",
-  "[01m-h[22m [01m--help[22m            [03mPrint help information and exit[23m",
-  "[01m[22m   [01m--[22m                [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m-p[22m [1m--requiredParsed[22m  [003mrequired parsed flag[00023m",
+  "[1m-h[22m [1m--help[22m            [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m--[22m                [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -410,9 +410,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > required parsed flag with default > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m[--requiredParsed][22m  [03mrequired parsed flag[23m                                     [[90mdefault =[39m ""]",
-  "[01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m                 [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m[--requiredParsed][22m  [003mrequired parsed flag[00023m                                     [[2mdefault =[22m ""]",
+  "[1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m                 [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -425,8 +425,8 @@ exports[`formatDocumentationForFlagParameters > parsed > required parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > required parsed flag with default [hidden] > with ANSI color 1`] = `
 [
-  "[01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m",
-  "[01m[22m   [01m--[22m      [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m--[22m      [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -440,9 +440,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > required parsed flag with default [hidden], hide all > with ANSI color 1`] = `
 [
-  "[90m[39m   [90m[--requiredParsed][39m  [90mrequired parsed flag[39m                                     [[90mdefault =[39m 100]",
-  "[01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m                 [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[2m[22m   [2m[--requiredParsed][22m  [2;3mrequired parsed flag[22;23m                                     [[2mdefault =[22m 100]",
+  "[1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m                 [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -456,9 +456,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > required parsed flag with default and alias > with ANSI color 1`] = `
 [
-  "[01m-p[22m [01m[--requiredParsed][22m  [03mrequired parsed flag[23m                                     [[90mdefault =[39m 100]",
-  "[01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m                 [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m-p[22m [1m[--requiredParsed][22m  [003mrequired parsed flag[00023m                                     [[2mdefault =[22m 100]",
+  "[1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m                 [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -472,9 +472,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required variadic parse
 
 exports[`formatDocumentationForFlagParameters > parsed > required variadic parsed flag > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m--requiredVariadicParsed...[22m  [03mrequired variadic parsed flag[23m",
-  "[01m-h[22m [01m--help[22m                       [03mPrint help information and exit[23m",
-  "[01m[22m   [01m--[22m                           [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m--requiredVariadicParsed...[22m  [003mrequired variadic parsed flag[00023m",
+  "[1m-h[22m [1m--help[22m                       [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m--[22m                           [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -488,9 +488,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required variadic parse
 
 exports[`formatDocumentationForFlagParameters > parsed > required variadic parsed flag with default (long) > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m[--variadicParsed]...[22m  [03mrequired variadic parsed flag with long default[23m          [[90mdefault =[39m one two three four five]",
-  "[01m-h[22m [01m --help[22m                [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m                    [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m[--variadicParsed]...[22m  [003mrequired variadic parsed flag with long default[00023m          [[2mdefault =[22m one two three four five]",
+  "[1m-h[22m [1m --help[22m                [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m                    [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -504,9 +504,9 @@ exports[`formatDocumentationForFlagParameters > parsed > required variadic parse
 
 exports[`formatDocumentationForFlagParameters > parsed > required variadic parsed flag with empty default > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m[--variadicParsed]...[22m  [03mrequired variadic parsed flag with empty default[23m         [[90mdefault =[39m []]",
-  "[01m-h[22m [01m --help[22m                [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m                    [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m[--variadicParsed]...[22m  [003mrequired variadic parsed flag with empty default[00023m         [[2mdefault =[22m []]",
+  "[1m-h[22m [1m --help[22m                [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m                    [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -520,9 +520,9 @@ exports[`formatDocumentationForFlagParameters > parsed > variadic parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > variadic parsed flag with separator > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m--variadicParsed...[22m  [03mvariadic parsed flag with separator[23m                      [[90mseparator =[39m ,]",
-  "[01m-h[22m [01m--help[22m               [03mPrint help information and exit[23m",
-  "[01m[22m   [01m--[22m                   [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m--variadicParsed...[22m  [003mvariadic parsed flag with separator[00023m                      [[2mseparator =[22m ,]",
+  "[1m-h[22m [1m--help[22m               [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m--[22m                   [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;
 
@@ -536,8 +536,8 @@ exports[`formatDocumentationForFlagParameters > parsed > variadic parsed flag wi
 
 exports[`formatDocumentationForFlagParameters > parsed > variadic parsed flag with separator and default > with ANSI color 1`] = `
 [
-  "[01m[22m   [01m[--variadicParsed]...[22m  [03mvariadic parsed flag with separator and default[23m          [[90mdefault =[39m json+xml, [90mseparator =[39m +]",
-  "[01m-h[22m [01m --help[22m                [03mPrint help information and exit[23m",
-  "[01m[22m   [01m --[22m                    [03mAll subsequent inputs should be interpreted as arguments[23m",
+  "[1m[22m   [1m[--variadicParsed]...[22m  [003mvariadic parsed flag with separator and default[00023m          [[2mdefault =[22m json+xml, [2mseparator =[22m +]",
+  "[1m-h[22m [1m --help[22m                [003mPrint help information and exit[00023m",
+  "[1m[22m   [1m --[22m                    [003mAll subsequent inputs should be interpreted as arguments[00023m",
 ]
 `;

--- a/packages/core/tests/parameter/flag/formatting.spec.ts
+++ b/packages/core/tests/parameter/flag/formatting.spec.ts
@@ -1,5 +1,6 @@
 // Copyright 2024 Bloomberg Finance L.P.
 // Distributed under the terms of the Apache 2.0 license.
+import { stripVTControlCharacters } from "node:util";
 import { describe, expect, it } from "vitest";
 import { type CommandContext, text_en, type TypedCommandParameters } from "../../../src";
 // eslint-disable-next-line no-restricted-imports
@@ -8,7 +9,6 @@ import { formatDocumentationForFlagParameters } from "../../../src/parameter/fla
 import type { BaseArgs } from "../../../src/parameter/positional/types";
 // eslint-disable-next-line no-restricted-imports
 import type { HelpFormattingArguments } from "../../../src/routing/types";
-import { stripAnsiCodes } from "../../util/ansi";
 
 type DocumentationArgs = Omit<HelpFormattingArguments, "prefix" | "ansiColor">;
 
@@ -48,7 +48,7 @@ function compareDocumentationToBaseline<FLAGS extends Readonly<Record<string, un
                 ansiColor: true,
             },
         );
-        const linesWithAnsiColorStrippedOut = linesWithAnsiColor.map(stripAnsiCodes);
+        const linesWithAnsiColorStrippedOut = linesWithAnsiColor.map(stripVTControlCharacters);
         const linesWithoutAnsiColor = formatDocumentationForFlagParameters(
             parameters.flags ?? {},
             parameters.aliases ?? {},
@@ -880,14 +880,16 @@ describe("formatDocumentationForFlagParameters", () => {
             ...defaultArgs,
             ansiColor: true,
             includeHidden: true,
-        }).map(stripAnsiCodes);
+        }).map(stripVTControlCharacters);
         const hiddenLines = formatDocumentationForFlagParameters(hiddenFlags, aliases, {
             ...defaultArgs,
             ansiColor: true,
             includeHidden: true,
-        }).map(stripAnsiCodes);
+        }).map(stripVTControlCharacters);
 
         // THEN
+        console.log(JSON.stringify(publicLines));
+        console.log(JSON.stringify(hiddenLines));
         expect(publicLines).to.deep.equal(hiddenLines);
     });
 });

--- a/packages/core/tests/parameter/positional/__snapshots__/formatting.spec.ts.snap
+++ b/packages/core/tests/parameter/positional/__snapshots__/formatting.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`formatDocumentationForPositionalParameters > homogenous array of positi
 
 exports[`formatDocumentationForPositionalParameters > homogenous array of positional parameters > with ANSI color 1`] = `
 [
-  "[36mparsed...[39m  [3mrequired positional parameter[23m",
+  "[01mparsed...[22m  [3mrequired positional parameter[23m",
 ]
 `;
 
@@ -22,9 +22,9 @@ exports[`formatDocumentationForPositionalParameters > tuple of multiple position
 
 exports[`formatDocumentationForPositionalParameters > tuple of multiple positional parameters > with ANSI color 1`] = `
 [
-  "[36mparsed[39m             [3mrequired positional parameter[23m",
-  "[36mparsedLonger[39m       [3mrequired positional parameter with longer placeholder[23m",
-  "[36mparsed-kebab-case[39m  [3mrequired positional parameter with kebab-case placeholder[23m",
+  "[1mparsed[22m             [3mrequired positional parameter[23m",
+  "[1mparsedLonger[22m       [3mrequired positional parameter with longer placeholder[23m",
+  "[1mparsed-kebab-case[22m  [3mrequired positional parameter with kebab-case placeholder[23m",
 ]
 `;
 
@@ -36,7 +36,7 @@ exports[`formatDocumentationForPositionalParameters > tuple of one optional posi
 
 exports[`formatDocumentationForPositionalParameters > tuple of one optional positional parameter > with ANSI color 1`] = `
 [
-  "[36m[parsed][39m  [3moptional positional parameter[23m",
+  "[1m[parsed][22m  [3moptional positional parameter[23m",
 ]
 `;
 
@@ -48,7 +48,7 @@ exports[`formatDocumentationForPositionalParameters > tuple of one optional posi
 
 exports[`formatDocumentationForPositionalParameters > tuple of one optional positional parameter with default > with ANSI color 1`] = `
 [
-  "[36m[parsed][39m  [3moptional positional parameter[23m [[90mdefault =[39m 1001]",
+  "[1m[parsed][22m  [3moptional positional parameter[23m [[90mdefault =[39m 1001]",
 ]
 `;
 
@@ -60,7 +60,7 @@ exports[`formatDocumentationForPositionalParameters > tuple of one positional pa
 
 exports[`formatDocumentationForPositionalParameters > tuple of one positional parameter with default > with ANSI color 1`] = `
 [
-  "[36mparsed[39m  [3mrequired positional parameter[23m [[90mdefault =[39m 1001]",
+  "[1mparsed[22m  [3mrequired positional parameter[23m [[90mdefault =[39m 1001]",
 ]
 `;
 
@@ -72,7 +72,7 @@ exports[`formatDocumentationForPositionalParameters > tuple of one positional pa
 
 exports[`formatDocumentationForPositionalParameters > tuple of one positional parameter with default, with alt text > with ANSI color 1`] = `
 [
-  "[36mparsed[39m  [3mrequired positional parameter[23m [[90mdef =[39m 1001]",
+  "[1mparsed[22m  [3mrequired positional parameter[23m [[90mdef =[39m 1001]",
 ]
 `;
 
@@ -84,7 +84,7 @@ exports[`formatDocumentationForPositionalParameters > tuple of one required posi
 
 exports[`formatDocumentationForPositionalParameters > tuple of one required positional parameter > with ANSI color 1`] = `
 [
-  "[36mparsed[39m  [3mrequired positional parameter[23m",
+  "[1mparsed[22m  [3mrequired positional parameter[23m",
 ]
 `;
 

--- a/packages/core/tests/parameter/positional/__snapshots__/formatting.spec.ts.snap
+++ b/packages/core/tests/parameter/positional/__snapshots__/formatting.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`formatDocumentationForPositionalParameters > homogenous array of positi
 
 exports[`formatDocumentationForPositionalParameters > homogenous array of positional parameters > with ANSI color 1`] = `
 [
-  "[01mparsed...[22m  [3mrequired positional parameter[23m",
+  "[1mparsed...[22m  [3mrequired positional parameter[23m",
 ]
 `;
 
@@ -48,7 +48,7 @@ exports[`formatDocumentationForPositionalParameters > tuple of one optional posi
 
 exports[`formatDocumentationForPositionalParameters > tuple of one optional positional parameter with default > with ANSI color 1`] = `
 [
-  "[1m[parsed][22m  [3moptional positional parameter[23m [[90mdefault =[39m 1001]",
+  "[1m[parsed][22m  [3moptional positional parameter[23m [[2mdefault =[22m 1001]",
 ]
 `;
 
@@ -60,7 +60,7 @@ exports[`formatDocumentationForPositionalParameters > tuple of one positional pa
 
 exports[`formatDocumentationForPositionalParameters > tuple of one positional parameter with default > with ANSI color 1`] = `
 [
-  "[1mparsed[22m  [3mrequired positional parameter[23m [[90mdefault =[39m 1001]",
+  "[1mparsed[22m  [3mrequired positional parameter[23m [[2mdefault =[22m 1001]",
 ]
 `;
 
@@ -72,7 +72,7 @@ exports[`formatDocumentationForPositionalParameters > tuple of one positional pa
 
 exports[`formatDocumentationForPositionalParameters > tuple of one positional parameter with default, with alt text > with ANSI color 1`] = `
 [
-  "[1mparsed[22m  [3mrequired positional parameter[23m [[90mdef =[39m 1001]",
+  "[1mparsed[22m  [3mrequired positional parameter[23m [[2mdef =[22m 1001]",
 ]
 `;
 

--- a/packages/core/tests/parameter/positional/formatting.spec.ts
+++ b/packages/core/tests/parameter/positional/formatting.spec.ts
@@ -1,5 +1,6 @@
 // Copyright 2024 Bloomberg Finance L.P.
 // Distributed under the terms of the Apache 2.0 license.
+import { stripVTControlCharacters } from "node:util";
 import { describe, expect, it } from "vitest";
 import { type CommandContext, text_en, type TypedPositionalParameters } from "../../../src";
 // eslint-disable-next-line no-restricted-imports
@@ -8,7 +9,6 @@ import { formatDocumentationForPositionalParameters } from "../../../src/paramet
 import type { PositionalParameters } from "../../../src/parameter/positional/types";
 // eslint-disable-next-line no-restricted-imports
 import type { HelpFormattingArguments } from "../../../src/routing/types";
-import { stripAnsiCodes } from "../../util/ansi";
 
 type DocumentationArgs = Pick<HelpFormattingArguments, "config" | "text">;
 
@@ -41,7 +41,7 @@ function compareDocumentationToBaseline(positional: PositionalParameters, args: 
             ...args,
             ansiColor: true,
         });
-        const linesWithAnsiColorStrippedOut = linesWithAnsiColor.map(stripAnsiCodes);
+        const linesWithAnsiColorStrippedOut = linesWithAnsiColor.map(stripVTControlCharacters);
         const linesWithoutAnsiColor = formatDocumentationForPositionalParameters(positional, {
             ...args,
             ansiColor: false,

--- a/packages/core/tests/parameter/positional/formatting.spec.ts
+++ b/packages/core/tests/parameter/positional/formatting.spec.ts
@@ -8,6 +8,7 @@ import { formatDocumentationForPositionalParameters } from "../../../src/paramet
 import type { PositionalParameters } from "../../../src/parameter/positional/types";
 // eslint-disable-next-line no-restricted-imports
 import type { HelpFormattingArguments } from "../../../src/routing/types";
+import { stripAnsiCodes } from "../../util/ansi";
 
 type DocumentationArgs = Pick<HelpFormattingArguments, "config" | "text">;
 
@@ -40,7 +41,7 @@ function compareDocumentationToBaseline(positional: PositionalParameters, args: 
             ...args,
             ansiColor: true,
         });
-        const linesWithAnsiColorStrippedOut = linesWithAnsiColor.map((line) => line.replace(/\x1B\[[0-9;]*m/g, ""));
+        const linesWithAnsiColorStrippedOut = linesWithAnsiColor.map(stripAnsiCodes);
         const linesWithoutAnsiColor = formatDocumentationForPositionalParameters(positional, {
             ...args,
             ansiColor: false,

--- a/packages/core/tests/routing/__snapshots__/command.spec.ts.snap
+++ b/packages/core/tests/routing/__snapshots__/command.spec.ts.snap
@@ -28,11 +28,11 @@ exports[`Command > printHelp > mixed parameters > with ANSI color 1`] = `
 brief
 
 [4mFLAGS[24m
-  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
-  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
-  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
-  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
+  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
+  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
+  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
+  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -68,11 +68,11 @@ exports[`Command > printHelp > mixed parameters with \`convert-camel-to-kebab\` 
 brief
 
 [4mFLAGS[24m
-  [01m-a[22m [01m --alpha-flag[22m                  [03malpha flag brief[23m
-  [01m[22m   [01m --bravo-flag...[22m               [03mbravo flag brief[23m
-  [01m[22m   [01m[--charlie-flag][22m               [03mcharlie flag brief[23m
-  [01m-d[22m [01m --delta-flag/--no-delta-flag[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m                        [03mPrint help information and exit[23m
+  [1m-a[22m [1m --alpha-flag[22m                  [003malpha flag brief[00023m
+  [1m[22m   [1m --bravo-flag...[22m               [003mbravo flag brief[00023m
+  [1m[22m   [1m[--charlie-flag][22m               [003mcharlie flag brief[00023m
+  [1m-d[22m [1m --delta-flag/--no-delta-flag[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m                        [003mPrint help information and exit[00023m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -108,11 +108,11 @@ exports[`Command > printHelp > mixed parameters with \`convert-camel-to-kebab\` 
 brief
 
 [4mFLAGS[24m
-  [01m-a[22m [01m --alpha-flag[22m                  [03malpha flag brief[23m
-  [01m[22m   [01m --bravo-flag...[22m               [03mbravo flag brief[23m
-  [01m[22m   [01m[--charlie-flag][22m               [03mcharlie flag brief[23m
-  [01m-d[22m [01m --delta-flag/--no-delta-flag[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m                        [03mPrint help information and exit[23m
+  [1m-a[22m [1m --alpha-flag[22m                  [003malpha flag brief[00023m
+  [1m[22m   [1m --bravo-flag...[22m               [003mbravo flag brief[00023m
+  [1m[22m   [1m[--charlie-flag][22m               [003mcharlie flag brief[00023m
+  [1m-d[22m [1m --delta-flag/--no-delta-flag[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m                        [003mPrint help information and exit[00023m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -148,11 +148,11 @@ exports[`Command > printHelp > mixed parameters with \`original\` display case s
 brief
 
 [4mFLAGS[24m
-  [01m-a[22m [01m --alphaFlag[22m                [03malpha flag brief[23m
-  [01m[22m   [01m --bravoFlag...[22m             [03mbravo flag brief[23m
-  [01m[22m   [01m[--charlieFlag][22m             [03mcharlie flag brief[23m
-  [01m-d[22m [01m --deltaFlag/--noDeltaFlag[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m                     [03mPrint help information and exit[23m
+  [1m-a[22m [1m --alphaFlag[22m                [003malpha flag brief[00023m
+  [1m[22m   [1m --bravoFlag...[22m             [003mbravo flag brief[00023m
+  [1m[22m   [1m[--charlieFlag][22m             [003mcharlie flag brief[00023m
+  [1m-d[22m [1m --deltaFlag/--noDeltaFlag[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m                     [003mPrint help information and exit[00023m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -188,11 +188,11 @@ exports[`Command > printHelp > mixed parameters with \`original\` display case s
 brief
 
 [4mFLAGS[24m
-  [01m-a[22m [01m --alphaFlag[22m                [03malpha flag brief[23m
-  [01m[22m   [01m --bravoFlag...[22m             [03mbravo flag brief[23m
-  [01m[22m   [01m[--charlieFlag][22m             [03mcharlie flag brief[23m
-  [01m-d[22m [01m --deltaFlag/--noDeltaFlag[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m                     [03mPrint help information and exit[23m
+  [1m-a[22m [1m --alphaFlag[22m                [003malpha flag brief[00023m
+  [1m[22m   [1m --bravoFlag...[22m             [003mbravo flag brief[00023m
+  [1m[22m   [1m[--charlieFlag][22m             [003mcharlie flag brief[00023m
+  [1m-d[22m [1m --deltaFlag/--noDeltaFlag[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m                     [003mPrint help information and exit[00023m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -239,12 +239,12 @@ brief
   cli alias2
 
 [4mFLAGS[24m
-  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
-  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
-  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
-  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
-  [01m-v[22m [01m --version[22m          [03mPrint version information and exit[23m
+  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
+  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
+  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
+  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
+  [1m-v[22m [1m --version[22m          [003mPrint version information and exit[00023m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -291,12 +291,12 @@ brief
   cli alias2
 
 [4mFLAGS[24m
-  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
-  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
-  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
-  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
-  [01m-v[22m [01m --version[22m          [03mPrint version information and exit[23m
+  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
+  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
+  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
+  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
+  [1m-v[22m [1m --version[22m          [003mPrint version information and exit[00023m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -343,12 +343,12 @@ brief
   cli alias2
 
 [4mFlags:[24m
-  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
-  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
-  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
-  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
-  [01m-v[22m [01m --version[22m          [03mPrint version information and exit[23m
+  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
+  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
+  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
+  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
+  [1m-v[22m [1m --version[22m          [003mPrint version information and exit[00023m
 
 [4mArguments:[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -395,12 +395,12 @@ brief
   cli alias2
 
 [4mFlags:[24m
-  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
-  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
-  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
-  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
-  [01m-v[22m [01m --version[22m          [03mPrint version information and exit[23m
+  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
+  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
+  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
+  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
+  [1m-v[22m [1m --version[22m          [003mPrint version information and exit[00023m
 
 [4mArguments:[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -439,12 +439,12 @@ exports[`Command > printHelp > mixed parameters with version available > with AN
 brief
 
 [4mFLAGS[24m
-  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
-  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
-  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
-  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
-  [01m-v[22m [01m --version[22m          [03mPrint version information and exit[23m
+  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
+  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
+  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
+  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
+  [1m-v[22m [1m --version[22m          [003mPrint version information and exit[00023m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -483,12 +483,12 @@ exports[`Command > printHelp > mixed parameters with version available, only req
 brief
 
 [4mFLAGS[24m
-  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
-  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
-  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
-  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
-  [01m-v[22m [01m --version[22m          [03mPrint version information and exit[23m
+  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
+  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
+  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
+  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
+  [1m-v[22m [1m --version[22m          [003mPrint version information and exit[00023m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -525,14 +525,14 @@ exports[`Command > printHelp > mixed parameters, custom usage > with ANSI color 
 brief
 
 [4mFLAGS[24m
-  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
-  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
-  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
-  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
+  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
+  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
+  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
+  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
 
 [4mARGUMENTS[24m
-  [01margs...[22m  [3mstring array brief[23m
+  [1margs...[22m  [3mstring array brief[23m
 "
 `;
 
@@ -569,14 +569,14 @@ exports[`Command > printHelp > mixed parameters, enhanced custom usage > with AN
 brief
 
 [4mFLAGS[24m
-  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
-  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
-  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
-  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
+  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
+  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
+  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
+  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
 
 [4mARGUMENTS[24m
-  [01margs...[22m  [3mstring array brief[23m
+  [1margs...[22m  [3mstring array brief[23m
 "
 `;
 
@@ -607,14 +607,14 @@ exports[`Command > printHelp > mixed parameters, force include hidden > with ANS
 brief
 
 [4mFLAGS[24m
-  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
-  [90m[39m   [90m --bravo...[39m         [90mbravo flag brief[39m
-  [90m[39m   [90m[--charlie][39m         [90mcharlie flag brief[39m
-  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
+  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
+  [2m[22m   [2m --bravo...[22m         [2;3mbravo flag brief[22;23m
+  [2m[22m   [2m[--charlie][22m         [2;3mcharlie flag brief[22;23m
+  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
 
 [4mARGUMENTS[24m
-  [01margs...[22m  [3mstring array brief[23m
+  [1margs...[22m  [3mstring array brief[23m
 "
 `;
 
@@ -645,14 +645,14 @@ exports[`Command > printHelp > mixed parameters, full description > with ANSI co
 Longer description of this command's behavior, only printed during --help
 
 [4mFLAGS[24m
-  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
-  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
-  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
-  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
+  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
+  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
+  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
+  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
 
 [4mARGUMENTS[24m
-  [01margs...[22m  [3mstring array brief[23m
+  [1margs...[22m  [3mstring array brief[23m
 "
 `;
 
@@ -683,14 +683,14 @@ exports[`Command > printHelp > mixed parameters, full description, only required
 Longer description of this command's behavior, only printed during --help
 
 [4mFLAGS[24m
-  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
-  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
-  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
-  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
+  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
+  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
+  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
+  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
 
 [4mARGUMENTS[24m
-  [01margs...[22m  [3mstring array brief[23m
+  [1margs...[22m  [3mstring array brief[23m
 "
 `;
 
@@ -724,15 +724,15 @@ exports[`Command > printHelp > mixed parameters, help all, force alias in usage 
 brief
 
 [4mFLAGS[24m
-  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
-  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
-  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
-  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
-  [90m-H[39m [90m --helpAll[39m          [90mPrint help information (including hidden commands/flags) and exit[39m
+  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
+  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
+  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
+  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
+  [2m-H[22m [2m --helpAll[22m          [2;3mPrint help information (including hidden commands/flags) and exit[22;23m
 
 [4mARGUMENTS[24m
-  [01margs...[22m  [3mstring array brief[23m
+  [1margs...[22m  [3mstring array brief[23m
 "
 `;
 
@@ -777,14 +777,14 @@ exports[`Command > printHelp > mixed parameters, mixed custom usage > with ANSI 
 brief
 
 [4mFLAGS[24m
-  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
-  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
-  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
-  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
+  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
+  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
+  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
+  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
 
 [4mARGUMENTS[24m
-  [01margs...[22m  [3mstring array brief[23m
+  [1margs...[22m  [3mstring array brief[23m
 "
 `;
 
@@ -816,11 +816,11 @@ exports[`Command > printHelp > mixed parameters, only required in usage line > w
 brief
 
 [4mFLAGS[24m
-  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
-  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
-  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
-  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
+  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
+  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
+  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
+  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -853,12 +853,12 @@ exports[`Command > printHelp > mixed parameters, skips hidden > with ANSI color 
 brief
 
 [4mFLAGS[24m
-  [01m-a[22m [01m--alpha[22m            [03malpha flag brief[23m
-  [01m-d[22m [01m--delta/--noDelta[22m  [03mdelta flag brief[23m
-  [01m-h[22m [01m--help[22m             [03mPrint help information and exit[23m
+  [1m-a[22m [1m--alpha[22m            [003malpha flag brief[00023m
+  [1m-d[22m [1m--delta/--noDelta[22m  [003mdelta flag brief[00023m
+  [1m-h[22m [1m--help[22m             [003mPrint help information and exit[00023m
 
 [4mARGUMENTS[24m
-  [01margs...[22m  [3mstring array brief[23m
+  [1margs...[22m  [3mstring array brief[23m
 "
 `;
 
@@ -885,10 +885,10 @@ exports[`Command > printHelp > multiple boolean flags > with ANSI color 1`] = `
 brief
 
 [4mFLAGS[24m
-  [01m[22m   [01m --alpha/--noAlpha[22m      [03malpha flag brief[23m
-  [01m[22m   [01m[--bravo/--noBravo][22m     [03mbravo flag brief[23m
-  [01m-c[22m [01m --charlie/--noCharlie[22m  [03mcharlie flag brief[23m
-  [01m-h[22m [01m --help[22m                 [03mPrint help information and exit[23m
+  [1m[22m   [1m --alpha/--noAlpha[22m      [003malpha flag brief[00023m
+  [1m[22m   [1m[--bravo/--noBravo][22m     [003mbravo flag brief[00023m
+  [1m-c[22m [1m --charlie/--noCharlie[22m  [003mcharlie flag brief[00023m
+  [1m-h[22m [1m --help[22m                 [003mPrint help information and exit[00023m
 "
 `;
 
@@ -915,10 +915,10 @@ exports[`Command > printHelp > multiple boolean flags, kebab-case > with ANSI co
 brief
 
 [4mFLAGS[24m
-  [01m[22m   [01m --alpha/--no-alpha[22m      [03malpha flag brief[23m
-  [01m[22m   [01m[--bravo/--no-bravo][22m     [03mbravo flag brief[23m
-  [01m-c[22m [01m --charlie/--no-charlie[22m  [03mcharlie flag brief[23m
-  [01m-h[22m [01m --help[22m                  [03mPrint help information and exit[23m
+  [1m[22m   [1m --alpha/--no-alpha[22m      [003malpha flag brief[00023m
+  [1m[22m   [1m[--bravo/--no-bravo][22m     [003mbravo flag brief[00023m
+  [1m-c[22m [1m --charlie/--no-charlie[22m  [003mcharlie flag brief[00023m
+  [1m-h[22m [1m --help[22m                  [003mPrint help information and exit[00023m
 "
 `;
 
@@ -945,10 +945,10 @@ exports[`Command > printHelp > multiple boolean flags, kebab-case, only required
 brief
 
 [4mFLAGS[24m
-  [01m[22m   [01m --alpha/--no-alpha[22m      [03malpha flag brief[23m
-  [01m[22m   [01m[--bravo/--no-bravo][22m     [03mbravo flag brief[23m
-  [01m-c[22m [01m --charlie/--no-charlie[22m  [03mcharlie flag brief[23m
-  [01m-h[22m [01m --help[22m                  [03mPrint help information and exit[23m
+  [1m[22m   [1m --alpha/--no-alpha[22m      [003malpha flag brief[00023m
+  [1m[22m   [1m[--bravo/--no-bravo][22m     [003mbravo flag brief[00023m
+  [1m-c[22m [1m --charlie/--no-charlie[22m  [003mcharlie flag brief[00023m
+  [1m-h[22m [1m --help[22m                  [003mPrint help information and exit[00023m
 "
 `;
 
@@ -975,10 +975,10 @@ exports[`Command > printHelp > multiple boolean flags, only required in usage li
 brief
 
 [4mFLAGS[24m
-  [01m[22m   [01m --alpha/--noAlpha[22m      [03malpha flag brief[23m
-  [01m[22m   [01m[--bravo/--noBravo][22m     [03mbravo flag brief[23m
-  [01m-c[22m [01m --charlie/--noCharlie[22m  [03mcharlie flag brief[23m
-  [01m-h[22m [01m --help[22m                 [03mPrint help information and exit[23m
+  [1m[22m   [1m --alpha/--noAlpha[22m      [003malpha flag brief[00023m
+  [1m[22m   [1m[--bravo/--noBravo][22m     [003mbravo flag brief[00023m
+  [1m-c[22m [1m --charlie/--noCharlie[22m  [003mcharlie flag brief[00023m
+  [1m-h[22m [1m --help[22m                 [003mPrint help information and exit[00023m
 "
 `;
 
@@ -1002,7 +1002,7 @@ exports[`Command > printHelp > no parameters > with ANSI color 1`] = `
 brief
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 "
 `;
 
@@ -1026,7 +1026,7 @@ exports[`Command > printHelp > no parameters, dropped empty flag spec > with ANS
 brief
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 "
 `;
 
@@ -1050,7 +1050,7 @@ exports[`Command > printHelp > no parameters, dropped empty positional spec > wi
 brief
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 "
 `;
 
@@ -1074,7 +1074,7 @@ exports[`Command > printHelp > no parameters, dropped empty specs > with ANSI co
 brief
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 "
 `;
 
@@ -1101,8 +1101,8 @@ exports[`Command > printHelp > no parameters, help all, force alias in usage lin
 brief
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [90m-H[39m [90m--helpAll[39m  [90mPrint help information (including hidden commands/flags) and exit[39m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [2m-H[22m [2m--helpAll[22m  [2;3mPrint help information (including hidden commands/flags) and exit[22;23m
 "
 `;
 

--- a/packages/core/tests/routing/__snapshots__/command.spec.ts.snap
+++ b/packages/core/tests/routing/__snapshots__/command.spec.ts.snap
@@ -28,11 +28,11 @@ exports[`Command > printHelp > mixed parameters > with ANSI color 1`] = `
 brief
 
 [4mFLAGS[24m
-  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
-  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
-  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
-  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
+  [1m-a[22m [1m --alpha[22m            [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m --bravo...[22m         [;;3mbravo flag brief[;;;23m
+  [1m[22m   [1m[--charlie][22m         [;;3mcharlie flag brief[;;;23m
+  [1m-d[22m [1m --delta/--noDelta[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -68,11 +68,11 @@ exports[`Command > printHelp > mixed parameters with \`convert-camel-to-kebab\` 
 brief
 
 [4mFLAGS[24m
-  [1m-a[22m [1m --alpha-flag[22m                  [003malpha flag brief[00023m
-  [1m[22m   [1m --bravo-flag...[22m               [003mbravo flag brief[00023m
-  [1m[22m   [1m[--charlie-flag][22m               [003mcharlie flag brief[00023m
-  [1m-d[22m [1m --delta-flag/--no-delta-flag[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m                        [003mPrint help information and exit[00023m
+  [1m-a[22m [1m --alpha-flag[22m                  [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m --bravo-flag...[22m               [;;3mbravo flag brief[;;;23m
+  [1m[22m   [1m[--charlie-flag][22m               [;;3mcharlie flag brief[;;;23m
+  [1m-d[22m [1m --delta-flag/--no-delta-flag[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m                        [;;3mPrint help information and exit[;;;23m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -108,11 +108,11 @@ exports[`Command > printHelp > mixed parameters with \`convert-camel-to-kebab\` 
 brief
 
 [4mFLAGS[24m
-  [1m-a[22m [1m --alpha-flag[22m                  [003malpha flag brief[00023m
-  [1m[22m   [1m --bravo-flag...[22m               [003mbravo flag brief[00023m
-  [1m[22m   [1m[--charlie-flag][22m               [003mcharlie flag brief[00023m
-  [1m-d[22m [1m --delta-flag/--no-delta-flag[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m                        [003mPrint help information and exit[00023m
+  [1m-a[22m [1m --alpha-flag[22m                  [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m --bravo-flag...[22m               [;;3mbravo flag brief[;;;23m
+  [1m[22m   [1m[--charlie-flag][22m               [;;3mcharlie flag brief[;;;23m
+  [1m-d[22m [1m --delta-flag/--no-delta-flag[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m                        [;;3mPrint help information and exit[;;;23m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -148,11 +148,11 @@ exports[`Command > printHelp > mixed parameters with \`original\` display case s
 brief
 
 [4mFLAGS[24m
-  [1m-a[22m [1m --alphaFlag[22m                [003malpha flag brief[00023m
-  [1m[22m   [1m --bravoFlag...[22m             [003mbravo flag brief[00023m
-  [1m[22m   [1m[--charlieFlag][22m             [003mcharlie flag brief[00023m
-  [1m-d[22m [1m --deltaFlag/--noDeltaFlag[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m                     [003mPrint help information and exit[00023m
+  [1m-a[22m [1m --alphaFlag[22m                [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m --bravoFlag...[22m             [;;3mbravo flag brief[;;;23m
+  [1m[22m   [1m[--charlieFlag][22m             [;;3mcharlie flag brief[;;;23m
+  [1m-d[22m [1m --deltaFlag/--noDeltaFlag[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m                     [;;3mPrint help information and exit[;;;23m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -188,11 +188,11 @@ exports[`Command > printHelp > mixed parameters with \`original\` display case s
 brief
 
 [4mFLAGS[24m
-  [1m-a[22m [1m --alphaFlag[22m                [003malpha flag brief[00023m
-  [1m[22m   [1m --bravoFlag...[22m             [003mbravo flag brief[00023m
-  [1m[22m   [1m[--charlieFlag][22m             [003mcharlie flag brief[00023m
-  [1m-d[22m [1m --deltaFlag/--noDeltaFlag[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m                     [003mPrint help information and exit[00023m
+  [1m-a[22m [1m --alphaFlag[22m                [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m --bravoFlag...[22m             [;;3mbravo flag brief[;;;23m
+  [1m[22m   [1m[--charlieFlag][22m             [;;3mcharlie flag brief[;;;23m
+  [1m-d[22m [1m --deltaFlag/--noDeltaFlag[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m                     [;;3mPrint help information and exit[;;;23m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -239,12 +239,12 @@ brief
   cli alias2
 
 [4mFLAGS[24m
-  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
-  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
-  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
-  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
-  [1m-v[22m [1m --version[22m          [003mPrint version information and exit[00023m
+  [1m-a[22m [1m --alpha[22m            [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m --bravo...[22m         [;;3mbravo flag brief[;;;23m
+  [1m[22m   [1m[--charlie][22m         [;;3mcharlie flag brief[;;;23m
+  [1m-d[22m [1m --delta/--noDelta[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m
+  [1m-v[22m [1m --version[22m          [;;3mPrint version information and exit[;;;23m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -291,12 +291,12 @@ brief
   cli alias2
 
 [4mFLAGS[24m
-  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
-  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
-  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
-  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
-  [1m-v[22m [1m --version[22m          [003mPrint version information and exit[00023m
+  [1m-a[22m [1m --alpha[22m            [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m --bravo...[22m         [;;3mbravo flag brief[;;;23m
+  [1m[22m   [1m[--charlie][22m         [;;3mcharlie flag brief[;;;23m
+  [1m-d[22m [1m --delta/--noDelta[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m
+  [1m-v[22m [1m --version[22m          [;;3mPrint version information and exit[;;;23m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -343,12 +343,12 @@ brief
   cli alias2
 
 [4mFlags:[24m
-  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
-  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
-  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
-  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
-  [1m-v[22m [1m --version[22m          [003mPrint version information and exit[00023m
+  [1m-a[22m [1m --alpha[22m            [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m --bravo...[22m         [;;3mbravo flag brief[;;;23m
+  [1m[22m   [1m[--charlie][22m         [;;3mcharlie flag brief[;;;23m
+  [1m-d[22m [1m --delta/--noDelta[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m
+  [1m-v[22m [1m --version[22m          [;;3mPrint version information and exit[;;;23m
 
 [4mArguments:[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -395,12 +395,12 @@ brief
   cli alias2
 
 [4mFlags:[24m
-  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
-  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
-  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
-  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
-  [1m-v[22m [1m --version[22m          [003mPrint version information and exit[00023m
+  [1m-a[22m [1m --alpha[22m            [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m --bravo...[22m         [;;3mbravo flag brief[;;;23m
+  [1m[22m   [1m[--charlie][22m         [;;3mcharlie flag brief[;;;23m
+  [1m-d[22m [1m --delta/--noDelta[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m
+  [1m-v[22m [1m --version[22m          [;;3mPrint version information and exit[;;;23m
 
 [4mArguments:[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -439,12 +439,12 @@ exports[`Command > printHelp > mixed parameters with version available > with AN
 brief
 
 [4mFLAGS[24m
-  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
-  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
-  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
-  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
-  [1m-v[22m [1m --version[22m          [003mPrint version information and exit[00023m
+  [1m-a[22m [1m --alpha[22m            [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m --bravo...[22m         [;;3mbravo flag brief[;;;23m
+  [1m[22m   [1m[--charlie][22m         [;;3mcharlie flag brief[;;;23m
+  [1m-d[22m [1m --delta/--noDelta[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m
+  [1m-v[22m [1m --version[22m          [;;3mPrint version information and exit[;;;23m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -483,12 +483,12 @@ exports[`Command > printHelp > mixed parameters with version available, only req
 brief
 
 [4mFLAGS[24m
-  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
-  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
-  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
-  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
-  [1m-v[22m [1m --version[22m          [003mPrint version information and exit[00023m
+  [1m-a[22m [1m --alpha[22m            [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m --bravo...[22m         [;;3mbravo flag brief[;;;23m
+  [1m[22m   [1m[--charlie][22m         [;;3mcharlie flag brief[;;;23m
+  [1m-d[22m [1m --delta/--noDelta[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m
+  [1m-v[22m [1m --version[22m          [;;3mPrint version information and exit[;;;23m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -525,11 +525,11 @@ exports[`Command > printHelp > mixed parameters, custom usage > with ANSI color 
 brief
 
 [4mFLAGS[24m
-  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
-  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
-  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
-  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
+  [1m-a[22m [1m --alpha[22m            [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m --bravo...[22m         [;;3mbravo flag brief[;;;23m
+  [1m[22m   [1m[--charlie][22m         [;;3mcharlie flag brief[;;;23m
+  [1m-d[22m [1m --delta/--noDelta[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m
 
 [4mARGUMENTS[24m
   [1margs...[22m  [3mstring array brief[23m
@@ -569,11 +569,11 @@ exports[`Command > printHelp > mixed parameters, enhanced custom usage > with AN
 brief
 
 [4mFLAGS[24m
-  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
-  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
-  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
-  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
+  [1m-a[22m [1m --alpha[22m            [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m --bravo...[22m         [;;3mbravo flag brief[;;;23m
+  [1m[22m   [1m[--charlie][22m         [;;3mcharlie flag brief[;;;23m
+  [1m-d[22m [1m --delta/--noDelta[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m
 
 [4mARGUMENTS[24m
   [1margs...[22m  [3mstring array brief[23m
@@ -607,11 +607,11 @@ exports[`Command > printHelp > mixed parameters, force include hidden > with ANS
 brief
 
 [4mFLAGS[24m
-  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
+  [1m-a[22m [1m --alpha[22m            [;;3malpha flag brief[;;;23m
   [2m[22m   [2m --bravo...[22m         [2;3mbravo flag brief[22;23m
   [2m[22m   [2m[--charlie][22m         [2;3mcharlie flag brief[22;23m
-  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
+  [1m-d[22m [1m --delta/--noDelta[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m
 
 [4mARGUMENTS[24m
   [1margs...[22m  [3mstring array brief[23m
@@ -645,11 +645,11 @@ exports[`Command > printHelp > mixed parameters, full description > with ANSI co
 Longer description of this command's behavior, only printed during --help
 
 [4mFLAGS[24m
-  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
-  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
-  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
-  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
+  [1m-a[22m [1m --alpha[22m            [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m --bravo...[22m         [;;3mbravo flag brief[;;;23m
+  [1m[22m   [1m[--charlie][22m         [;;3mcharlie flag brief[;;;23m
+  [1m-d[22m [1m --delta/--noDelta[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m
 
 [4mARGUMENTS[24m
   [1margs...[22m  [3mstring array brief[23m
@@ -683,11 +683,11 @@ exports[`Command > printHelp > mixed parameters, full description, only required
 Longer description of this command's behavior, only printed during --help
 
 [4mFLAGS[24m
-  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
-  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
-  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
-  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
+  [1m-a[22m [1m --alpha[22m            [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m --bravo...[22m         [;;3mbravo flag brief[;;;23m
+  [1m[22m   [1m[--charlie][22m         [;;3mcharlie flag brief[;;;23m
+  [1m-d[22m [1m --delta/--noDelta[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m
 
 [4mARGUMENTS[24m
   [1margs...[22m  [3mstring array brief[23m
@@ -724,11 +724,11 @@ exports[`Command > printHelp > mixed parameters, help all, force alias in usage 
 brief
 
 [4mFLAGS[24m
-  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
-  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
-  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
-  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
+  [1m-a[22m [1m --alpha[22m            [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m --bravo...[22m         [;;3mbravo flag brief[;;;23m
+  [1m[22m   [1m[--charlie][22m         [;;3mcharlie flag brief[;;;23m
+  [1m-d[22m [1m --delta/--noDelta[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m
   [2m-H[22m [2m --helpAll[22m          [2;3mPrint help information (including hidden commands/flags) and exit[22;23m
 
 [4mARGUMENTS[24m
@@ -777,11 +777,11 @@ exports[`Command > printHelp > mixed parameters, mixed custom usage > with ANSI 
 brief
 
 [4mFLAGS[24m
-  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
-  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
-  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
-  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
+  [1m-a[22m [1m --alpha[22m            [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m --bravo...[22m         [;;3mbravo flag brief[;;;23m
+  [1m[22m   [1m[--charlie][22m         [;;3mcharlie flag brief[;;;23m
+  [1m-d[22m [1m --delta/--noDelta[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m
 
 [4mARGUMENTS[24m
   [1margs...[22m  [3mstring array brief[23m
@@ -816,11 +816,11 @@ exports[`Command > printHelp > mixed parameters, only required in usage line > w
 brief
 
 [4mFLAGS[24m
-  [1m-a[22m [1m --alpha[22m            [003malpha flag brief[00023m
-  [1m[22m   [1m --bravo...[22m         [003mbravo flag brief[00023m
-  [1m[22m   [1m[--charlie][22m         [003mcharlie flag brief[00023m
-  [1m-d[22m [1m --delta/--noDelta[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m --help[22m             [003mPrint help information and exit[00023m
+  [1m-a[22m [1m --alpha[22m            [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m --bravo...[22m         [;;3mbravo flag brief[;;;23m
+  [1m[22m   [1m[--charlie][22m         [;;3mcharlie flag brief[;;;23m
+  [1m-d[22m [1m --delta/--noDelta[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m --help[22m             [;;3mPrint help information and exit[;;;23m
 
 [4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
@@ -853,9 +853,9 @@ exports[`Command > printHelp > mixed parameters, skips hidden > with ANSI color 
 brief
 
 [4mFLAGS[24m
-  [1m-a[22m [1m--alpha[22m            [003malpha flag brief[00023m
-  [1m-d[22m [1m--delta/--noDelta[22m  [003mdelta flag brief[00023m
-  [1m-h[22m [1m--help[22m             [003mPrint help information and exit[00023m
+  [1m-a[22m [1m--alpha[22m            [;;3malpha flag brief[;;;23m
+  [1m-d[22m [1m--delta/--noDelta[22m  [;;3mdelta flag brief[;;;23m
+  [1m-h[22m [1m--help[22m             [;;3mPrint help information and exit[;;;23m
 
 [4mARGUMENTS[24m
   [1margs...[22m  [3mstring array brief[23m
@@ -885,10 +885,10 @@ exports[`Command > printHelp > multiple boolean flags > with ANSI color 1`] = `
 brief
 
 [4mFLAGS[24m
-  [1m[22m   [1m --alpha/--noAlpha[22m      [003malpha flag brief[00023m
-  [1m[22m   [1m[--bravo/--noBravo][22m     [003mbravo flag brief[00023m
-  [1m-c[22m [1m --charlie/--noCharlie[22m  [003mcharlie flag brief[00023m
-  [1m-h[22m [1m --help[22m                 [003mPrint help information and exit[00023m
+  [1m[22m   [1m --alpha/--noAlpha[22m      [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m[--bravo/--noBravo][22m     [;;3mbravo flag brief[;;;23m
+  [1m-c[22m [1m --charlie/--noCharlie[22m  [;;3mcharlie flag brief[;;;23m
+  [1m-h[22m [1m --help[22m                 [;;3mPrint help information and exit[;;;23m
 "
 `;
 
@@ -915,10 +915,10 @@ exports[`Command > printHelp > multiple boolean flags, kebab-case > with ANSI co
 brief
 
 [4mFLAGS[24m
-  [1m[22m   [1m --alpha/--no-alpha[22m      [003malpha flag brief[00023m
-  [1m[22m   [1m[--bravo/--no-bravo][22m     [003mbravo flag brief[00023m
-  [1m-c[22m [1m --charlie/--no-charlie[22m  [003mcharlie flag brief[00023m
-  [1m-h[22m [1m --help[22m                  [003mPrint help information and exit[00023m
+  [1m[22m   [1m --alpha/--no-alpha[22m      [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m[--bravo/--no-bravo][22m     [;;3mbravo flag brief[;;;23m
+  [1m-c[22m [1m --charlie/--no-charlie[22m  [;;3mcharlie flag brief[;;;23m
+  [1m-h[22m [1m --help[22m                  [;;3mPrint help information and exit[;;;23m
 "
 `;
 
@@ -945,10 +945,10 @@ exports[`Command > printHelp > multiple boolean flags, kebab-case, only required
 brief
 
 [4mFLAGS[24m
-  [1m[22m   [1m --alpha/--no-alpha[22m      [003malpha flag brief[00023m
-  [1m[22m   [1m[--bravo/--no-bravo][22m     [003mbravo flag brief[00023m
-  [1m-c[22m [1m --charlie/--no-charlie[22m  [003mcharlie flag brief[00023m
-  [1m-h[22m [1m --help[22m                  [003mPrint help information and exit[00023m
+  [1m[22m   [1m --alpha/--no-alpha[22m      [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m[--bravo/--no-bravo][22m     [;;3mbravo flag brief[;;;23m
+  [1m-c[22m [1m --charlie/--no-charlie[22m  [;;3mcharlie flag brief[;;;23m
+  [1m-h[22m [1m --help[22m                  [;;3mPrint help information and exit[;;;23m
 "
 `;
 
@@ -975,10 +975,10 @@ exports[`Command > printHelp > multiple boolean flags, only required in usage li
 brief
 
 [4mFLAGS[24m
-  [1m[22m   [1m --alpha/--noAlpha[22m      [003malpha flag brief[00023m
-  [1m[22m   [1m[--bravo/--noBravo][22m     [003mbravo flag brief[00023m
-  [1m-c[22m [1m --charlie/--noCharlie[22m  [003mcharlie flag brief[00023m
-  [1m-h[22m [1m --help[22m                 [003mPrint help information and exit[00023m
+  [1m[22m   [1m --alpha/--noAlpha[22m      [;;3malpha flag brief[;;;23m
+  [1m[22m   [1m[--bravo/--noBravo][22m     [;;3mbravo flag brief[;;;23m
+  [1m-c[22m [1m --charlie/--noCharlie[22m  [;;3mcharlie flag brief[;;;23m
+  [1m-h[22m [1m --help[22m                 [;;3mPrint help information and exit[;;;23m
 "
 `;
 
@@ -1002,7 +1002,7 @@ exports[`Command > printHelp > no parameters > with ANSI color 1`] = `
 brief
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 "
 `;
 
@@ -1026,7 +1026,7 @@ exports[`Command > printHelp > no parameters, dropped empty flag spec > with ANS
 brief
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 "
 `;
 
@@ -1050,7 +1050,7 @@ exports[`Command > printHelp > no parameters, dropped empty positional spec > wi
 brief
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 "
 `;
 
@@ -1074,7 +1074,7 @@ exports[`Command > printHelp > no parameters, dropped empty specs > with ANSI co
 brief
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 "
 `;
 
@@ -1101,7 +1101,7 @@ exports[`Command > printHelp > no parameters, help all, force alias in usage lin
 brief
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
   [2m-H[22m [2m--helpAll[22m  [2;3mPrint help information (including hidden commands/flags) and exit[22;23m
 "
 `;

--- a/packages/core/tests/routing/__snapshots__/command.spec.ts.snap
+++ b/packages/core/tests/routing/__snapshots__/command.spec.ts.snap
@@ -21,20 +21,20 @@ ARGUMENTS
 `;
 
 exports[`Command > printHelp > mixed parameters > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix (--alpha value) (--bravo value)... [--charlie c] (--delta) <arg1> [<arg2>]
   prefix --help
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
   [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
   [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
   [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
   [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
 
-[1mARGUMENTS[22m
+[4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
   [1m[arg2][22m  [3msecond argument brief[23m
 "
@@ -61,20 +61,20 @@ ARGUMENTS
 `;
 
 exports[`Command > printHelp > mixed parameters with \`convert-camel-to-kebab\` display case style > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix (--alpha-flag value) (--bravo-flag value)... [--charlie-flag c] (--delta-flag) <arg1> [<arg2>]
   prefix --help
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-a[22m [01m --alpha-flag[22m                  [03malpha flag brief[23m
   [01m[22m   [01m --bravo-flag...[22m               [03mbravo flag brief[23m
   [01m[22m   [01m[--charlie-flag][22m               [03mcharlie flag brief[23m
   [01m-d[22m [01m --delta-flag/--no-delta-flag[22m  [03mdelta flag brief[23m
   [01m-h[22m [01m --help[22m                        [03mPrint help information and exit[23m
 
-[1mARGUMENTS[22m
+[4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
   [1m[arg2][22m  [3msecond argument brief[23m
 "
@@ -101,20 +101,20 @@ ARGUMENTS
 `;
 
 exports[`Command > printHelp > mixed parameters with \`convert-camel-to-kebab\` display case style, only required in usage line > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix (--alpha-flag value) (--bravo-flag value)... (--delta-flag) <arg1>
   prefix --help
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-a[22m [01m --alpha-flag[22m                  [03malpha flag brief[23m
   [01m[22m   [01m --bravo-flag...[22m               [03mbravo flag brief[23m
   [01m[22m   [01m[--charlie-flag][22m               [03mcharlie flag brief[23m
   [01m-d[22m [01m --delta-flag/--no-delta-flag[22m  [03mdelta flag brief[23m
   [01m-h[22m [01m --help[22m                        [03mPrint help information and exit[23m
 
-[1mARGUMENTS[22m
+[4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
   [1m[arg2][22m  [3msecond argument brief[23m
 "
@@ -141,20 +141,20 @@ ARGUMENTS
 `;
 
 exports[`Command > printHelp > mixed parameters with \`original\` display case style > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix (--alphaFlag value) (--bravoFlag value)... [--charlieFlag c] (--deltaFlag) <arg1> [<arg2>]
   prefix --help
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-a[22m [01m --alphaFlag[22m                [03malpha flag brief[23m
   [01m[22m   [01m --bravoFlag...[22m             [03mbravo flag brief[23m
   [01m[22m   [01m[--charlieFlag][22m             [03mcharlie flag brief[23m
   [01m-d[22m [01m --deltaFlag/--noDeltaFlag[22m  [03mdelta flag brief[23m
   [01m-h[22m [01m --help[22m                     [03mPrint help information and exit[23m
 
-[1mARGUMENTS[22m
+[4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
   [1m[arg2][22m  [3msecond argument brief[23m
 "
@@ -181,20 +181,20 @@ ARGUMENTS
 `;
 
 exports[`Command > printHelp > mixed parameters with \`original\` display case style, only required in usage line > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix (--alphaFlag value) (--bravoFlag value)... (--deltaFlag) <arg1>
   prefix --help
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-a[22m [01m --alphaFlag[22m                [03malpha flag brief[23m
   [01m[22m   [01m --bravoFlag...[22m             [03mbravo flag brief[23m
   [01m[22m   [01m[--charlieFlag][22m             [03mcharlie flag brief[23m
   [01m-d[22m [01m --deltaFlag/--noDeltaFlag[22m  [03mdelta flag brief[23m
   [01m-h[22m [01m --help[22m                     [03mPrint help information and exit[23m
 
-[1mARGUMENTS[22m
+[4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
   [1m[arg2][22m  [3msecond argument brief[23m
 "
@@ -227,18 +227,18 @@ ARGUMENTS
 `;
 
 exports[`Command > printHelp > mixed parameters with aliases > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   cli route (--alpha value) (--bravo value)... [--charlie c] (--delta) <arg1> [<arg2>]
   cli route --help
   cli route --version
 
 brief
 
-[1mALIASES[22m
+[4mALIASES[24m
   cli alias1
   cli alias2
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
   [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
   [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
@@ -246,7 +246,7 @@ brief
   [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
   [01m-v[22m [01m --version[22m          [03mPrint version information and exit[23m
 
-[1mARGUMENTS[22m
+[4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
   [1m[arg2][22m  [3msecond argument brief[23m
 "
@@ -279,18 +279,18 @@ ARGUMENTS
 `;
 
 exports[`Command > printHelp > mixed parameters with aliases, only required in usage line > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   cli route (--alpha value) (--bravo value)... (--delta) <arg1>
   cli route --help
   cli route --version
 
 brief
 
-[1mALIASES[22m
+[4mALIASES[24m
   cli alias1
   cli alias2
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
   [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
   [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
@@ -298,7 +298,7 @@ brief
   [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
   [01m-v[22m [01m --version[22m          [03mPrint version information and exit[23m
 
-[1mARGUMENTS[22m
+[4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
   [1m[arg2][22m  [3msecond argument brief[23m
 "
@@ -331,18 +331,18 @@ Arguments:
 `;
 
 exports[`Command > printHelp > mixed parameters with custom headers > with ANSI color 1`] = `
-"[1mUsage:[22m
+"[4mUsage:[24m
   cli route (--alpha value) (--bravo value)... [--charlie c] (--delta) <arg1> [<arg2>]
   cli route --help
   cli route --version
 
 brief
 
-[1mAliases:[22m
+[4mAliases:[24m
   cli alias1
   cli alias2
 
-[1mFlags:[22m
+[4mFlags:[24m
   [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
   [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
   [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
@@ -350,7 +350,7 @@ brief
   [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
   [01m-v[22m [01m --version[22m          [03mPrint version information and exit[23m
 
-[1mArguments:[22m
+[4mArguments:[24m
   [1m arg1[22m   [3mfirst argument brief[23m
   [1m[arg2][22m  [3msecond argument brief[23m
 "
@@ -383,18 +383,18 @@ Arguments:
 `;
 
 exports[`Command > printHelp > mixed parameters with custom headers, only required in usage line > with ANSI color 1`] = `
-"[1mUsage:[22m
+"[4mUsage:[24m
   cli route (--alpha value) (--bravo value)... (--delta) <arg1>
   cli route --help
   cli route --version
 
 brief
 
-[1mAliases:[22m
+[4mAliases:[24m
   cli alias1
   cli alias2
 
-[1mFlags:[22m
+[4mFlags:[24m
   [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
   [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
   [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
@@ -402,7 +402,7 @@ brief
   [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
   [01m-v[22m [01m --version[22m          [03mPrint version information and exit[23m
 
-[1mArguments:[22m
+[4mArguments:[24m
   [1m arg1[22m   [3mfirst argument brief[23m
   [1m[arg2][22m  [3msecond argument brief[23m
 "
@@ -431,14 +431,14 @@ ARGUMENTS
 `;
 
 exports[`Command > printHelp > mixed parameters with version available > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix (--alpha value) (--bravo value)... [--charlie c] (--delta) <arg1> [<arg2>]
   prefix --help
   prefix --version
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
   [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
   [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
@@ -446,7 +446,7 @@ brief
   [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
   [01m-v[22m [01m --version[22m          [03mPrint version information and exit[23m
 
-[1mARGUMENTS[22m
+[4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
   [1m[arg2][22m  [3msecond argument brief[23m
 "
@@ -475,14 +475,14 @@ ARGUMENTS
 `;
 
 exports[`Command > printHelp > mixed parameters with version available, only required in usage line > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix (--alpha value) (--bravo value)... (--delta) <arg1>
   prefix --help
   prefix --version
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
   [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
   [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
@@ -490,7 +490,7 @@ brief
   [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
   [01m-v[22m [01m --version[22m          [03mPrint version information and exit[23m
 
-[1mARGUMENTS[22m
+[4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
   [1m[arg2][22m  [3msecond argument brief[23m
 "
@@ -517,21 +517,21 @@ ARGUMENTS
 `;
 
 exports[`Command > printHelp > mixed parameters, custom usage > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix custom usage line #1
   prefix custom usage line #2
   prefix --help
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
   [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
   [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
   [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
   [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
 
-[1mARGUMENTS[22m
+[4mARGUMENTS[24m
   [01margs...[22m  [3mstring array brief[23m
 "
 `;
@@ -559,7 +559,7 @@ ARGUMENTS
 `;
 
 exports[`Command > printHelp > mixed parameters, enhanced custom usage > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix -a 1
     [3menhanced usage line #1[23m
   prefix -a 2 -d
@@ -568,14 +568,14 @@ exports[`Command > printHelp > mixed parameters, enhanced custom usage > with AN
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
   [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
   [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
   [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
   [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
 
-[1mARGUMENTS[22m
+[4mARGUMENTS[24m
   [01margs...[22m  [3mstring array brief[23m
 "
 `;
@@ -600,20 +600,20 @@ ARGUMENTS
 `;
 
 exports[`Command > printHelp > mixed parameters, force include hidden > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix (--alpha value) (--delta) <args>...
   prefix --help
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
   [90m[39m   [90m --bravo...[39m         [90mbravo flag brief[39m
   [90m[39m   [90m[--charlie][39m         [90mcharlie flag brief[39m
   [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
   [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
 
-[1mARGUMENTS[22m
+[4mARGUMENTS[24m
   [01margs...[22m  [3mstring array brief[23m
 "
 `;
@@ -638,20 +638,20 @@ ARGUMENTS
 `;
 
 exports[`Command > printHelp > mixed parameters, full description > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix (--alpha value) (--bravo value)... [--charlie c] (--delta) <args>...
   prefix --help
 
 Longer description of this command's behavior, only printed during --help
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
   [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
   [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
   [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
   [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
 
-[1mARGUMENTS[22m
+[4mARGUMENTS[24m
   [01margs...[22m  [3mstring array brief[23m
 "
 `;
@@ -676,20 +676,20 @@ ARGUMENTS
 `;
 
 exports[`Command > printHelp > mixed parameters, full description, only required in usage line > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix (--alpha value) (--bravo value)... (--delta) <args>...
   prefix --help
 
 Longer description of this command's behavior, only printed during --help
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
   [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
   [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
   [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
   [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
 
-[1mARGUMENTS[22m
+[4mARGUMENTS[24m
   [01margs...[22m  [3mstring array brief[23m
 "
 `;
@@ -716,14 +716,14 @@ ARGUMENTS
 `;
 
 exports[`Command > printHelp > mixed parameters, help all, force alias in usage line > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix (-a value) (--bravo value)... [--charlie c] (-d) <args>...
   prefix -h
   prefix -H
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
   [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
   [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
@@ -731,7 +731,7 @@ brief
   [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
   [90m-H[39m [90m --helpAll[39m          [90mPrint help information (including hidden commands/flags) and exit[39m
 
-[1mARGUMENTS[22m
+[4mARGUMENTS[24m
   [01margs...[22m  [3mstring array brief[23m
 "
 `;
@@ -763,7 +763,7 @@ ARGUMENTS
 `;
 
 exports[`Command > printHelp > mixed parameters, mixed custom usage > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix -a 1
     [3menhanced usage line #1[23m
   prefix normal custom usage A
@@ -776,14 +776,14 @@ exports[`Command > printHelp > mixed parameters, mixed custom usage > with ANSI 
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
   [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
   [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
   [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
   [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
 
-[1mARGUMENTS[22m
+[4mARGUMENTS[24m
   [01margs...[22m  [3mstring array brief[23m
 "
 `;
@@ -809,20 +809,20 @@ ARGUMENTS
 `;
 
 exports[`Command > printHelp > mixed parameters, only required in usage line > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix (--alpha value) (--bravo value)... (--delta) <arg1>
   prefix --help
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
   [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
   [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
   [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
   [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
 
-[1mARGUMENTS[22m
+[4mARGUMENTS[24m
   [1m arg1[22m   [3mfirst argument brief[23m
   [1m[arg2][22m  [3msecond argument brief[23m
 "
@@ -846,18 +846,18 @@ ARGUMENTS
 `;
 
 exports[`Command > printHelp > mixed parameters, skips hidden > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix (--alpha value) (--delta) <args>...
   prefix --help
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-a[22m [01m--alpha[22m            [03malpha flag brief[23m
   [01m-d[22m [01m--delta/--noDelta[22m  [03mdelta flag brief[23m
   [01m-h[22m [01m--help[22m             [03mPrint help information and exit[23m
 
-[1mARGUMENTS[22m
+[4mARGUMENTS[24m
   [01margs...[22m  [3mstring array brief[23m
 "
 `;
@@ -878,13 +878,13 @@ FLAGS
 `;
 
 exports[`Command > printHelp > multiple boolean flags > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix (--alpha) [--bravo] (--charlie)
   prefix --help
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m[22m   [01m --alpha/--noAlpha[22m      [03malpha flag brief[23m
   [01m[22m   [01m[--bravo/--noBravo][22m     [03mbravo flag brief[23m
   [01m-c[22m [01m --charlie/--noCharlie[22m  [03mcharlie flag brief[23m
@@ -908,13 +908,13 @@ FLAGS
 `;
 
 exports[`Command > printHelp > multiple boolean flags, kebab-case > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix (--alpha) [--bravo] (--charlie)
   prefix --help
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m[22m   [01m --alpha/--no-alpha[22m      [03malpha flag brief[23m
   [01m[22m   [01m[--bravo/--no-bravo][22m     [03mbravo flag brief[23m
   [01m-c[22m [01m --charlie/--no-charlie[22m  [03mcharlie flag brief[23m
@@ -938,13 +938,13 @@ FLAGS
 `;
 
 exports[`Command > printHelp > multiple boolean flags, kebab-case, only required in usage line > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix (--alpha) (--charlie)
   prefix --help
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m[22m   [01m --alpha/--no-alpha[22m      [03malpha flag brief[23m
   [01m[22m   [01m[--bravo/--no-bravo][22m     [03mbravo flag brief[23m
   [01m-c[22m [01m --charlie/--no-charlie[22m  [03mcharlie flag brief[23m
@@ -968,13 +968,13 @@ FLAGS
 `;
 
 exports[`Command > printHelp > multiple boolean flags, only required in usage line > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix (--alpha) (--charlie)
   prefix --help
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m[22m   [01m --alpha/--noAlpha[22m      [03malpha flag brief[23m
   [01m[22m   [01m[--bravo/--noBravo][22m     [03mbravo flag brief[23m
   [01m-c[22m [01m --charlie/--noCharlie[22m  [03mcharlie flag brief[23m
@@ -995,13 +995,13 @@ FLAGS
 `;
 
 exports[`Command > printHelp > no parameters > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix
   prefix --help
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 "
 `;
@@ -1019,13 +1019,13 @@ FLAGS
 `;
 
 exports[`Command > printHelp > no parameters, dropped empty flag spec > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix
   prefix --help
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 "
 `;
@@ -1043,13 +1043,13 @@ FLAGS
 `;
 
 exports[`Command > printHelp > no parameters, dropped empty positional spec > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix
   prefix --help
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 "
 `;
@@ -1067,13 +1067,13 @@ FLAGS
 `;
 
 exports[`Command > printHelp > no parameters, dropped empty specs > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix
   prefix --help
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 "
 `;
@@ -1093,14 +1093,14 @@ FLAGS
 `;
 
 exports[`Command > printHelp > no parameters, help all, force alias in usage line > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix
   prefix -h
   prefix -H
 
 brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [90m-H[39m [90m--helpAll[39m  [90mPrint help information (including hidden commands/flags) and exit[39m
 "

--- a/packages/core/tests/routing/__snapshots__/command.spec.ts.snap
+++ b/packages/core/tests/routing/__snapshots__/command.spec.ts.snap
@@ -28,15 +28,15 @@ exports[`Command > printHelp > mixed parameters > with ANSI color 1`] = `
 brief
 
 [1mFLAGS[22m
-  [36m-a[39m [36m --alpha[39m            [03malpha flag brief[23m
-  [36m[39m   [36m --bravo...[39m         [03mbravo flag brief[23m
-  [36m[39m   [36m[--charlie][39m         [03mcharlie flag brief[23m
-  [36m-d[39m [36m --delta/--noDelta[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m
+  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
+  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
+  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
+  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
 
 [1mARGUMENTS[22m
-  [36m arg1[39m   [3mfirst argument brief[23m
-  [36m[arg2][39m  [3msecond argument brief[23m
+  [1m arg1[22m   [3mfirst argument brief[23m
+  [1m[arg2][22m  [3msecond argument brief[23m
 "
 `;
 
@@ -68,15 +68,15 @@ exports[`Command > printHelp > mixed parameters with \`convert-camel-to-kebab\` 
 brief
 
 [1mFLAGS[22m
-  [36m-a[39m [36m --alpha-flag[39m                  [03malpha flag brief[23m
-  [36m[39m   [36m --bravo-flag...[39m               [03mbravo flag brief[23m
-  [36m[39m   [36m[--charlie-flag][39m               [03mcharlie flag brief[23m
-  [36m-d[39m [36m --delta-flag/--no-delta-flag[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m                        [03mPrint help information and exit[23m
+  [01m-a[22m [01m --alpha-flag[22m                  [03malpha flag brief[23m
+  [01m[22m   [01m --bravo-flag...[22m               [03mbravo flag brief[23m
+  [01m[22m   [01m[--charlie-flag][22m               [03mcharlie flag brief[23m
+  [01m-d[22m [01m --delta-flag/--no-delta-flag[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m                        [03mPrint help information and exit[23m
 
 [1mARGUMENTS[22m
-  [36m arg1[39m   [3mfirst argument brief[23m
-  [36m[arg2][39m  [3msecond argument brief[23m
+  [1m arg1[22m   [3mfirst argument brief[23m
+  [1m[arg2][22m  [3msecond argument brief[23m
 "
 `;
 
@@ -108,15 +108,15 @@ exports[`Command > printHelp > mixed parameters with \`convert-camel-to-kebab\` 
 brief
 
 [1mFLAGS[22m
-  [36m-a[39m [36m --alpha-flag[39m                  [03malpha flag brief[23m
-  [36m[39m   [36m --bravo-flag...[39m               [03mbravo flag brief[23m
-  [36m[39m   [36m[--charlie-flag][39m               [03mcharlie flag brief[23m
-  [36m-d[39m [36m --delta-flag/--no-delta-flag[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m                        [03mPrint help information and exit[23m
+  [01m-a[22m [01m --alpha-flag[22m                  [03malpha flag brief[23m
+  [01m[22m   [01m --bravo-flag...[22m               [03mbravo flag brief[23m
+  [01m[22m   [01m[--charlie-flag][22m               [03mcharlie flag brief[23m
+  [01m-d[22m [01m --delta-flag/--no-delta-flag[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m                        [03mPrint help information and exit[23m
 
 [1mARGUMENTS[22m
-  [36m arg1[39m   [3mfirst argument brief[23m
-  [36m[arg2][39m  [3msecond argument brief[23m
+  [1m arg1[22m   [3mfirst argument brief[23m
+  [1m[arg2][22m  [3msecond argument brief[23m
 "
 `;
 
@@ -148,15 +148,15 @@ exports[`Command > printHelp > mixed parameters with \`original\` display case s
 brief
 
 [1mFLAGS[22m
-  [36m-a[39m [36m --alphaFlag[39m                [03malpha flag brief[23m
-  [36m[39m   [36m --bravoFlag...[39m             [03mbravo flag brief[23m
-  [36m[39m   [36m[--charlieFlag][39m             [03mcharlie flag brief[23m
-  [36m-d[39m [36m --deltaFlag/--noDeltaFlag[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m                     [03mPrint help information and exit[23m
+  [01m-a[22m [01m --alphaFlag[22m                [03malpha flag brief[23m
+  [01m[22m   [01m --bravoFlag...[22m             [03mbravo flag brief[23m
+  [01m[22m   [01m[--charlieFlag][22m             [03mcharlie flag brief[23m
+  [01m-d[22m [01m --deltaFlag/--noDeltaFlag[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m                     [03mPrint help information and exit[23m
 
 [1mARGUMENTS[22m
-  [36m arg1[39m   [3mfirst argument brief[23m
-  [36m[arg2][39m  [3msecond argument brief[23m
+  [1m arg1[22m   [3mfirst argument brief[23m
+  [1m[arg2][22m  [3msecond argument brief[23m
 "
 `;
 
@@ -188,15 +188,15 @@ exports[`Command > printHelp > mixed parameters with \`original\` display case s
 brief
 
 [1mFLAGS[22m
-  [36m-a[39m [36m --alphaFlag[39m                [03malpha flag brief[23m
-  [36m[39m   [36m --bravoFlag...[39m             [03mbravo flag brief[23m
-  [36m[39m   [36m[--charlieFlag][39m             [03mcharlie flag brief[23m
-  [36m-d[39m [36m --deltaFlag/--noDeltaFlag[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m                     [03mPrint help information and exit[23m
+  [01m-a[22m [01m --alphaFlag[22m                [03malpha flag brief[23m
+  [01m[22m   [01m --bravoFlag...[22m             [03mbravo flag brief[23m
+  [01m[22m   [01m[--charlieFlag][22m             [03mcharlie flag brief[23m
+  [01m-d[22m [01m --deltaFlag/--noDeltaFlag[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m                     [03mPrint help information and exit[23m
 
 [1mARGUMENTS[22m
-  [36m arg1[39m   [3mfirst argument brief[23m
-  [36m[arg2][39m  [3msecond argument brief[23m
+  [1m arg1[22m   [3mfirst argument brief[23m
+  [1m[arg2][22m  [3msecond argument brief[23m
 "
 `;
 
@@ -239,16 +239,16 @@ brief
   cli alias2
 
 [1mFLAGS[22m
-  [36m-a[39m [36m --alpha[39m            [03malpha flag brief[23m
-  [36m[39m   [36m --bravo...[39m         [03mbravo flag brief[23m
-  [36m[39m   [36m[--charlie][39m         [03mcharlie flag brief[23m
-  [36m-d[39m [36m --delta/--noDelta[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m
-  [36m-v[39m [36m --version[39m          [03mPrint version information and exit[23m
+  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
+  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
+  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
+  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
+  [01m-v[22m [01m --version[22m          [03mPrint version information and exit[23m
 
 [1mARGUMENTS[22m
-  [36m arg1[39m   [3mfirst argument brief[23m
-  [36m[arg2][39m  [3msecond argument brief[23m
+  [1m arg1[22m   [3mfirst argument brief[23m
+  [1m[arg2][22m  [3msecond argument brief[23m
 "
 `;
 
@@ -291,16 +291,16 @@ brief
   cli alias2
 
 [1mFLAGS[22m
-  [36m-a[39m [36m --alpha[39m            [03malpha flag brief[23m
-  [36m[39m   [36m --bravo...[39m         [03mbravo flag brief[23m
-  [36m[39m   [36m[--charlie][39m         [03mcharlie flag brief[23m
-  [36m-d[39m [36m --delta/--noDelta[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m
-  [36m-v[39m [36m --version[39m          [03mPrint version information and exit[23m
+  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
+  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
+  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
+  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
+  [01m-v[22m [01m --version[22m          [03mPrint version information and exit[23m
 
 [1mARGUMENTS[22m
-  [36m arg1[39m   [3mfirst argument brief[23m
-  [36m[arg2][39m  [3msecond argument brief[23m
+  [1m arg1[22m   [3mfirst argument brief[23m
+  [1m[arg2][22m  [3msecond argument brief[23m
 "
 `;
 
@@ -343,16 +343,16 @@ brief
   cli alias2
 
 [1mFlags:[22m
-  [36m-a[39m [36m --alpha[39m            [03malpha flag brief[23m
-  [36m[39m   [36m --bravo...[39m         [03mbravo flag brief[23m
-  [36m[39m   [36m[--charlie][39m         [03mcharlie flag brief[23m
-  [36m-d[39m [36m --delta/--noDelta[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m
-  [36m-v[39m [36m --version[39m          [03mPrint version information and exit[23m
+  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
+  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
+  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
+  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
+  [01m-v[22m [01m --version[22m          [03mPrint version information and exit[23m
 
 [1mArguments:[22m
-  [36m arg1[39m   [3mfirst argument brief[23m
-  [36m[arg2][39m  [3msecond argument brief[23m
+  [1m arg1[22m   [3mfirst argument brief[23m
+  [1m[arg2][22m  [3msecond argument brief[23m
 "
 `;
 
@@ -395,16 +395,16 @@ brief
   cli alias2
 
 [1mFlags:[22m
-  [36m-a[39m [36m --alpha[39m            [03malpha flag brief[23m
-  [36m[39m   [36m --bravo...[39m         [03mbravo flag brief[23m
-  [36m[39m   [36m[--charlie][39m         [03mcharlie flag brief[23m
-  [36m-d[39m [36m --delta/--noDelta[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m
-  [36m-v[39m [36m --version[39m          [03mPrint version information and exit[23m
+  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
+  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
+  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
+  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
+  [01m-v[22m [01m --version[22m          [03mPrint version information and exit[23m
 
 [1mArguments:[22m
-  [36m arg1[39m   [3mfirst argument brief[23m
-  [36m[arg2][39m  [3msecond argument brief[23m
+  [1m arg1[22m   [3mfirst argument brief[23m
+  [1m[arg2][22m  [3msecond argument brief[23m
 "
 `;
 
@@ -439,16 +439,16 @@ exports[`Command > printHelp > mixed parameters with version available > with AN
 brief
 
 [1mFLAGS[22m
-  [36m-a[39m [36m --alpha[39m            [03malpha flag brief[23m
-  [36m[39m   [36m --bravo...[39m         [03mbravo flag brief[23m
-  [36m[39m   [36m[--charlie][39m         [03mcharlie flag brief[23m
-  [36m-d[39m [36m --delta/--noDelta[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m
-  [36m-v[39m [36m --version[39m          [03mPrint version information and exit[23m
+  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
+  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
+  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
+  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
+  [01m-v[22m [01m --version[22m          [03mPrint version information and exit[23m
 
 [1mARGUMENTS[22m
-  [36m arg1[39m   [3mfirst argument brief[23m
-  [36m[arg2][39m  [3msecond argument brief[23m
+  [1m arg1[22m   [3mfirst argument brief[23m
+  [1m[arg2][22m  [3msecond argument brief[23m
 "
 `;
 
@@ -483,16 +483,16 @@ exports[`Command > printHelp > mixed parameters with version available, only req
 brief
 
 [1mFLAGS[22m
-  [36m-a[39m [36m --alpha[39m            [03malpha flag brief[23m
-  [36m[39m   [36m --bravo...[39m         [03mbravo flag brief[23m
-  [36m[39m   [36m[--charlie][39m         [03mcharlie flag brief[23m
-  [36m-d[39m [36m --delta/--noDelta[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m
-  [36m-v[39m [36m --version[39m          [03mPrint version information and exit[23m
+  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
+  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
+  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
+  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
+  [01m-v[22m [01m --version[22m          [03mPrint version information and exit[23m
 
 [1mARGUMENTS[22m
-  [36m arg1[39m   [3mfirst argument brief[23m
-  [36m[arg2][39m  [3msecond argument brief[23m
+  [1m arg1[22m   [3mfirst argument brief[23m
+  [1m[arg2][22m  [3msecond argument brief[23m
 "
 `;
 
@@ -525,14 +525,14 @@ exports[`Command > printHelp > mixed parameters, custom usage > with ANSI color 
 brief
 
 [1mFLAGS[22m
-  [36m-a[39m [36m --alpha[39m            [03malpha flag brief[23m
-  [36m[39m   [36m --bravo...[39m         [03mbravo flag brief[23m
-  [36m[39m   [36m[--charlie][39m         [03mcharlie flag brief[23m
-  [36m-d[39m [36m --delta/--noDelta[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m
+  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
+  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
+  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
+  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
 
 [1mARGUMENTS[22m
-  [36margs...[39m  [3mstring array brief[23m
+  [01margs...[22m  [3mstring array brief[23m
 "
 `;
 
@@ -569,14 +569,14 @@ exports[`Command > printHelp > mixed parameters, enhanced custom usage > with AN
 brief
 
 [1mFLAGS[22m
-  [36m-a[39m [36m --alpha[39m            [03malpha flag brief[23m
-  [36m[39m   [36m --bravo...[39m         [03mbravo flag brief[23m
-  [36m[39m   [36m[--charlie][39m         [03mcharlie flag brief[23m
-  [36m-d[39m [36m --delta/--noDelta[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m
+  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
+  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
+  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
+  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
 
 [1mARGUMENTS[22m
-  [36margs...[39m  [3mstring array brief[23m
+  [01margs...[22m  [3mstring array brief[23m
 "
 `;
 
@@ -607,14 +607,14 @@ exports[`Command > printHelp > mixed parameters, force include hidden > with ANS
 brief
 
 [1mFLAGS[22m
-  [36m-a[39m [36m --alpha[39m            [03malpha flag brief[23m
+  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
   [90m[39m   [90m --bravo...[39m         [90mbravo flag brief[39m
   [90m[39m   [90m[--charlie][39m         [90mcharlie flag brief[39m
-  [36m-d[39m [36m --delta/--noDelta[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m
+  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
 
 [1mARGUMENTS[22m
-  [36margs...[39m  [3mstring array brief[23m
+  [01margs...[22m  [3mstring array brief[23m
 "
 `;
 
@@ -645,14 +645,14 @@ exports[`Command > printHelp > mixed parameters, full description > with ANSI co
 Longer description of this command's behavior, only printed during --help
 
 [1mFLAGS[22m
-  [36m-a[39m [36m --alpha[39m            [03malpha flag brief[23m
-  [36m[39m   [36m --bravo...[39m         [03mbravo flag brief[23m
-  [36m[39m   [36m[--charlie][39m         [03mcharlie flag brief[23m
-  [36m-d[39m [36m --delta/--noDelta[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m
+  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
+  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
+  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
+  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
 
 [1mARGUMENTS[22m
-  [36margs...[39m  [3mstring array brief[23m
+  [01margs...[22m  [3mstring array brief[23m
 "
 `;
 
@@ -683,14 +683,14 @@ exports[`Command > printHelp > mixed parameters, full description, only required
 Longer description of this command's behavior, only printed during --help
 
 [1mFLAGS[22m
-  [36m-a[39m [36m --alpha[39m            [03malpha flag brief[23m
-  [36m[39m   [36m --bravo...[39m         [03mbravo flag brief[23m
-  [36m[39m   [36m[--charlie][39m         [03mcharlie flag brief[23m
-  [36m-d[39m [36m --delta/--noDelta[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m
+  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
+  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
+  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
+  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
 
 [1mARGUMENTS[22m
-  [36margs...[39m  [3mstring array brief[23m
+  [01margs...[22m  [3mstring array brief[23m
 "
 `;
 
@@ -724,15 +724,15 @@ exports[`Command > printHelp > mixed parameters, help all, force alias in usage 
 brief
 
 [1mFLAGS[22m
-  [36m-a[39m [36m --alpha[39m            [03malpha flag brief[23m
-  [36m[39m   [36m --bravo...[39m         [03mbravo flag brief[23m
-  [36m[39m   [36m[--charlie][39m         [03mcharlie flag brief[23m
-  [36m-d[39m [36m --delta/--noDelta[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m
+  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
+  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
+  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
+  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
   [90m-H[39m [90m --helpAll[39m          [90mPrint help information (including hidden commands/flags) and exit[39m
 
 [1mARGUMENTS[22m
-  [36margs...[39m  [3mstring array brief[23m
+  [01margs...[22m  [3mstring array brief[23m
 "
 `;
 
@@ -777,14 +777,14 @@ exports[`Command > printHelp > mixed parameters, mixed custom usage > with ANSI 
 brief
 
 [1mFLAGS[22m
-  [36m-a[39m [36m --alpha[39m            [03malpha flag brief[23m
-  [36m[39m   [36m --bravo...[39m         [03mbravo flag brief[23m
-  [36m[39m   [36m[--charlie][39m         [03mcharlie flag brief[23m
-  [36m-d[39m [36m --delta/--noDelta[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m
+  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
+  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
+  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
+  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
 
 [1mARGUMENTS[22m
-  [36margs...[39m  [3mstring array brief[23m
+  [01margs...[22m  [3mstring array brief[23m
 "
 `;
 
@@ -816,15 +816,15 @@ exports[`Command > printHelp > mixed parameters, only required in usage line > w
 brief
 
 [1mFLAGS[22m
-  [36m-a[39m [36m --alpha[39m            [03malpha flag brief[23m
-  [36m[39m   [36m --bravo...[39m         [03mbravo flag brief[23m
-  [36m[39m   [36m[--charlie][39m         [03mcharlie flag brief[23m
-  [36m-d[39m [36m --delta/--noDelta[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m --help[39m             [03mPrint help information and exit[23m
+  [01m-a[22m [01m --alpha[22m            [03malpha flag brief[23m
+  [01m[22m   [01m --bravo...[22m         [03mbravo flag brief[23m
+  [01m[22m   [01m[--charlie][22m         [03mcharlie flag brief[23m
+  [01m-d[22m [01m --delta/--noDelta[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m --help[22m             [03mPrint help information and exit[23m
 
 [1mARGUMENTS[22m
-  [36m arg1[39m   [3mfirst argument brief[23m
-  [36m[arg2][39m  [3msecond argument brief[23m
+  [1m arg1[22m   [3mfirst argument brief[23m
+  [1m[arg2][22m  [3msecond argument brief[23m
 "
 `;
 
@@ -853,12 +853,12 @@ exports[`Command > printHelp > mixed parameters, skips hidden > with ANSI color 
 brief
 
 [1mFLAGS[22m
-  [36m-a[39m [36m--alpha[39m            [03malpha flag brief[23m
-  [36m-d[39m [36m--delta/--noDelta[39m  [03mdelta flag brief[23m
-  [36m-h[39m [36m--help[39m             [03mPrint help information and exit[23m
+  [01m-a[22m [01m--alpha[22m            [03malpha flag brief[23m
+  [01m-d[22m [01m--delta/--noDelta[22m  [03mdelta flag brief[23m
+  [01m-h[22m [01m--help[22m             [03mPrint help information and exit[23m
 
 [1mARGUMENTS[22m
-  [36margs...[39m  [3mstring array brief[23m
+  [01margs...[22m  [3mstring array brief[23m
 "
 `;
 
@@ -885,10 +885,10 @@ exports[`Command > printHelp > multiple boolean flags > with ANSI color 1`] = `
 brief
 
 [1mFLAGS[22m
-  [36m[39m   [36m --alpha/--noAlpha[39m      [03malpha flag brief[23m
-  [36m[39m   [36m[--bravo/--noBravo][39m     [03mbravo flag brief[23m
-  [36m-c[39m [36m --charlie/--noCharlie[39m  [03mcharlie flag brief[23m
-  [36m-h[39m [36m --help[39m                 [03mPrint help information and exit[23m
+  [01m[22m   [01m --alpha/--noAlpha[22m      [03malpha flag brief[23m
+  [01m[22m   [01m[--bravo/--noBravo][22m     [03mbravo flag brief[23m
+  [01m-c[22m [01m --charlie/--noCharlie[22m  [03mcharlie flag brief[23m
+  [01m-h[22m [01m --help[22m                 [03mPrint help information and exit[23m
 "
 `;
 
@@ -915,10 +915,10 @@ exports[`Command > printHelp > multiple boolean flags, kebab-case > with ANSI co
 brief
 
 [1mFLAGS[22m
-  [36m[39m   [36m --alpha/--no-alpha[39m      [03malpha flag brief[23m
-  [36m[39m   [36m[--bravo/--no-bravo][39m     [03mbravo flag brief[23m
-  [36m-c[39m [36m --charlie/--no-charlie[39m  [03mcharlie flag brief[23m
-  [36m-h[39m [36m --help[39m                  [03mPrint help information and exit[23m
+  [01m[22m   [01m --alpha/--no-alpha[22m      [03malpha flag brief[23m
+  [01m[22m   [01m[--bravo/--no-bravo][22m     [03mbravo flag brief[23m
+  [01m-c[22m [01m --charlie/--no-charlie[22m  [03mcharlie flag brief[23m
+  [01m-h[22m [01m --help[22m                  [03mPrint help information and exit[23m
 "
 `;
 
@@ -945,10 +945,10 @@ exports[`Command > printHelp > multiple boolean flags, kebab-case, only required
 brief
 
 [1mFLAGS[22m
-  [36m[39m   [36m --alpha/--no-alpha[39m      [03malpha flag brief[23m
-  [36m[39m   [36m[--bravo/--no-bravo][39m     [03mbravo flag brief[23m
-  [36m-c[39m [36m --charlie/--no-charlie[39m  [03mcharlie flag brief[23m
-  [36m-h[39m [36m --help[39m                  [03mPrint help information and exit[23m
+  [01m[22m   [01m --alpha/--no-alpha[22m      [03malpha flag brief[23m
+  [01m[22m   [01m[--bravo/--no-bravo][22m     [03mbravo flag brief[23m
+  [01m-c[22m [01m --charlie/--no-charlie[22m  [03mcharlie flag brief[23m
+  [01m-h[22m [01m --help[22m                  [03mPrint help information and exit[23m
 "
 `;
 
@@ -975,10 +975,10 @@ exports[`Command > printHelp > multiple boolean flags, only required in usage li
 brief
 
 [1mFLAGS[22m
-  [36m[39m   [36m --alpha/--noAlpha[39m      [03malpha flag brief[23m
-  [36m[39m   [36m[--bravo/--noBravo][39m     [03mbravo flag brief[23m
-  [36m-c[39m [36m --charlie/--noCharlie[39m  [03mcharlie flag brief[23m
-  [36m-h[39m [36m --help[39m                 [03mPrint help information and exit[23m
+  [01m[22m   [01m --alpha/--noAlpha[22m      [03malpha flag brief[23m
+  [01m[22m   [01m[--bravo/--noBravo][22m     [03mbravo flag brief[23m
+  [01m-c[22m [01m --charlie/--noCharlie[22m  [03mcharlie flag brief[23m
+  [01m-h[22m [01m --help[22m                 [03mPrint help information and exit[23m
 "
 `;
 
@@ -1002,7 +1002,7 @@ exports[`Command > printHelp > no parameters > with ANSI color 1`] = `
 brief
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 "
 `;
 
@@ -1026,7 +1026,7 @@ exports[`Command > printHelp > no parameters, dropped empty flag spec > with ANS
 brief
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 "
 `;
 
@@ -1050,7 +1050,7 @@ exports[`Command > printHelp > no parameters, dropped empty positional spec > wi
 brief
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 "
 `;
 
@@ -1074,7 +1074,7 @@ exports[`Command > printHelp > no parameters, dropped empty specs > with ANSI co
 brief
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 "
 `;
 
@@ -1101,7 +1101,7 @@ exports[`Command > printHelp > no parameters, help all, force alias in usage lin
 brief
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [90m-H[39m [90m--helpAll[39m  [90mPrint help information (including hidden commands/flags) and exit[39m
 "
 `;

--- a/packages/core/tests/routing/__snapshots__/route-map.spec.ts.snap
+++ b/packages/core/tests/routing/__snapshots__/route-map.spec.ts.snap
@@ -24,7 +24,7 @@ COMMANDS
 `;
 
 exports[`RouteMap > printHelp > aliased nested route map with aliases > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   cli alias1 doNothing
   cli alias1 sub doNothing1|doNothing2 ...
   cli alias1 --help
@@ -32,15 +32,15 @@ exports[`RouteMap > printHelp > aliased nested route map with aliases > with ANS
 
 route map brief
 
-[1mALIASES[22m
+[4mALIASES[24m
   cli route
   cli alias2
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mdoNothing[32m  [03mtop command brief[23m
   [01msub[32m        [03msub route map brief[23m
 "
@@ -64,17 +64,17 @@ COMMANDS
 `;
 
 exports[`RouteMap > printHelp > nested route map > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix doNothing
   prefix sub doNothing1|doNothing2 ...
   prefix --help
 
 route map brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mdoNothing[32m  [03mtop command brief[23m
   [01msub[32m        [03msub route map brief[23m
 "
@@ -100,7 +100,7 @@ COMMANDS
 `;
 
 exports[`RouteMap > printHelp > nested route map force include hidden routes > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix doNothing
   prefix sub doNothing1|doNothing2 ...
   prefix --help
@@ -108,11 +108,11 @@ exports[`RouteMap > printHelp > nested route map force include hidden routes > w
 
 route map brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mdoNothing[32m  [03mtop command brief[23m
   [90msub[39m        [90msub route map brief[39m
 "
@@ -138,7 +138,7 @@ COMMANDS
 `;
 
 exports[`RouteMap > printHelp > nested route map with \`convert-camel-to-kebab\` display case style > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix do-nothing
   prefix sub do-nothing1|do-nothing2 ...
   prefix --help
@@ -146,11 +146,11 @@ exports[`RouteMap > printHelp > nested route map with \`convert-camel-to-kebab\`
 
 Longer description of this route map's behavior, only printed during --help
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mdo-nothing[32m  [03mtop command brief[23m
   [01msub[32m         [03msub route map brief[23m
 "
@@ -180,7 +180,7 @@ COMMANDS
 `;
 
 exports[`RouteMap > printHelp > nested route map with aliases > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   cli route doNothing
   cli route sub doNothing1|doNothing2 ...
   cli route --help
@@ -188,15 +188,15 @@ exports[`RouteMap > printHelp > nested route map with aliases > with ANSI color 
 
 route map brief
 
-[1mALIASES[22m
+[4mALIASES[24m
   cli alias1
   cli alias2
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mdoNothing[32m  [03mtop command brief[23m
   [01msub[32m        [03msub route map brief[23m
 "
@@ -220,18 +220,18 @@ COMMANDS
 `;
 
 exports[`RouteMap > printHelp > nested route map with hidden routes > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix doNothing
   prefix --help
   prefix --version
 
 route map brief
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mdoNothing[32m  [03mtop command brief[23m
 "
 `;
@@ -256,7 +256,7 @@ COMMANDS
 `;
 
 exports[`RouteMap > printHelp > nested route map with version available > with ANSI color 1`] = `
-"[1mUSAGE[22m
+"[4mUSAGE[24m
   prefix doNothing
   prefix sub doNothing1|doNothing2 ...
   prefix --help
@@ -264,11 +264,11 @@ exports[`RouteMap > printHelp > nested route map with version available > with A
 
 Longer description of this route map's behavior, only printed during --help
 
-[1mFLAGS[22m
+[4mFLAGS[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
-[1mCOMMANDS[22m
+[4mCOMMANDS[24m
   [01mdoNothing[32m  [03mtop command brief[23m
   [01msub[32m        [03msub route map brief[23m
 "
@@ -298,7 +298,7 @@ Commands:
 `;
 
 exports[`RouteMap > printHelp > nested route maps with custom header text > with ANSI color 1`] = `
-"[1mUsage:[22m
+"[4mUsage:[24m
   cli route doNothing
   cli route sub doNothing1|doNothing2 ...
   cli route --help
@@ -306,15 +306,15 @@ exports[`RouteMap > printHelp > nested route maps with custom header text > with
 
 route map brief
 
-[1mAliases:[22m
+[4mAliases:[24m
   cli alias1
   cli alias2
 
-[1mFlags:[22m
+[4mFlags:[24m
   [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
   [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
-[1mCommands:[22m
+[4mCommands:[24m
   [01mdoNothing[32m  [03mtop command brief[23m
   [01msub[32m        [03msub route map brief[23m
 "

--- a/packages/core/tests/routing/__snapshots__/route-map.spec.ts.snap
+++ b/packages/core/tests/routing/__snapshots__/route-map.spec.ts.snap
@@ -37,12 +37,12 @@ route map brief
   cli alias2
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-v[22m [1m--version[22m  [;;3mPrint version information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mdoNothing[32m  [003mtop command brief[00023m
-  [1msub[32m        [003msub route map brief[00023m
+  [1mdoNothing[32m  [;;3mtop command brief[;;;23m
+  [1msub[32m        [;;3msub route map brief[;;;23m
 "
 `;
 
@@ -72,11 +72,11 @@ exports[`RouteMap > printHelp > nested route map > with ANSI color 1`] = `
 route map brief
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
+  [1m-h[22m [1m--help[22m  [;;3mPrint help information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mdoNothing[32m  [003mtop command brief[00023m
-  [1msub[32m        [003msub route map brief[00023m
+  [1mdoNothing[32m  [;;3mtop command brief[;;;23m
+  [1msub[32m        [;;3msub route map brief[;;;23m
 "
 `;
 
@@ -109,11 +109,11 @@ exports[`RouteMap > printHelp > nested route map force include hidden routes > w
 route map brief
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-v[22m [1m--version[22m  [;;3mPrint version information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mdoNothing[32m  [003mtop command brief[00023m
+  [1mdoNothing[32m  [;;3mtop command brief[;;;23m
   [2msub[22m        [2;3msub route map brief[22;23m
 "
 `;
@@ -147,12 +147,12 @@ exports[`RouteMap > printHelp > nested route map with \`convert-camel-to-kebab\`
 Longer description of this route map's behavior, only printed during --help
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-v[22m [1m--version[22m  [;;3mPrint version information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mdo-nothing[32m  [003mtop command brief[00023m
-  [1msub[32m         [003msub route map brief[00023m
+  [1mdo-nothing[32m  [;;3mtop command brief[;;;23m
+  [1msub[32m         [;;3msub route map brief[;;;23m
 "
 `;
 
@@ -193,12 +193,12 @@ route map brief
   cli alias2
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-v[22m [1m--version[22m  [;;3mPrint version information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mdoNothing[32m  [003mtop command brief[00023m
-  [1msub[32m        [003msub route map brief[00023m
+  [1mdoNothing[32m  [;;3mtop command brief[;;;23m
+  [1msub[32m        [;;3msub route map brief[;;;23m
 "
 `;
 
@@ -228,11 +228,11 @@ exports[`RouteMap > printHelp > nested route map with hidden routes > with ANSI 
 route map brief
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-v[22m [1m--version[22m  [;;3mPrint version information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mdoNothing[32m  [003mtop command brief[00023m
+  [1mdoNothing[32m  [;;3mtop command brief[;;;23m
 "
 `;
 
@@ -265,12 +265,12 @@ exports[`RouteMap > printHelp > nested route map with version available > with A
 Longer description of this route map's behavior, only printed during --help
 
 [4mFLAGS[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-v[22m [1m--version[22m  [;;3mPrint version information and exit[;;;23m
 
 [4mCOMMANDS[24m
-  [1mdoNothing[32m  [003mtop command brief[00023m
-  [1msub[32m        [003msub route map brief[00023m
+  [1mdoNothing[32m  [;;3mtop command brief[;;;23m
+  [1msub[32m        [;;3msub route map brief[;;;23m
 "
 `;
 
@@ -311,11 +311,11 @@ route map brief
   cli alias2
 
 [4mFlags:[24m
-  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
-  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
+  [1m-h[22m [1m--help[22m     [;;3mPrint help information and exit[;;;23m
+  [1m-v[22m [1m--version[22m  [;;3mPrint version information and exit[;;;23m
 
 [4mCommands:[24m
-  [1mdoNothing[32m  [003mtop command brief[00023m
-  [1msub[32m        [003msub route map brief[00023m
+  [1mdoNothing[32m  [;;3mtop command brief[;;;23m
+  [1msub[32m        [;;3msub route map brief[;;;23m
 "
 `;

--- a/packages/core/tests/routing/__snapshots__/route-map.spec.ts.snap
+++ b/packages/core/tests/routing/__snapshots__/route-map.spec.ts.snap
@@ -37,12 +37,12 @@ route map brief
   cli alias2
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-v[39m [36m--version[39m  [03mPrint version information and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mdoNothing[39m  [03mtop command brief[23m
-  [36msub[39m        [03msub route map brief[23m
+  [01mdoNothing[32m  [03mtop command brief[23m
+  [01msub[32m        [03msub route map brief[23m
 "
 `;
 
@@ -72,11 +72,11 @@ exports[`RouteMap > printHelp > nested route map > with ANSI color 1`] = `
 route map brief
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m  [03mPrint help information and exit[23m
+  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mdoNothing[39m  [03mtop command brief[23m
-  [36msub[39m        [03msub route map brief[23m
+  [01mdoNothing[32m  [03mtop command brief[23m
+  [01msub[32m        [03msub route map brief[23m
 "
 `;
 
@@ -109,11 +109,11 @@ exports[`RouteMap > printHelp > nested route map force include hidden routes > w
 route map brief
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-v[39m [36m--version[39m  [03mPrint version information and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mdoNothing[39m  [03mtop command brief[23m
+  [01mdoNothing[32m  [03mtop command brief[23m
   [90msub[39m        [90msub route map brief[39m
 "
 `;
@@ -147,12 +147,12 @@ exports[`RouteMap > printHelp > nested route map with \`convert-camel-to-kebab\`
 Longer description of this route map's behavior, only printed during --help
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-v[39m [36m--version[39m  [03mPrint version information and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mdo-nothing[39m  [03mtop command brief[23m
-  [36msub[39m         [03msub route map brief[23m
+  [01mdo-nothing[32m  [03mtop command brief[23m
+  [01msub[32m         [03msub route map brief[23m
 "
 `;
 
@@ -193,12 +193,12 @@ route map brief
   cli alias2
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-v[39m [36m--version[39m  [03mPrint version information and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mdoNothing[39m  [03mtop command brief[23m
-  [36msub[39m        [03msub route map brief[23m
+  [01mdoNothing[32m  [03mtop command brief[23m
+  [01msub[32m        [03msub route map brief[23m
 "
 `;
 
@@ -228,11 +228,11 @@ exports[`RouteMap > printHelp > nested route map with hidden routes > with ANSI 
 route map brief
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-v[39m [36m--version[39m  [03mPrint version information and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mdoNothing[39m  [03mtop command brief[23m
+  [01mdoNothing[32m  [03mtop command brief[23m
 "
 `;
 
@@ -265,12 +265,12 @@ exports[`RouteMap > printHelp > nested route map with version available > with A
 Longer description of this route map's behavior, only printed during --help
 
 [1mFLAGS[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-v[39m [36m--version[39m  [03mPrint version information and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
 [1mCOMMANDS[22m
-  [36mdoNothing[39m  [03mtop command brief[23m
-  [36msub[39m        [03msub route map brief[23m
+  [01mdoNothing[32m  [03mtop command brief[23m
+  [01msub[32m        [03msub route map brief[23m
 "
 `;
 
@@ -311,11 +311,11 @@ route map brief
   cli alias2
 
 [1mFlags:[22m
-  [36m-h[39m [36m--help[39m     [03mPrint help information and exit[23m
-  [36m-v[39m [36m--version[39m  [03mPrint version information and exit[23m
+  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
+  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
 
 [1mCommands:[22m
-  [36mdoNothing[39m  [03mtop command brief[23m
-  [36msub[39m        [03msub route map brief[23m
+  [01mdoNothing[32m  [03mtop command brief[23m
+  [01msub[32m        [03msub route map brief[23m
 "
 `;

--- a/packages/core/tests/routing/__snapshots__/route-map.spec.ts.snap
+++ b/packages/core/tests/routing/__snapshots__/route-map.spec.ts.snap
@@ -37,12 +37,12 @@ route map brief
   cli alias2
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mdoNothing[32m  [03mtop command brief[23m
-  [01msub[32m        [03msub route map brief[23m
+  [1mdoNothing[32m  [003mtop command brief[00023m
+  [1msub[32m        [003msub route map brief[00023m
 "
 `;
 
@@ -72,11 +72,11 @@ exports[`RouteMap > printHelp > nested route map > with ANSI color 1`] = `
 route map brief
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m  [03mPrint help information and exit[23m
+  [1m-h[22m [1m--help[22m  [003mPrint help information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mdoNothing[32m  [03mtop command brief[23m
-  [01msub[32m        [03msub route map brief[23m
+  [1mdoNothing[32m  [003mtop command brief[00023m
+  [1msub[32m        [003msub route map brief[00023m
 "
 `;
 
@@ -109,12 +109,12 @@ exports[`RouteMap > printHelp > nested route map force include hidden routes > w
 route map brief
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mdoNothing[32m  [03mtop command brief[23m
-  [90msub[39m        [90msub route map brief[39m
+  [1mdoNothing[32m  [003mtop command brief[00023m
+  [2msub[22m        [2;3msub route map brief[22;23m
 "
 `;
 
@@ -147,12 +147,12 @@ exports[`RouteMap > printHelp > nested route map with \`convert-camel-to-kebab\`
 Longer description of this route map's behavior, only printed during --help
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mdo-nothing[32m  [03mtop command brief[23m
-  [01msub[32m         [03msub route map brief[23m
+  [1mdo-nothing[32m  [003mtop command brief[00023m
+  [1msub[32m         [003msub route map brief[00023m
 "
 `;
 
@@ -193,12 +193,12 @@ route map brief
   cli alias2
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mdoNothing[32m  [03mtop command brief[23m
-  [01msub[32m        [03msub route map brief[23m
+  [1mdoNothing[32m  [003mtop command brief[00023m
+  [1msub[32m        [003msub route map brief[00023m
 "
 `;
 
@@ -228,11 +228,11 @@ exports[`RouteMap > printHelp > nested route map with hidden routes > with ANSI 
 route map brief
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mdoNothing[32m  [03mtop command brief[23m
+  [1mdoNothing[32m  [003mtop command brief[00023m
 "
 `;
 
@@ -265,12 +265,12 @@ exports[`RouteMap > printHelp > nested route map with version available > with A
 Longer description of this route map's behavior, only printed during --help
 
 [4mFLAGS[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
 
 [4mCOMMANDS[24m
-  [01mdoNothing[32m  [03mtop command brief[23m
-  [01msub[32m        [03msub route map brief[23m
+  [1mdoNothing[32m  [003mtop command brief[00023m
+  [1msub[32m        [003msub route map brief[00023m
 "
 `;
 
@@ -311,11 +311,11 @@ route map brief
   cli alias2
 
 [4mFlags:[24m
-  [01m-h[22m [01m--help[22m     [03mPrint help information and exit[23m
-  [01m-v[22m [01m--version[22m  [03mPrint version information and exit[23m
+  [1m-h[22m [1m--help[22m     [003mPrint help information and exit[00023m
+  [1m-v[22m [1m--version[22m  [003mPrint version information and exit[00023m
 
 [4mCommands:[24m
-  [01mdoNothing[32m  [03mtop command brief[23m
-  [01msub[32m        [03msub route map brief[23m
+  [1mdoNothing[32m  [003mtop command brief[00023m
+  [1msub[32m        [003msub route map brief[00023m
 "
 `;

--- a/packages/core/tests/routing/command.spec.ts
+++ b/packages/core/tests/routing/command.spec.ts
@@ -1,5 +1,6 @@
 // Copyright 2024 Bloomberg Finance L.P.
 // Distributed under the terms of the Apache 2.0 license.
+import { stripVTControlCharacters } from "node:util";
 import { describe, expect, it } from "vitest";
 import { booleanParser, buildCommand, numberParser, text_en, type Command, type CommandContext } from "../../src";
 // eslint-disable-next-line no-restricted-imports
@@ -8,7 +9,6 @@ import { buildFakeContext } from "../fakes/context";
 // eslint-disable-next-line no-restricted-imports
 import { runCommand, type CommandRunArguments } from "../../src/routing/command/run";
 import { runResultSerializer } from "../snapshot-serializers";
-import { stripAnsiCodes } from "../util/ansi";
 
 // Register custom snapshot serializer
 expect.addSnapshotSerializer(runResultSerializer);
@@ -61,7 +61,7 @@ function compareHelpTextToBaseline(command: Command<CommandContext>, args: Omit<
             ...args,
             ansiColor: true,
         });
-        const helpTextWithAnsiColorStrippedOut = stripAnsiCodes(helpTextWithAnsiColor);
+        const helpTextWithAnsiColorStrippedOut = stripVTControlCharacters(helpTextWithAnsiColor);
         const helpTextWithoutAnsiColor = command.formatHelp({
             ...args,
             ansiColor: false,

--- a/packages/core/tests/routing/command.spec.ts
+++ b/packages/core/tests/routing/command.spec.ts
@@ -1,21 +1,14 @@
 // Copyright 2024 Bloomberg Finance L.P.
 // Distributed under the terms of the Apache 2.0 license.
 import { describe, expect, it } from "vitest";
-import {
-    ExitCode,
-    booleanParser,
-    buildCommand,
-    numberParser,
-    text_en,
-    type Command,
-    type CommandContext,
-} from "../../src";
+import { booleanParser, buildCommand, numberParser, text_en, type Command, type CommandContext } from "../../src";
 // eslint-disable-next-line no-restricted-imports
 import type { HelpFormattingArguments } from "../../src/routing/types";
 import { buildFakeContext } from "../fakes/context";
 // eslint-disable-next-line no-restricted-imports
 import { runCommand, type CommandRunArguments } from "../../src/routing/command/run";
 import { runResultSerializer } from "../snapshot-serializers";
+import { stripAnsiCodes } from "../util/ansi";
 
 // Register custom snapshot serializer
 expect.addSnapshotSerializer(runResultSerializer);
@@ -68,7 +61,7 @@ function compareHelpTextToBaseline(command: Command<CommandContext>, args: Omit<
             ...args,
             ansiColor: true,
         });
-        const helpTextWithAnsiColorStrippedOut = helpTextWithAnsiColor.replace(/\x1B\[[0-9;]*m/g, "");
+        const helpTextWithAnsiColorStrippedOut = stripAnsiCodes(helpTextWithAnsiColor);
         const helpTextWithoutAnsiColor = command.formatHelp({
             ...args,
             ansiColor: false,

--- a/packages/core/tests/routing/route-map.spec.ts
+++ b/packages/core/tests/routing/route-map.spec.ts
@@ -1,5 +1,6 @@
 // Copyright 2024 Bloomberg Finance L.P.
 // Distributed under the terms of the Apache 2.0 license.
+import { stripVTControlCharacters } from "node:util";
 import { describe, expect, it } from "vitest";
 import {
     buildCommand,
@@ -11,7 +12,6 @@ import {
 } from "../../src";
 // eslint-disable-next-line no-restricted-imports
 import type { HelpFormattingArguments } from "../../src/routing/types";
-import { stripAnsiCodes } from "../util/ansi";
 
 function compareHelpTextToBaseline(
     routeMap: RouteMap<CommandContext>,
@@ -45,7 +45,7 @@ function compareHelpTextToBaseline(
             ...args,
             ansiColor: true,
         });
-        const helpTextWithAnsiColorStrippedOut = stripAnsiCodes(helpTextWithAnsiColor);
+        const helpTextWithAnsiColorStrippedOut = stripVTControlCharacters(helpTextWithAnsiColor);
         const helpTextWithoutAnsiColor = routeMap.formatHelp({
             ...args,
             ansiColor: false,
@@ -358,7 +358,7 @@ describe("RouteMap", () => {
             });
 
             // THEN
-            expect(stripAnsiCodes(publicHelpText)).to.deep.equal(stripAnsiCodes(hiddenHelpText));
+            expect(stripVTControlCharacters(publicHelpText)).to.deep.equal(stripVTControlCharacters(hiddenHelpText));
         });
     });
 

--- a/packages/core/tests/util/ansi.ts
+++ b/packages/core/tests/util/ansi.ts
@@ -1,0 +1,5 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// Distributed under the terms of the Apache 2.0 license.
+export function stripAnsiCodes(str: string): string {
+    return str.replace(/\x1B\[[0-9;]*m/g, "");
+}

--- a/packages/core/tests/util/ansi.ts
+++ b/packages/core/tests/util/ansi.ts
@@ -1,5 +1,0 @@
-// Copyright 2024 Bloomberg Finance L.P.
-// Distributed under the terms of the Apache 2.0 license.
-export function stripAnsiCodes(str: string): string {
-    return str.replace(/\x1B\[[0-9;]*m/g, "");
-}


### PR DESCRIPTION
Addresses #140 (additional edge case)

**Describe your changes**
The original purpose of using ANSI white for flag/command names was to differentiate it from the rest of the line, specifically the beginning of the brief. The white-on-white rendering was an unintended bug, and one that also technically could impact the keywords/hidden text if the background was the right shade of gray. So rather than rely on color codes, I've made this change to use the graphics modifiers: 
- section headers are now underlined (were bold)
- flags/commands are now bold (were cyan, formerly white)
- keywords/hidden text are now dim (were bright black)

<table><tr><th>Before</th><td><img width="1556" height="405" alt="image" src="https://github.com/user-attachments/assets/bf400b3a-a3a5-4659-8703-70707e8f923b" /></td></tr><tr><th>After</th><td><img width="1556" height="403" alt="image" src="https://github.com/user-attachments/assets/73493899-4ef6-42b0-bd3a-455b5b7ee3bd" /></td></tr></table>

This PR does supplant #141, with the intention of removing all color codes where possible to avoid #140 resurfacing.

**Testing performed**
Updated snapshots, also introduced new tests to confirm that hidden commands/flags are printed with the same content after ANSI codes are stripped out.

**Additional context**
Added two new style classes for playground, so the ANSI modes are correctly displayed. I suspect that part of the reason why the original bug went undetected was because I had manually set bright white to be the same as bold default. 🙃 Now it looks much better:

<img width="806" height="93" alt="image" src="https://github.com/user-attachments/assets/40a15eef-ae44-4079-b995-6203e09e81cb" />
<img width="805" height="91" alt="image" src="https://github.com/user-attachments/assets/90143ffe-9be7-413d-88a6-3987b8b125f4" />

Oh and I also fixed a bug where the brief descriptions of hidden commands/flags weren't italicized like the rest of the briefs.