### PR TITLE
fix: allow override for formatException on formatting object

### DIFF
--- a/docs/docs/features/configuration/localization.mdx
+++ b/docs/docs/features/configuration/localization.mdx
@@ -24,6 +24,10 @@ The text for an application is composed of several static values and several dyn
 
 The following are brief descriptions of all of the dynamic functions that accept some arguments and output a string to be printed to stderr. All of these have default implementations in the included `en` text.
 
+-   `formatException` (optional)
+
+    -   This function is used to format any exception that is thrown during the loading or running of a command. It is used to generate the `{formattedException}` value that is passed to several of the error functions described below. If this function is not provided, Stricli will attempt to use the stack trace of the exception if it exists, and if not it will just convert the exception to a string.
+
 -   `currentVersionIsNotLatest`
 
     -   Default: `Latest available version is {latestVersion} (currently running {currentVersion})`

--- a/packages/core/tests/application/__snapshots__/run.spec.ts.snap
+++ b/packages/core/tests/application/__snapshots__/run.spec.ts.snap
@@ -704,6 +704,14 @@ ExitCode=ContextLoadError
     at #/tests/application/run.spec.ts:?:?
 `;
 
+exports[`run > fails when context.forCommand throws error, with custom exception formatting 1`] = `
+ExitCode=ContextLoadError
+:: STDOUT
+
+:: STDERR
+Unable to load command context, FORMATTED_EXCEPTION
+`;
+
 exports[`run > fails when context.forCommand throws error, with no ansi color 1`] = `
 ExitCode=ContextLoadError
 :: STDOUT

--- a/packages/core/tests/application/run.spec.ts
+++ b/packages/core/tests/application/run.spec.ts
@@ -907,6 +907,35 @@ describe("run", () => {
         expect(result).toMatchSnapshot();
     });
 
+    it("fails when context.forCommand throws error, with custom exception formatting", async (context) => {
+        // GIVEN
+        const command = buildBasicCommand();
+        const app = buildApplication(command, {
+            name: "cli",
+            localization: {
+                loadText() {
+                    return {
+                        ...text_en,
+                        formatException() {
+                            return "FORMATTED_EXCEPTION";
+                        },
+                    };
+                },
+            },
+        });
+
+        // WHEN
+        const result = await runWithInputs(app, [], {
+            forCommand: () => {
+                throw new Error("This function purposefully throws an error");
+            },
+            colorDepth: void 0,
+        });
+
+        // THEN
+        expect(result).toMatchSnapshot();
+    });
+
     it("fails when context.forCommand throws error (without stack)", async () => {
         // GIVEN
         const command = buildBasicCommand();

--- a/packages/core/tests/fakes/config.ts
+++ b/packages/core/tests/fakes/config.ts
@@ -19,6 +19,7 @@ export function buildFakeApplicationText(): SinonStubbedInstance<ApplicationText
             stub<[{ currentVersion: string; latestVersion: string; ansiColor: boolean }]>().returns(
                 "currentVersionIsNotLatest",
             ),
+        formatException: stub<[unknown]>().returns("formatException"),
         exceptionWhileParsingArguments: stub<[unknown, boolean]>().returns("exceptionWhileParsingArguments"),
         exceptionWhileLoadingCommandFunction: stub<[unknown, boolean]>().returns(
             "exceptionWhileLoadingCommandFunction",

--- a/packages/core/tests/parameter/formatting.spec.ts
+++ b/packages/core/tests/parameter/formatting.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 Bloomberg Finance L.P.
 // Distributed under the terms of the Apache 2.0 license.
 import { describe, expect, it } from "vitest";
-import { buildChoiceParser, type CommandContext, numberParser, type TypedCommandParameters } from "../../src";
+import type { CommandContext, TypedCommandParameters } from "../../src";
 // eslint-disable-next-line no-restricted-imports
 import { formatUsageLineForParameters, type UsageFormattingArguments } from "../../src/parameter/formatting";
 // eslint-disable-next-line no-restricted-imports

--- a/packages/core/tests/routing/__snapshots__/command.spec.ts.snap
+++ b/packages/core/tests/routing/__snapshots__/command.spec.ts.snap
@@ -1160,6 +1160,15 @@ ExitCode=CommandRunError
 
 `;
 
+exports[`Command > run > command function throws error > with default exit code, custom exception formatting 1`] = `
+ExitCode=CommandRunError
+:: STDOUT
+
+:: STDERR
+[1m[31mCommand failed, FORMATTED_EXCEPTION[39m[22m
+
+`;
+
 exports[`Command > run > doNothing (loader returns function) > no inputs 1`] = `
 ExitCode=Success
 :: STDOUT
@@ -1287,6 +1296,15 @@ ExitCode=InvalidArgument
 
 `;
 
+exports[`Command > run > echoArguments > unexpected error, with custom exception formatting 1`] = `
+ExitCode=InvalidArgument
+:: STDOUT
+
+:: STDERR
+[1m[31mUnable to parse arguments, FORMATTED_EXCEPTION[39m[22m
+
+`;
+
 exports[`Command > run > fails to load command module 1`] = `
 ExitCode=CommandLoadError
 :: STDOUT
@@ -1310,6 +1328,15 @@ ExitCode=CommandLoadError
     at runCommand (#/src/routing/command/run.ts:?:?)
     at runWithInputs (#/tests/routing/command.spec.ts:?:?)
     at #/tests/routing/command.spec.ts:?:?
+
+`;
+
+exports[`Command > run > fails to load command module, with custom exception formatting 1`] = `
+ExitCode=CommandLoadError
+:: STDOUT
+
+:: STDERR
+[1m[31mUnable to load command function, FORMATTED_EXCEPTION[39m[22m
 
 `;
 

--- a/packages/core/tests/routing/command.spec.ts
+++ b/packages/core/tests/routing/command.spec.ts
@@ -2034,6 +2034,29 @@ describe("Command", () => {
                 });
                 expect(result).toMatchSnapshot();
             });
+
+            it("unexpected error, with custom exception formatting", async () => {
+                const error = {
+                    toString() {
+                        throw new Error("Unexpected error thrown by input");
+                    },
+                };
+                const result = await runWithInputs(command, {
+                    ...defaultArgs,
+                    documentationConfig: {
+                        ...defaultArgs.documentationConfig,
+                        disableAnsiColor: false,
+                    },
+                    errorFormatting: {
+                        ...defaultArgs.errorFormatting,
+                        formatException() {
+                            return "FORMATTED_EXCEPTION";
+                        },
+                    },
+                    inputs: [error as any],
+                });
+                expect(result).toMatchSnapshot();
+            });
         });
 
         it("fails to scan missing flags", async () => {
@@ -2158,6 +2181,35 @@ describe("Command", () => {
             expect(result).toMatchSnapshot();
         });
 
+        it("fails to load command module, with custom exception formatting", async () => {
+            const command = buildCommand<{}, []>({
+                loader: async () => {
+                    throw new Error("This command load purposefully throws an error");
+                },
+                parameters: {
+                    positional: { kind: "tuple", parameters: [] },
+                    flags: {},
+                },
+                docs: { brief: "brief" },
+            });
+
+            const result = await runWithInputs(command, {
+                ...defaultArgs,
+                documentationConfig: {
+                    ...defaultArgs.documentationConfig,
+                    disableAnsiColor: false,
+                },
+                errorFormatting: {
+                    ...defaultArgs.errorFormatting,
+                    formatException() {
+                        return "FORMATTED_EXCEPTION";
+                    },
+                },
+                inputs: [],
+            });
+            expect(result).toMatchSnapshot();
+        });
+
         describe("command function throws error", () => {
             class ErrorWithoutStack extends Error {
                 override stack = void 0;
@@ -2188,6 +2240,24 @@ describe("Command", () => {
                     documentationConfig: {
                         ...defaultArgs.documentationConfig,
                         disableAnsiColor: false,
+                    },
+                    inputs: [],
+                });
+                expect(result).toMatchSnapshot();
+            });
+
+            it("with default exit code, custom exception formatting", async () => {
+                const result = await runWithInputs(command, {
+                    ...defaultArgs,
+                    documentationConfig: {
+                        ...defaultArgs.documentationConfig,
+                        disableAnsiColor: false,
+                    },
+                    errorFormatting: {
+                        ...defaultArgs.errorFormatting,
+                        formatException() {
+                            return "FORMATTED_EXCEPTION";
+                        },
                     },
                     inputs: [],
                 });


### PR DESCRIPTION
Related to #93, #132 

**Describe your changes**
There are edge cases where the default formatting of thrown exceptions doesn't work well for some inputs. Rather than make changes to attempt to account for all of those edge cases, supply the ability to override the default formatting with a custom function.

**Testing performed**
Updated test suite with new cases for each of the `CommandErrorFormatting` methods that format an exception.

**Additional context**
There are a handful of unused imports and leftover log calls in the tests that were cleaned up.
