### PR TITLE
fix: allow single application text, disabling locale support

### DIFF
--- a/docs/docs/features/configuration/localization.mdx
+++ b/docs/docs/features/configuration/localization.mdx
@@ -6,23 +6,11 @@ sidebar_position: 4
 
 Every single string of text that is printed by a Stricli application can be customized and controlled by the `localization` configuration. The only exception to this is the internal errors that are thrown by `buildApplication` if the application configuration itself was invalid in some way.
 
-The `context` object provided to the `run` command can optionally include a `locale` property that will be used to control what text is used by the application. For this section, locale roughly refers to [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag), but since application owners provide both the locale and the text loader that interprets the locale, any locale scheme can be used.
-
-## Default Locale
-
-This is the default locale that will be used if the `context` object does not define its own `locale` property. If a default locale is not explicitly set in the configuration, it will be `en`.
-
-## Text Loader
-
-The `loadText` function is responsible for loading the [application text](#application-text) object for the requested locale. It can return `undefined` but doing so will print an error message to stderr and the application will switch to the default locale. If this function returns `undefined` for the default locale, the application will fail with an internal error.
-
-If this function is not specified, it defaults to a function that will return the default `en` application text for all `en` locales.
-
 ## Application Text
 
 The text for an application is composed of several static values and several dynamic functions for errors. The static values are primarily used for documentation, which includes the section headers (`USAGE`, `COMMANDS`, `FLAGS`, etc.), keywords (`optional`, `default`, etc.), and built-in briefs (`Print this help information and exit`, etc.).
 
-The following are brief descriptions of all of the dynamic functions that accept some arguments and output a string to be printed to stderr. All of these have default implementations in the included `en` text.
+You can customize this text by providing a custom `ApplicationText` object. The following are brief descriptions of all of the dynamic functions that accept some arguments and output a string (to be printed to stderr). All of these have default implementations in the included `en` text.
 
 -   `formatException` (optional)
 
@@ -66,3 +54,11 @@ The following are brief descriptions of all of the dynamic functions that accept
 -   `commandErrorResult`
     -   Default: `{err.message}`
     -   This function is called if the command function safely returned an `Error` instance. Note that if an `Error` is thrown, then Stricli will call `exceptionWhileRunningCommand` instead of this function. The `Error` must be returned from the command function and must satisfy `instanceof Error`.
+
+## Locale-specific Text
+
+The `context` object provided to the `run` command can optionally include a `locale` property that can be used to control what text is used by the application. For this section, locale roughly refers to [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag), but since application owners provide both the locale and the text loader that interprets the locale, any locale scheme can be used.
+
+When setting up locale support a default locale must be provided for when the `context` object does not define its own `locale` property. If a default locale is not explicitly set in the configuration, it will be `en`.
+
+The `loadText` function is responsible for loading the [application text](#application-text) object for the requested locale. It can return `undefined` but doing so will print an error message to stderr and the application will switch to the default locale. If this function returns `undefined` for the default locale, the application will fail with an internal error.

--- a/packages/core/src/application/builder.ts
+++ b/packages/core/src/application/builder.ts
@@ -6,6 +6,7 @@ import type { CommandContext } from "../context";
 import { CommandSymbol, type Command } from "../routing/command/types";
 import type { RouteMap } from "../routing/route-map/types";
 import type { RoutingTarget } from "../routing/types";
+import type { ApplicationText } from "../text";
 import { InternalError } from "../util/error";
 import type { Application } from "./types";
 
@@ -36,9 +37,15 @@ export function buildApplication<CONTEXT extends CommandContext>(
             throw new InternalError("Unable to use command with alias -v as root when version info is supplied");
         }
     }
-    const defaultText = config.localization.loadText(config.localization.defaultLocale);
-    if (!defaultText) {
-        throw new InternalError(`No text available for the default locale "${config.localization.defaultLocale}"`);
+    let defaultText: ApplicationText;
+    if ("text" in config.localization) {
+        defaultText = config.localization.text;
+    } else {
+        const text = config.localization.loadText(config.localization.defaultLocale);
+        if (!text) {
+            throw new InternalError(`No text available for the default locale "${config.localization.defaultLocale}"`);
+        }
+        defaultText = text;
     }
     return {
         root,

--- a/packages/core/src/application/documentation.ts
+++ b/packages/core/src/application/documentation.ts
@@ -45,7 +45,7 @@ export function generateHelpTextForAllCommands(
     locale?: string,
 ): readonly DocumentedCommand[] {
     let text = defaultText;
-    if (locale) {
+    if (locale && "loadText" in config.localization) {
         const localeText = config.localization.loadText(locale);
         if (localeText) {
             text = localeText;

--- a/packages/core/src/application/run.ts
+++ b/packages/core/src/application/run.ts
@@ -19,7 +19,7 @@ export async function runApplication<CONTEXT extends CommandContext>(
     context: StricliDynamicCommandContext<CONTEXT>,
 ): Promise<number> {
     let text = defaultText;
-    if (context.locale) {
+    if (context.locale && "loadText" in config.localization) {
         const localeText = config.localization.loadText(context.locale);
         if (localeText) {
             text = localeText;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -180,21 +180,30 @@ export interface CompletionConfiguration {
 /**
  * Configuration for controlling the localization behavior.
  */
-export interface LocalizationConfiguration {
-    /**
-     * The default locale that should be used if the context does not have a locale.
-     *
-     * If unspecified, will default to `en`.
-     */
-    readonly defaultLocale: string;
-    /**
-     * Mapping of locale to application text.
-     * Locale is optionally provided at runtime by the context.
-     *
-     * If unspecified, will return the default English implementation {@link text_en} for all "en" locales.
-     */
-    readonly loadText: (locale: string) => ApplicationText | undefined;
-}
+export type LocalizationConfiguration =
+    | {
+          /**
+           * Single application text object for the intended locale.
+           * If provided, it will be the only text used for this application.
+           * It should only be used when custom locale support is not needed.
+           */
+          readonly text: ApplicationText;
+      }
+    | {
+          /**
+           * The default locale that should be used if the context does not have a locale.
+           *
+           * If unspecified, will default to `en`.
+           */
+          readonly defaultLocale: string;
+          /**
+           * Mapping of locale to application text.
+           * Locale is optionally provided at runtime by the context.
+           *
+           * If unspecified, will return the default English implementation {@link text_en} for all "en" locales.
+           */
+          readonly loadText: (locale: string) => ApplicationText | undefined;
+      };
 
 /**
  * Configuration for controlling the runtime behavior of the application.

--- a/packages/core/tests/application/__snapshots__/run.spec.ts.snap
+++ b/packages/core/tests/application/__snapshots__/run.spec.ts.snap
@@ -1,14 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Application > run > uses provided text, disregards unsupported context locale 1`] = `
-ExitCode=Success
-:: STDOUT
-
-:: STDERR
-[1m[33mApplication does not support "other" locale, defaulting to "en"[39m[22m
-
-`;
-
 exports[`run > basic command at root > display help text for root (with flag alias) 1`] = `
 ExitCode=Success
 :: STDOUT

--- a/packages/core/tests/application/__snapshots__/run.spec.ts.snap
+++ b/packages/core/tests/application/__snapshots__/run.spec.ts.snap
@@ -1,5 +1,14 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Application > run > uses provided text, disregards unsupported context locale 1`] = `
+ExitCode=Success
+:: STDOUT
+
+:: STDERR
+[1m[33mApplication does not support "other" locale, defaulting to "en"[39m[22m
+
+`;
+
 exports[`run > basic command at root > display help text for root (with flag alias) 1`] = `
 ExitCode=Success
 :: STDOUT
@@ -1741,5 +1750,14 @@ ExitCode=Success
 
 :: STDERR
 Application does not support "other" locale, defaulting to "en"
+
+`;
+
+exports[`run > uses provided text, disregards unsupported context locale 1`] = `
+ExitCode=Success
+:: STDOUT
+
+:: STDERR
+[1m[33mApplication does not support "other" locale, defaulting to "en"[39m[22m
 
 `;

--- a/packages/core/tests/application/build.spec.ts
+++ b/packages/core/tests/application/build.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 Bloomberg Finance L.P.
 // Distributed under the terms of the Apache 2.0 license.
 import { describe, expect, it } from "vitest";
-import { buildApplication, buildCommand, type VersionInfo } from "../../src";
+import { buildApplication, buildCommand, text_en, type VersionInfo } from "../../src";
 import { buildBasicRouteMap, buildRouteMapForFakeContext } from "../application";
 
 describe("buildApplication", () => {
@@ -236,7 +236,7 @@ describe("buildApplication", () => {
         ).to.throw('No text available for the default locale "en"');
     });
 
-    it("fails if no text for custom default locale", async () => {
+    it("default text with no loader disables locale support", async () => {
         // GIVEN
         const command = buildCommand({
             loader: async () => {
@@ -257,16 +257,11 @@ describe("buildApplication", () => {
         });
 
         // WHEN
-        expect(() =>
-            buildApplication(command, {
-                name: "cli",
-                localization: {
-                    defaultLocale: "eo",
-                    loadText: (): undefined => {
-                        return;
-                    },
-                },
-            }),
-        ).to.throw('No text available for the default locale "eo"');
+        buildApplication(command, {
+            name: "cli",
+            localization: {
+                text: text_en,
+            },
+        });
     });
 });

--- a/packages/core/tests/application/run.spec.ts
+++ b/packages/core/tests/application/run.spec.ts
@@ -1029,6 +1029,23 @@ describe("run", () => {
         expect(result).toMatchSnapshot();
     });
 
+    it("uses provided text, disregards unsupported context locale", async (context) => {
+        // GIVEN
+        const command = buildBasicCommand();
+        const app = buildApplication(command, {
+            name: "cli",
+            localization: {
+                text: text_en,
+            },
+        });
+
+        // WHEN
+        const result = await runWithInputs(app, [], { locale: "other", colorDepth: 4 });
+
+        // THEN
+        expect(result).toMatchSnapshot();
+    });
+
     describe("nested basic route map with hidden routes", () => {
         // GIVEN
         const rootRouteMap = buildRouteMapForFakeContext({


### PR DESCRIPTION
**Describe your changes**
All of the text formatting logic in Stricli is built with the intention that output can be localized for their intended audience. One downside is that if an application is only intended for a single locale, the way to define that in the API is a bit clunky. Updates `LocalizationConfiguration` to allow for a single `ApplicationText` which is used as the default and all of the behavior to load another based on an alternate locale is disabled.

**Testing performed**
New tests that pass a single app text object.

