### PR TITLE
Migrate create-app to tsdown for new projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4245,20 +4245,20 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.3.1.tgz",
-            "integrity": "sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==",
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+            "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@emnapi/wasi-threads": "1.0.1",
+                "@emnapi/wasi-threads": "1.2.1",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
-            "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+            "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4266,9 +4266,9 @@
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.1.tgz",
-            "integrity": "sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5571,6 +5571,16 @@
                 "node": ">=8.0.0"
             }
         },
+        "node_modules/@oxc-project/types": {
+            "version": "0.122.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+            "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -5644,6 +5654,329 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
             }
+        },
+        "node_modules/@quansync/fs": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@quansync/fs/-/fs-1.0.0.tgz",
+            "integrity": "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "quansync": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
+            }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+            "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+            "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+            "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+            "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+            "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+            "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+            "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+            "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.22.4",
@@ -6655,6 +6988,13 @@
                 "@types/istanbul-lib-report": "*"
             }
         },
+        "node_modules/@types/jsesc": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+            "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -6871,7 +7211,6 @@
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
             "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-            "dev": true,
             "license": "MIT",
             "optional": true
         },
@@ -7747,6 +8086,16 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/ansis": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
+            "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/any-promise": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -7961,6 +8310,74 @@
             "dev": true,
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/ast-kit": {
+            "version": "3.0.0-beta.1",
+            "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-3.0.0-beta.1.tgz",
+            "integrity": "sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^8.0.0-beta.4",
+                "estree-walker": "^3.0.3",
+                "pathe": "^2.0.3"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
+            }
+        },
+        "node_modules/ast-kit/node_modules/@babel/helper-string-parser": {
+            "version": "8.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.3.tgz",
+            "integrity": "sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/ast-kit/node_modules/@babel/helper-validator-identifier": {
+            "version": "8.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.3.tgz",
+            "integrity": "sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/ast-kit/node_modules/@babel/parser": {
+            "version": "8.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.3.tgz",
+            "integrity": "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^8.0.0-rc.3"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/ast-kit/node_modules/@babel/types": {
+            "version": "8.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.3.tgz",
+            "integrity": "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^8.0.0-rc.3",
+                "@babel/helper-validator-identifier": "^8.0.0-rc.3"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
             }
         },
         "node_modules/ast-types-flow": {
@@ -8300,6 +8717,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/birpc": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/birpc/-/birpc-4.0.0.tgz",
+            "integrity": "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/bl": {
@@ -10146,6 +10573,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/defu": {
+            "version": "6.1.6",
+            "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.6.tgz",
+            "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -10344,7 +10778,6 @@
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
             "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
-            "dev": true,
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -10400,6 +10833,27 @@
             },
             "funding": {
                 "url": "https://dotenvx.com"
+            }
+        },
+        "node_modules/dts-resolver": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/dts-resolver/-/dts-resolver-2.1.3.tgz",
+            "integrity": "sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
+            },
+            "peerDependencies": {
+                "oxc-resolver": ">=11.0.0"
+            },
+            "peerDependenciesMeta": {
+                "oxc-resolver": {
+                    "optional": true
+                }
             }
         },
         "node_modules/dunder-proto": {
@@ -10481,6 +10935,16 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/empathic": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+            "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/encodeurl": {
@@ -12257,10 +12721,11 @@
             }
         },
         "node_modules/get-tsconfig": {
-            "version": "4.8.1",
-            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
-            "integrity": "sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==",
+            "version": "4.13.7",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+            "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "resolve-pkg-maps": "^1.0.0"
             },
@@ -12918,6 +13383,13 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
+        "node_modules/hookable": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.0.tgz",
+            "integrity": "sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/hosted-git-info": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
@@ -13302,8 +13774,7 @@
         "node_modules/immutable": {
             "version": "4.3.7",
             "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-            "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
-            "dev": true
+            "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw=="
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
@@ -13326,6 +13797,19 @@
             "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/import-without-cache": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/import-without-cache/-/import-without-cache-0.2.5.tgz",
+            "integrity": "sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
             }
         },
         "node_modules/imurmurhash": {
@@ -14753,7 +15237,6 @@
             "version": "14.0.0",
             "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
             "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "marked": "bin/marked.js"
@@ -17075,7 +17558,6 @@
             "version": "0.55.1",
             "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
             "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "dompurify": "3.2.7",
@@ -17556,6 +18038,17 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
             "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+            "license": "MIT"
+        },
+        "node_modules/obug": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
             "license": "MIT"
         },
         "node_modules/on-finished": {
@@ -19907,6 +20400,23 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/quansync": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/quansync/-/quansync-1.0.0.tgz",
+            "integrity": "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/antfu"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/sxzz"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -20746,6 +21256,40 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/rolldown": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+            "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.122.0",
+                "@rolldown/pluginutils": "1.0.0-rc.12"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+            }
+        },
         "node_modules/rollup": {
             "version": "3.29.5",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
@@ -20898,7 +21442,6 @@
             "version": "1.79.4",
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.79.4.tgz",
             "integrity": "sha512-K0QDSNPXgyqO4GZq2HO5Q70TLxTH6cIT59RdoCHMivrC8rqzaTw5ab9prjz9KUN1El4FLXrBXJhik61JR4HcGg==",
-            "dev": true,
             "dependencies": {
                 "chokidar": "^4.0.0",
                 "immutable": "^4.0.0",
@@ -20968,7 +21511,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
             "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
-            "dev": true,
             "dependencies": {
                 "readdirp": "^4.0.1"
             },
@@ -20983,7 +21525,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.1.tgz",
             "integrity": "sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==",
-            "dev": true,
             "engines": {
                 "node": ">= 14.16.0"
             },
@@ -21095,9 +21636,10 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -23354,6 +23896,20 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/unconfig-core": {
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/unconfig-core/-/unconfig-core-7.5.0.tgz",
+            "integrity": "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@quansync/fs": "^1.0.0",
+                "quansync": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -26316,6 +26872,7 @@
                 "memfs": "^4.9.2",
                 "prettier": "^3.2.5",
                 "sinon": "^18.0.0",
+                "tsdown": "^0.21.7",
                 "tsup": "^6.7.0",
                 "tsx": "^4.8.2",
                 "type-fest": "^3.5.4",
@@ -26323,6 +26880,74 @@
             },
             "engines": {
                 "node": ">=18.x"
+            }
+        },
+        "packages/create-app/node_modules/@babel/generator": {
+            "version": "8.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0-rc.3.tgz",
+            "integrity": "sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^8.0.0-rc.3",
+                "@babel/types": "^8.0.0-rc.3",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
+                "@types/jsesc": "^2.5.0",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "packages/create-app/node_modules/@babel/helper-string-parser": {
+            "version": "8.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.3.tgz",
+            "integrity": "sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "packages/create-app/node_modules/@babel/helper-validator-identifier": {
+            "version": "8.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.3.tgz",
+            "integrity": "sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "packages/create-app/node_modules/@babel/parser": {
+            "version": "8.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.3.tgz",
+            "integrity": "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^8.0.0-rc.3"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "packages/create-app/node_modules/@babel/types": {
+            "version": "8.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.3.tgz",
+            "integrity": "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^8.0.0-rc.3",
+                "@babel/helper-validator-identifier": "^8.0.0-rc.3"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
             }
         },
         "packages/create-app/node_modules/@types/node": {
@@ -26334,11 +26959,183 @@
                 "undici-types": "~5.26.4"
             }
         },
+        "packages/create-app/node_modules/cac": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
+            "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "packages/create-app/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "packages/create-app/node_modules/tinyexec": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+            "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/create-app/node_modules/tsdown": {
+            "version": "0.21.7",
+            "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.21.7.tgz",
+            "integrity": "sha512-ukKIxKQzngkWvOYJAyptudclkm4VQqbjq+9HF5K5qDO8GJsYtMh8gIRwicbnZEnvFPr6mquFwYAVZ8JKt3rY2g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansis": "^4.2.0",
+                "cac": "^7.0.0",
+                "defu": "^6.1.4",
+                "empathic": "^2.0.0",
+                "hookable": "^6.1.0",
+                "import-without-cache": "^0.2.5",
+                "obug": "^2.1.1",
+                "picomatch": "^4.0.4",
+                "rolldown": "1.0.0-rc.12",
+                "rolldown-plugin-dts": "^0.23.2",
+                "semver": "^7.7.4",
+                "tinyexec": "^1.0.4",
+                "tinyglobby": "^0.2.15",
+                "tree-kill": "^1.2.2",
+                "unconfig-core": "^7.5.0",
+                "unrun": "^0.2.34"
+            },
+            "bin": {
+                "tsdown": "dist/run.mjs"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
+            },
+            "peerDependencies": {
+                "@arethetypeswrong/core": "^0.18.1",
+                "@tsdown/css": "0.21.7",
+                "@tsdown/exe": "0.21.7",
+                "@vitejs/devtools": "*",
+                "publint": "^0.3.0",
+                "typescript": "^5.0.0 || ^6.0.0",
+                "unplugin-unused": "^0.5.0"
+            },
+            "peerDependenciesMeta": {
+                "@arethetypeswrong/core": {
+                    "optional": true
+                },
+                "@tsdown/css": {
+                    "optional": true
+                },
+                "@tsdown/exe": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "publint": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                },
+                "unplugin-unused": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/create-app/node_modules/tsdown/node_modules/rolldown-plugin-dts": {
+            "version": "0.23.2",
+            "resolved": "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.23.2.tgz",
+            "integrity": "sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/generator": "8.0.0-rc.3",
+                "@babel/helper-validator-identifier": "8.0.0-rc.3",
+                "@babel/parser": "8.0.0-rc.3",
+                "@babel/types": "8.0.0-rc.3",
+                "ast-kit": "^3.0.0-beta.1",
+                "birpc": "^4.0.0",
+                "dts-resolver": "^2.1.3",
+                "get-tsconfig": "^4.13.7",
+                "obug": "^2.1.1",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
+            },
+            "peerDependencies": {
+                "@ts-macro/tsc": "^0.3.6",
+                "@typescript/native-preview": ">=7.0.0-dev.20260325.1",
+                "rolldown": "^1.0.0-rc.12",
+                "typescript": "^5.0.0 || ^6.0.0",
+                "vue-tsc": "~3.2.0"
+            },
+            "peerDependenciesMeta": {
+                "@ts-macro/tsc": {
+                    "optional": true
+                },
+                "@typescript/native-preview": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                },
+                "vue-tsc": {
+                    "optional": true
+                }
+            }
+        },
         "packages/create-app/node_modules/undici-types": {
             "version": "5.26.5",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true
+        },
+        "packages/create-app/node_modules/unrun": {
+            "version": "0.2.34",
+            "resolved": "https://registry.npmjs.org/unrun/-/unrun-0.2.34.tgz",
+            "integrity": "sha512-LyaghRBR++r7svhDK6tnDz2XaYHWdneBOA0jbS8wnRsHerI9MFljX4fIiTgbbNbEVzZ0C9P1OjWLLe1OqoaaEw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "rolldown": "1.0.0-rc.12"
+            },
+            "bin": {
+                "unrun": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Gugustinette"
+            },
+            "peerDependencies": {
+                "synckit": "^0.11.11"
+            },
+            "peerDependenciesMeta": {
+                "synckit": {
+                    "optional": true
+                }
+            }
         }
     }
 }

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -27,10 +27,10 @@
         "test": "vitest --run",
         "test:update-snapshots": "vitest --run --update",
         "coverage": "vitest --run --coverage.enabled",
-        "build": "tsup --silent",
+        "build": "tsdown --silent",
         "prepublishOnly": "npm run build"
     },
-    "tsup": {
+    "tsdown": {
         "entry": [
             "src/bin/cli.ts"
         ],
@@ -58,6 +58,7 @@
         "memfs": "^4.9.2",
         "prettier": "^3.2.5",
         "sinon": "^18.0.0",
+        "tsdown": "^0.21.7",
         "tsup": "^6.7.0",
         "tsx": "^4.8.2",
         "type-fest": "^3.5.4",

--- a/packages/create-app/src/app.ts
+++ b/packages/create-app/src/app.ts
@@ -74,6 +74,12 @@ const command = buildCommand({
                 optional: true,
                 hidden: true,
             },
+            bundler: {
+                kind: "enum",
+                brief: "Whether to use tsdown (beta - uses Rolldown) or tsup (deprecated - uses esbuild)",
+                values: ["tsdown", "tsup"],
+                default: "tsdown",
+            },
         },
         aliases: {
             n: "name",

--- a/packages/create-app/src/impl.ts
+++ b/packages/create-app/src/impl.ts
@@ -22,7 +22,7 @@ import {
 } from "./files";
 import srcTsconfig from "./tsconfig.json";
 
-interface TsupConfig {
+interface BundlerConfig {
     entry?: string[];
     format?: ("cjs" | "esm" | "iife")[];
     tsconfig?: string;
@@ -32,20 +32,22 @@ interface TsupConfig {
 }
 
 interface LocalPackageJson extends PackageJson.PackageJsonStandard, PackageJson.TypeScriptConfiguration {
-    tsup?: TsupConfig;
+    tsdown?: BundlerConfig;
+    tsup?: BundlerConfig;
 }
 
 function calculateBashCompletionCommand(command: string): string {
     return `__${command}_bash_complete`;
 }
 
-type PackageJsonTemplateValues = Pick<PackageJson.PackageJsonStandard, "name"> &
-    Required<Pick<PackageJson.PackageJsonStandard, "author" | "description" | "license" | "type">>;
+type PackageJsonTemplateValues = Pick<LocalPackageJson, "name"> &
+    Required<Pick<LocalPackageJson, "author" | "description" | "license" | "type">>;
 
 function buildPackageJson(
     values: PackageJsonTemplateValues,
     commandName: string,
     nodeMajorVersion: string | undefined,
+    bundler: "tsdown" | "tsup",
 ): LocalPackageJson {
     return {
         ...values,
@@ -59,10 +61,10 @@ function buildPackageJson(
         },
         scripts: {
             prebuild: "tsc -p src/tsconfig.json",
-            build: "tsup --silent",
+            build: `${bundler} --silent`,
             prepublishOnly: "npm run build",
         },
-        tsup: {
+        [bundler]: {
             entry: ["src/bin/cli.ts"],
             format: [values.type === "commonjs" ? "cjs" : "esm"],
             tsconfig: "src/tsconfig.json",
@@ -75,13 +77,17 @@ function buildPackageJson(
         },
         devDependencies: {
             "@types/node": nodeMajorVersion && `${nodeMajorVersion}.x`,
-            tsup: self.devDependencies.tsup,
+            [bundler]: self.devDependencies[bundler],
             typescript: self.devDependencies.typescript,
         },
     };
 }
 
-function addAutoCompleteBin(packageJson: LocalPackageJson, bashCompleteCommandName: string): LocalPackageJson {
+function addAutoCompleteBin(
+    packageJson: LocalPackageJson,
+    bashCompleteCommandName: string,
+    bundler: CreateProjectFlags["bundler"],
+): LocalPackageJson {
     return {
         ...packageJson,
         dependencies: {
@@ -92,10 +98,10 @@ function addAutoCompleteBin(packageJson: LocalPackageJson, bashCompleteCommandNa
             ...(packageJson.bin as Record<string, string>),
             [bashCompleteCommandName]: "dist/bash-complete.js",
         },
-        tsup: {
-            ...packageJson.tsup,
+        [bundler]: {
+            ...packageJson[bundler],
             /* v8 ignore next -- @preserve */
-            entry: [...(packageJson.tsup?.entry ?? []), "src/bin/bash-complete.ts"],
+            entry: [...(packageJson?.[bundler]?.entry ?? []), "src/bin/bash-complete.ts"],
         },
     };
 }
@@ -115,6 +121,7 @@ export interface CreateProjectFlags extends PackageJsonTemplateValues {
     readonly autoComplete: boolean;
     readonly command?: string;
     readonly nodeVersion?: string;
+    readonly bundler: "tsdown" | "tsup";
 }
 
 export default async function (this: LocalContext, flags: CreateProjectFlags, directoryPath: string): Promise<void> {
@@ -151,12 +158,13 @@ export default async function (this: LocalContext, flags: CreateProjectFlags, di
         },
         commandName,
         nodeMajorVersion,
+        flags.bundler,
     );
 
     const bashCommandName = calculateBashCompletionCommand(commandName);
 
     if (flags.autoComplete) {
-        packageJson = addAutoCompleteBin(packageJson, bashCommandName);
+        packageJson = addAutoCompleteBin(packageJson, bashCommandName, flags.bundler);
         if (flags.template === "multi") {
             packageJson = addPostinstallScript(packageJson, `${commandName} install`);
         } else {

--- a/packages/create-app/src/impl.ts
+++ b/packages/create-app/src/impl.ts
@@ -54,7 +54,7 @@ function buildPackageJson(
         version: "0.0.0",
         files: ["dist"],
         bin: {
-            [commandName]: "dist/cli.js",
+            [commandName]: "dist/cli.mjs",
         },
         engines: {
             node: nodeMajorVersion && `>=${nodeMajorVersion}`,


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #120*

**Describe your changes**

This PR migrates create-app to utilize tsdown for new projects instead of the deprecated tsup, while adding a flag, `--bundler`, to allow for using tsup.

**Testing performed**

I created 2 new projects using create-app with tsdown and tsup, both worked as expected.

**Additional context**

This doesn't cl*se #120, since the rest of the library remains on tsup.
