### PR TITLE
fix: only set exit code if not set by application

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -78,7 +78,7 @@ export async function run<CONTEXT extends CommandContext>(
 ): Promise<void> {
     const exitCode = await runApplication(app, inputs, context);
 
-    // We set the exit code instead of calling exit() so as not
-    // to cancel any pending tasks (e.g. stdout writes)
-    context.process.exitCode = exitCode;
+    // Update exit code to indicate failure without immediately exiting,
+    // only if it hasn't already been set by the application itself.
+    context.process.exitCode ??= exitCode;
 }

--- a/packages/core/tests/__snapshots__/application.spec.ts.snap
+++ b/packages/core/tests/__snapshots__/application.spec.ts.snap
@@ -1809,6 +1809,50 @@ ExitCode=Success
 
 `;
 
+exports[`Application > run > sets exit code > to CommandRunError when no error thrown 1`] = `
+ExitCode=CommandRunError
+:: STDOUT
+
+:: STDERR
+
+`;
+
+exports[`Application > run > sets exit code > to CommandRunError, even if error is thrown 1`] = `
+ExitCode=CommandRunError
+:: STDOUT
+
+:: STDERR
+[1m[31mCommand failed, Error: Command failed with exit code 1
+    at Object.func (#/tests/application.spec.ts:?:?)
+    at runCommand (#/src/routing/command/run.ts:?:?)
+    at run (#/src/index.ts:?:?)
+    at runWithInputs (#/tests/application.spec.ts:?:?)
+    at #/tests/application.spec.ts:?:?
+
+`;
+
+exports[`Application > run > sets exit code > to Success when no error thrown 1`] = `
+ExitCode=Success
+:: STDOUT
+
+:: STDERR
+
+`;
+
+exports[`Application > run > sets exit code > to Success, even if error is thrown 1`] = `
+ExitCode=Success
+:: STDOUT
+
+:: STDERR
+[1m[31mCommand failed, Error: Command failed with exit code 0
+    at Object.func (#/tests/application.spec.ts:?:?)
+    at runCommand (#/src/routing/command/run.ts:?:?)
+    at run (#/src/index.ts:?:?)
+    at runWithInputs (#/tests/application.spec.ts:?:?)
+    at #/tests/application.spec.ts:?:?
+
+`;
+
 exports[`Application > run > uses default text when no text loaded for unsupported context locale 1`] = `
 ExitCode=Success
 :: STDOUT

--- a/packages/core/tests/application.spec.ts
+++ b/packages/core/tests/application.spec.ts
@@ -6,12 +6,14 @@ import {
     buildApplication,
     buildCommand,
     buildRouteMap,
+    ExitCode,
     generateHelpTextForAllCommands,
     numberParser,
     proposeCompletions,
     run,
     text_en,
     type Application,
+    type ApplicationContext,
     type CommandContext,
     type DocumentedCommand,
     type InputCompletion,
@@ -1499,6 +1501,65 @@ describe("Application", () => {
 
             it("displays help text for nested hidden route map", async (context) => {
                 const result = await runWithInputs(app, ["subHidden", "--help"]);
+                expect(result).toMatchSnapshot();
+            });
+        });
+
+        describe("sets exit code", () => {
+            const echoExitCodeCommand = buildCommand({
+                func: function (this: ApplicationContext, { fail, exitCode }: { fail: boolean; exitCode: number }) {
+                    this.process.exitCode = exitCode;
+                    if (fail) {
+                        throw new Error(`Command failed with exit code ${exitCode}`);
+                    }
+                },
+                docs: {
+                    brief: "Echoes the provided exit code by setting it on the context's process",
+                },
+                parameters: {
+                    flags: {
+                        fail: {
+                            brief: "Whether to throw an error after setting the exit code",
+                            kind: "boolean",
+                            default: false,
+                        },
+                        exitCode: {
+                            kind: "parsed",
+                            brief: "Exit code to set",
+                            parse: numberParser,
+                        },
+                    },
+                },
+            });
+            const echoExitCodeApp = buildApplication(echoExitCodeCommand, {
+                name: "cli",
+                documentation: {
+                    alwaysShowHelpAllFlag: true,
+                    useAliasInUsageLine: true,
+                },
+            });
+
+            it("to Success when no error thrown", async (context) => {
+                const result = await runWithInputs(echoExitCodeApp, ["--exitCode", `${ExitCode.Success}`]);
+                expect(result).toMatchSnapshot();
+            });
+
+            it("to Success, even if error is thrown", async (context) => {
+                const result = await runWithInputs(echoExitCodeApp, ["--exitCode", `${ExitCode.Success}`, "--fail"]);
+                expect(result).toMatchSnapshot();
+            });
+
+            it("to CommandRunError when no error thrown", async (context) => {
+                const result = await runWithInputs(echoExitCodeApp, ["--exitCode", `${ExitCode.CommandRunError}`]);
+                expect(result).toMatchSnapshot();
+            });
+
+            it("to CommandRunError, even if error is thrown", async (context) => {
+                const result = await runWithInputs(echoExitCodeApp, [
+                    "--exitCode",
+                    `${ExitCode.CommandRunError}`,
+                    "--fail",
+                ]);
                 expect(result).toMatchSnapshot();
             });
         });


### PR DESCRIPTION
**Describe your changes**
When an application finishes running, Stricli is responsible for determining if there was an error, formatting it if so, and setting the exit code. However, there are cases where the exit code may have been manually set in the application. When that happens, we don't want to override it after the application has finished. The `determineExitCode` feature exists to do this kind of mapping automatically in a more robust way, but there's nothing wrong with setting `process.exitCode` manually.

With the change to `??=`, Stricli will only update the `process.exitCode` property if the value (after the application has completed) is nullish.

**Testing performed**
Added cases for 0 or 1 exit codes, with and without thrown errors.
