### PR TITLE
ci: upgrade to latest node-based actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,15 @@ jobs:
     nx:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 22
                   cache: "npm"
 
             - run: npm ci --legacy-peer-deps
-            - uses: nrwl/nx-set-shas@v4
+            - uses: nrwl/nx-set-shas@v5
 
             - run: npx nx run-many -t format:check lint build coverage

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,12 +13,11 @@ jobs:
         name: Build Docusaurus
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 22
                   cache: npm
 
             - name: Install dependencies

--- a/.github/workflows/pr_labels.yml
+++ b/.github/workflows/pr_labels.yml
@@ -18,7 +18,7 @@ jobs:
         permissions:
             pull-requests: write
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,14 +21,13 @@ jobs:
         permissions:
             id-token: write # needed for provenance data generation
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   fetch-tags: true
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 22
                   cache: "npm"
                   registry-url: "https://registry.npmjs.org/"
 
@@ -37,7 +36,7 @@ jobs:
               run: npm install -g npm@latest
 
             - run: npm ci --legacy-peer-deps
-            - uses: nrwl/nx-set-shas@v4
+            - uses: nrwl/nx-set-shas@v5
 
             - run: npx nx release publish ${{ inputs.dry-run == 'true' && '--dry-run' || '' }}
               env:


### PR DESCRIPTION
**Describe your changes**
Despite manually setting Node.js v20 we're getting deprecation warnings with recommendations to switch to Node.js v24: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

**Testing performed**
Will observe actions on PR
