### PR TITLE
ci: remove step that ensured npm was updated to latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,10 +31,6 @@ jobs:
                   cache: "npm"
                   registry-url: "https://registry.npmjs.org/"
 
-            # Ensure npm 11.5.1 or later is installed
-            - name: Update npm
-              run: npm install -g npm@latest
-
             - run: npm ci --legacy-peer-deps
             - uses: nrwl/nx-set-shas@v5
 


### PR DESCRIPTION
**Describe your changes**
Attempting to fix some bizarre CI failures on `npm i -g npm@latest`. It shouldn't be needed anymore, so just removing this step entirely.

https://github.com/bloomberg/stricli/actions/runs/24671876459/job/72144688709
https://github.com/bloomberg/stricli/actions/runs/24672695353/job/72147709890

