### PR TITLE
fix: use loose boolean parser for env, treat empty as true

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,6 +1,8 @@
 // Copyright 2024 Bloomberg Finance L.P.
 // Distributed under the terms of the Apache 2.0 license.
 
+import { looseBooleanParser } from "./parameter/parser/boolean";
+
 /**
  * Minimal expected interface for an output stream; used to narrow the types of NodeJS's stdout/stderr.
  */
@@ -64,7 +66,7 @@ export type EnvironmentVariableName = "STRICLI_SKIP_VERSION_CHECK" | "STRICLI_NO
  */
 export function checkEnvironmentVariable(process: StricliProcess, varName: EnvironmentVariableName): boolean {
     const value = process.env?.[varName];
-    return typeof value === "string" && value !== "0";
+    return typeof value === "string" && looseBooleanParser(value);
 }
 
 /**

--- a/packages/core/src/parameter/parser/boolean.ts
+++ b/packages/core/src/parameter/parser/boolean.ts
@@ -15,14 +15,17 @@ export const booleanParser = (input: string): boolean => {
     throw new SyntaxError(`Cannot convert ${input} to a boolean`);
 };
 
-const TRUTHY_VALUES = new Set(["true", "t", "yes", "y", "on", "1"]);
+const TRUTHY_VALUES = new Set(["true", "t", "yes", "y", "on", "1", ""]);
 const FALSY_VALUES = new Set(["false", "f", "no", "n", "off", "0"]);
 
 /**
  * Parses input strings as booleans (loosely).
  * Transforms to lowercase and then checks against the following values:
- *  - `true`: `"true"`, `"t"`, `"yes"`, `"y"`, `"on"`, `"1"`
+ *  - `true`: `"true"`, `"t"`, `"yes"`, `"y"`, `"on"`, `"1"`, `""`
  *  - `false`: `"false"`, `"f"`, `"no"`, `"n"`, `"off"`, `"0"`
+ *
+ * Parsers are only executed when an input is provided,
+ * so the empty string is treated as a truthy value (i.e. a flag that is present but has no value is treated as `true`).
  */
 export const looseBooleanParser = (input: string): boolean => {
     const value = input.toLowerCase();

--- a/packages/core/tests/__snapshots__/application.spec.ts.snap
+++ b/packages/core/tests/__snapshots__/application.spec.ts.snap
@@ -407,6 +407,25 @@ Latest available version is 1.1.0 (currently running 1.0.0)
 
 `;
 
+exports[`Application > run > basic command at root > with outdated version info (as static string) > display help text for root, warn on outdated version, ansi color with env var set to yes 1`] = `
+ExitCode=Success
+:: STDOUT
+USAGE
+  cli
+  cli --help
+  cli --version
+
+basic command
+
+FLAGS
+  -h --help     Print help information and exit
+  -v --version  Print version information and exit
+
+:: STDERR
+Latest available version is 1.1.0 (currently running 1.0.0)
+
+`;
+
 exports[`Application > run > basic command at root > with outdated version info (as static string) > display help text for root, warn on outdated version, no ansi color with env var 1`] = `
 ExitCode=Success
 :: STDOUT
@@ -727,6 +746,15 @@ ExitCode=Success
 
 :: STDERR
 Latest available version is 1.1.0 (currently running 1.0.0)
+
+`;
+
+exports[`Application > run > basic route map at root > with outdated version info > display help text for root, do not skip check with env var set to yes 1`] = `
+ExitCode=Success
+:: STDOUT
+1.0.0
+
+:: STDERR
 
 `;
 

--- a/packages/core/tests/application.spec.ts
+++ b/packages/core/tests/application.spec.ts
@@ -544,6 +544,16 @@ describe("Application", () => {
                     expect(result).toMatchSnapshot();
                 });
 
+                it("display help text for root, warn on outdated version, ansi color with env var set to yes", async (context) => {
+                    const result = await runWithInputs(appWithOutdatedVersion, ["--help"], {
+                        colorDepth: void 0,
+                        env: {
+                            STRICLI_NO_COLOR: "yes",
+                        },
+                    });
+                    expect(result).toMatchSnapshot();
+                });
+
                 it("request current version", async (context) => {
                     const result = await runWithInputs(appWithOutdatedVersion, ["--version"]);
                     expect(result).toMatchSnapshot();
@@ -766,6 +776,15 @@ describe("Application", () => {
                     const result = await runWithInputs(appWithOutdatedVersion, ["--version"], {
                         env: {
                             STRICLI_SKIP_VERSION_CHECK: "0",
+                        },
+                    });
+                    expect(result).toMatchSnapshot();
+                });
+
+                it("display help text for root, do not skip check with env var set to yes", async (context) => {
+                    const result = await runWithInputs(appWithOutdatedVersion, ["--version"], {
+                        env: {
+                            STRICLI_SKIP_VERSION_CHECK: "yes",
                         },
                     });
                     expect(result).toMatchSnapshot();

--- a/packages/core/tests/parameter/parsers/boolean.spec.ts
+++ b/packages/core/tests/parameter/parsers/boolean.spec.ts
@@ -56,6 +56,7 @@ describe("loose boolean parser", () => {
         ["off", false],
         ["OFF", false],
         ["Off", false],
+        ["", true],
     ]);
 
     testParserError(looseBooleanParser, [


### PR DESCRIPTION
**Describe your changes**
The "loose" boolean parser is used to support ambiguous boolean values in flags and (now) environment variables. The parser is only called when there is a value to parse (i.e. it is never given `undefined` as a value) so the presence of *some* value (even an empty string) indicates at least a minimum level of truthiness.

For environment variables, the previous logic only compared it to `"0"` but now treats it as a loose boolean. 

**Testing performed**
Adds new test case for loose boolean parser, and new cases for environment variable checks.

