### PR TITLE
chore(release): 1.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 1.2.7 (2026-05-04)
+
+### 🩹 Fixes
+
+- only set exit code if not set by application ([85a4a14](https://github.com/bloomberg/stricli/commit/85a4a14))
+- remove unnecessary logging ([ca534c9](https://github.com/bloomberg/stricli/commit/ca534c9))
+- treat empty string as true for loose boolean parser ([6c2e6b6](https://github.com/bloomberg/stricli/commit/6c2e6b6))
+- use loose boolean parser to check env vars ([6a7f180](https://github.com/bloomberg/stricli/commit/6a7f180))
+- allow override for formatException on formatting object ([2f2ed04](https://github.com/bloomberg/stricli/commit/2f2ed04))
+- allow single application text, disabling locale support ([d7de2b1](https://github.com/bloomberg/stricli/commit/d7de2b1))
+
+### ❤️ Thank You
+
+- Michael Molisani
+- mmolisani
+
 ## 1.2.6 (2026-02-20)
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -25616,10 +25616,10 @@
         },
         "packages/auto-complete": {
             "name": "@stricli/auto-complete",
-            "version": "1.2.6",
+            "version": "1.2.7",
             "license": "Apache-2.0",
             "dependencies": {
-                "@stricli/core": "^1.2.6"
+                "@stricli/core": "^1.2.7"
             },
             "bin": {
                 "auto-complete": "dist/bin/cli.js"
@@ -25637,7 +25637,7 @@
         },
         "packages/core": {
             "name": "@stricli/core",
-            "version": "1.2.6",
+            "version": "1.2.7",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/chai": "^4.3.11",
@@ -26295,11 +26295,11 @@
         },
         "packages/create-app": {
             "name": "@stricli/create-app",
-            "version": "1.2.6",
+            "version": "1.2.7",
             "license": "Apache-2.0",
             "dependencies": {
-                "@stricli/auto-complete": "^1.2.6",
-                "@stricli/core": "^1.2.6"
+                "@stricli/auto-complete": "^1.2.7",
+                "@stricli/core": "^1.2.7"
             },
             "bin": {
                 "create-app": "dist/cli.js"

--- a/packages/auto-complete/package.json
+++ b/packages/auto-complete/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stricli/auto-complete",
-    "version": "1.2.6",
+    "version": "1.2.7",
     "description": "Common utilities for enhancing Stricli applications with autocomplete",
     "license": "Apache-2.0",
     "repository": {
@@ -52,6 +52,6 @@
         "typescript": "5.6.x"
     },
     "dependencies": {
-        "@stricli/core": "^1.2.6"
+        "@stricli/core": "^1.2.7"
     }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stricli/core",
-    "version": "1.2.6",
+    "version": "1.2.7",
     "description": "Build complex CLIs with type safety and no dependencies",
     "license": "Apache-2.0",
     "repository": {

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stricli/create-app",
-    "version": "1.2.6",
+    "version": "1.2.7",
     "description": "Generate a new Stricli application",
     "license": "Apache-2.0",
     "repository": {
@@ -43,8 +43,8 @@
         "minify": true
     },
     "dependencies": {
-        "@stricli/auto-complete": "^1.2.6",
-        "@stricli/core": "^1.2.6"
+        "@stricli/auto-complete": "^1.2.7",
+        "@stricli/core": "^1.2.7"
     },
     "devDependencies": {
         "@types/chai": "^4.3.16",


### PR DESCRIPTION
**Describe your changes**
Ran `npx nx release --skip-publish` to bump version and generate changelog. New versions of packages will be published when this PR is merged to main.
