### PR TITLE
ci: revert step to ensure npm updated to at least 11.5.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,10 @@ jobs:
                   cache: "npm"
                   registry-url: "https://registry.npmjs.org/"
 
+            # Ensure npm 11.5.1 or later is installed
+            - name: Update npm
+              run: npm install -g npm@latest
+
             - run: npm ci --legacy-peer-deps
             - uses: nrwl/nx-set-shas@v5
 


### PR DESCRIPTION
Reverts bloomberg/stricli#150

Latest node image still doesn't have npm >=11.5.1 by default