### PR TITLE
ci: set node/npm version in package.json, use in setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
 
             - uses: actions/setup-node@v6
               with:
+                  node-version-file: package.json
                   cache: "npm"
 
             - run: npm ci --legacy-peer-deps

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,7 @@ jobs:
                   fetch-depth: 0
             - uses: actions/setup-node@v6
               with:
+                  node-version-file: package.json
                   cache: npm
 
             - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,12 +28,9 @@ jobs:
 
             - uses: actions/setup-node@v6
               with:
+                  node-version-file: package.json
                   cache: "npm"
                   registry-url: "https://registry.npmjs.org/"
-
-            # Ensure npm 11.5.1 or later is installed
-            - name: Update npm
-              run: npm install -g npm@latest
 
             - run: npm ci --legacy-peer-deps
             - uses: nrwl/nx-set-shas@v5

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,9 @@
                 "typescript": "^5.6.2",
                 "typescript-eslint": "^8.6.0",
                 "vitest": "^4.0.12"
+            },
+            "engines": {
+                "node": ">=24.5.0"
             }
         },
         "docs": {
@@ -6871,7 +6874,6 @@
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
             "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-            "dev": true,
             "license": "MIT",
             "optional": true
         },
@@ -10344,7 +10346,6 @@
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
             "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
-            "dev": true,
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -13302,8 +13303,7 @@
         "node_modules/immutable": {
             "version": "4.3.7",
             "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-            "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
-            "dev": true
+            "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw=="
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
@@ -14753,7 +14753,6 @@
             "version": "14.0.0",
             "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
             "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "marked": "bin/marked.js"
@@ -17075,7 +17074,6 @@
             "version": "0.55.1",
             "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
             "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "dompurify": "3.2.7",
@@ -20898,7 +20896,6 @@
             "version": "1.79.4",
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.79.4.tgz",
             "integrity": "sha512-K0QDSNPXgyqO4GZq2HO5Q70TLxTH6cIT59RdoCHMivrC8rqzaTw5ab9prjz9KUN1El4FLXrBXJhik61JR4HcGg==",
-            "dev": true,
             "dependencies": {
                 "chokidar": "^4.0.0",
                 "immutable": "^4.0.0",
@@ -20968,7 +20965,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
             "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
-            "dev": true,
             "dependencies": {
                 "readdirp": "^4.0.1"
             },
@@ -20983,7 +20979,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.1.tgz",
             "integrity": "sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==",
-            "dev": true,
             "engines": {
                 "node": ">= 14.16.0"
             },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
         "docs",
         "packages/*"
     ],
-    "packageManager": "npm@10.4.0",
+    "engines": {
+        "node": ">=24.5.0"
+    },
+    "packageManager": "npm@11.5.1",
     "nx": {},
     "scripts": {
         "format": "prettier --config .prettierrc -w *.md *.json *.mjs",


### PR DESCRIPTION
Resolves issue tackled by #150 #156 

**Describe your changes**
Set `engines.node` to `>=24.5.0` in the workspace-level `package.json`. This is then picked up by every `actions/setup-node` step. 

I've also set `packageManager` to `npm@11.5.1`. While this is read by `actions/setup-node` for dependency caching, it does **NOT** determine which version of `npm` is used by the workflow. I picked `24.5.0` as the minimum because that is the version that first shipped with npm `11.5.1`, and that is the minimum version necessary to use the trusted publisher workflow.

**Testing performed**
~Will confirm by running workflow manually in `--dry-run` mode.~
