### PR TITLE
ci: use separate step for dry run publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,11 +9,11 @@ on:
             - main
     workflow_dispatch:
         inputs:
-            dry-run:
+            dry_run:
                 type: boolean
                 required: true
                 default: true
-                description: Trigger publish as a dry run, so no packages are published.
+                description: Add `--dry-run` flag to publish command
 
 jobs:
     publish:
@@ -35,6 +35,10 @@ jobs:
             - run: npm ci --legacy-peer-deps
             - uses: nrwl/nx-set-shas@v5
 
-            - run: npx nx release publish ${{ inputs.dry-run == 'true' && '--dry-run' || '' }}
+            - if: ${{ inputs.dry_run == 'true' }}
+              run: npx nx release publish --dry-run
+
+            - if: ${{ inputs.dry_run != 'true' }} # always runs for push events
+              run: npx nx release publish
               env:
                   NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
**Describe your changes**
During previous testing of the publish workflow, I initiated it with the dry-run input enabled but it did not actually add the `--dry-run` flag. Splitting this logic into two separate steps should restore the intended behavior.