### PR TITLE
ci: new workflow to create release PR

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,61 @@
+name: Create Release
+
+# Declare default permissions as read-only
+permissions: read-all
+
+on:
+    workflow_dispatch:
+        inputs:
+            version_bump:
+                description: Version bump for this release
+                required: true
+                type: choice
+                default: patch
+                options:
+                    - patch
+                    - minor
+                    - major
+            dry_run:
+                type: boolean
+                required: true
+                default: true
+                description: Simulate Nx release with `--dry-run`
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+                  fetch-tags: true
+
+            - uses: actions/setup-node@v6
+              with:
+                  node-version-file: package.json
+                  cache: "npm"
+                  registry-url: "https://registry.npmjs.org/"
+
+            - run: npm ci --legacy-peer-deps
+            - uses: nrwl/nx-set-shas@v5
+
+            - name: Simulate Release (Dry Run)
+              if: ${{ inputs.dry_run }}
+              run: |
+                npx nx release ${{ inputs.version_bump }} --skip-publish --dry-run
+
+            - name: Create Release PR and Prerelease on Github
+              if: ${{ !inputs.dry_run }}
+              env:
+                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                git config user.name "github-actions[bot]"
+                git config user.email "github-actions[bot]@users.noreply.github.com"
+                git checkout -b "release-$GITHUB_RUN_NUMBER"
+                npx nx release ${{ inputs.version_bump }} --skip-publish
+                RELEASE_VERSION=$(npm pkg get version --workspaces | jq -r '.["@stricli/core"]')
+                gh release edit "v$RELEASE_VERSION" --prerelease=true
+                gh pr create --title "Release $RELEASE_VERSION" --body "Automated release PR for ${{ inputs.version_bump }} version bump to release v$RELEASE_VERSION." --head "release-$GITHUB_RUN_NUMBER" --base main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,13 +7,6 @@ on:
     push:
         branches:
             - main
-    workflow_dispatch:
-        inputs:
-            dry-run:
-                type: boolean
-                required: true
-                default: true
-                description: Trigger publish as a dry run, so no packages are published.
 
 jobs:
     publish:
@@ -35,6 +28,11 @@ jobs:
             - run: npm ci --legacy-peer-deps
             - uses: nrwl/nx-set-shas@v5
 
-            - run: npx nx release publish ${{ inputs.dry-run == 'true' && '--dry-run' || '' }}
+            - run: RELEASE_VERSION=$(npm pkg get version --workspaces | jq -r '.["@stricli/core"]')
+            - run: npx nx release publish
               env:
                   NPM_CONFIG_PROVENANCE: true
+
+            - run: gh release edit "v$RELEASE_VERSION" --prerelease=false --latest
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Describe your changes**
New workflow to automate the process of creating a release PR (i.e. #155, #143, etc.) with options for `patch`/`minor`/`major` version bumps. The workflow sets `github-actions[bot]` as the active user, creates a temporary release branch, and then triggers `nx release [bump] --skip-publish`. Nx should commit the version bump changes, tag, and push before creating a new GitHub release. After that completes, the workflow edits the GitHub release so that it is "prerelease" (there is no configuration option in Nx to do this on creation). Finally, we create a new pull request from the temporary release branch.

When run with the "dry run" input, it only simulates the release by calling `nx release [bump] --dry-run`.

**Testing performed**
Unable to test this new workflow against this repo because `workflow_dispatch` events can only be triggered for workflows that already exist in the default branch.
