### PR TITLE
ci: skip publish if there is no pending release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,11 +28,14 @@ jobs:
             - run: npm ci --legacy-peer-deps
             - uses: nrwl/nx-set-shas@v5
 
+            - run: LATEST_VERSION=$(npm view @stricli/core --json | jq -r '.version')
             - run: RELEASE_VERSION=$(npm pkg get version --workspaces | jq -r '.["@stricli/core"]')
-            - run: npx nx release publish
+
+            - name: Publish to npm and update GitHub Release
+              if: ${{ env.LATEST_VERSION != env.RELEASE_VERSION }}
               env:
                   NPM_CONFIG_PROVENANCE: true
-
-            - run: gh release edit "v$RELEASE_VERSION" --prerelease=false --latest
-              env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                npx nx release publish
+                gh release edit "v$RELEASE_VERSION" --prerelease=false --latest


### PR DESCRIPTION
Follow-up from #160.

Previous publish workflow could always be invoked, even if there wasn't a pending release (it would just be a no-op). However, now that there's logic to edit the GitHub release, this should only be called when there's a pending release (i.e. the local version doesn't match whatever is in the registry for `latest`). 