### PR TITLE
fix: handle argument escape sequence in route scanner

### DIFF
--- a/packages/core/src/routing/scanner.ts
+++ b/packages/core/src/routing/scanner.ts
@@ -53,21 +53,30 @@ export function buildRouteScanner<CONTEXT extends CommandContext>(
     let target: RoutingTarget<CONTEXT> | undefined;
     let rootLevel = true;
     let helpRequested: HelpRequested = false;
+    let treatInputsAsArguments = false;
 
     return {
         next: (input) => {
-            if (input === "--help" || input === "-h") {
-                helpRequested = true;
-                if (!target) {
-                    target = current;
-                }
+            if (!treatInputsAsArguments && config.allowArgumentEscapeSequence && input === "--") {
+                treatInputsAsArguments = true;
+                unprocessedInputs.push(input);
                 return;
-            } else if (input === "--helpAll" || input === "--help-all" || input === "-H") {
-                helpRequested = "all";
-                if (!target) {
-                    target = current;
+            }
+
+            if (!treatInputsAsArguments) {
+                if (input === "--help" || input === "-h") {
+                    helpRequested = true;
+                    if (!target) {
+                        target = current;
+                    }
+                    return;
+                } else if (input === "--helpAll" || input === "--help-all" || input === "-H") {
+                    helpRequested = "all";
+                    if (!target) {
+                        target = current;
+                    }
+                    return;
                 }
-                return;
             }
 
             if (target) {

--- a/packages/core/tests/routing/scanner.spec.ts
+++ b/packages/core/tests/routing/scanner.spec.ts
@@ -3,43 +3,35 @@
 import { describe, expect, it } from "vitest";
 import { buildCommand, buildRouteMap, type CommandContext, type ScannerConfiguration } from "../../src";
 // eslint-disable-next-line no-restricted-imports
-import { CommandSymbol } from "../../src/routing/command/types";
-// eslint-disable-next-line no-restricted-imports
 import { buildRouteScanner, type RouteNotFoundError, type RouteScanResult } from "../../src/routing/scanner";
 
-function testScan(
+function confirmRouteScanResult(
     args: Parameters<typeof buildRouteScanner<CommandContext>>,
     inputs: readonly string[],
     expected: RouteScanResult<CommandContext>,
 ): void {
-    it(`scans [${inputs.map((input) => `"${input}"`).join(", ")}] to ${
-        expected.target.kind === CommandSymbol ? "command" : "route map"
-    } at /${expected.prefix.join("/")} with ${JSON.stringify(args[1])}`, () => {
-        const scanner = buildRouteScanner(...args);
-        for (const input of inputs) {
-            scanner.next(input);
-        }
-        const result = scanner.finish();
-        expect(result).to.deep.equal(expected);
-    });
+    const scanner = buildRouteScanner(...args);
+    for (const input of inputs) {
+        scanner.next(input);
+    }
+    const result = scanner.finish();
+    expect(result).to.deep.equal(expected);
 }
 
-function testScanError(
+function confirmRouteScanError(
     args: Parameters<typeof buildRouteScanner<CommandContext>>,
     inputs: readonly string[],
     expected: RouteNotFoundError<CommandContext>,
 ): void {
-    it(`scan [${inputs.join(" ")}] fails with ${JSON.stringify(args[1])}`, () => {
-        const scanner = buildRouteScanner(...args);
-        let error: RouteNotFoundError<CommandContext> | undefined;
-        for (const input of inputs) {
-            if (error) {
-                expect.fail(`Error encountered before end of inputs, did not scan "${input}"`);
-            }
-            error = scanner.next(input);
+    const scanner = buildRouteScanner(...args);
+    let error: RouteNotFoundError<CommandContext> | undefined;
+    for (const input of inputs) {
+        if (error) {
+            expect.fail(`Error encountered before end of inputs, did not scan "${input}"`);
         }
-        expect(error).to.deep.equal(expected);
-    });
+        error = scanner.next(input);
+    }
+    expect(error).to.deep.equal(expected);
 }
 
 describe("RouteScanner", () => {
@@ -77,93 +69,190 @@ describe("RouteScanner", () => {
             docs: { brief: "top command brief" },
         });
 
-        testScan([command, defaultScannerConfig, ["cli"]], [], {
-            helpRequested: false,
-            target: command,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([command, defaultScannerConfig, ["cli"]], ["--help"], {
-            helpRequested: true,
-            target: command,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([command, defaultScannerConfig, ["cli"]], ["-h"], {
-            helpRequested: true,
-            target: command,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([command, defaultScannerConfig, ["cli"]], ["--help", "--help"], {
-            helpRequested: true,
-            target: command,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([command, defaultScannerConfig, ["cli"]], ["--helpAll"], {
-            helpRequested: "all",
-            target: command,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([command, defaultScannerConfig, ["cli"]], ["-H"], {
-            helpRequested: "all",
-            target: command,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([command, defaultScannerConfig, ["cli"]], ["--help", "--helpAll"], {
-            helpRequested: "all",
-            target: command,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([command, defaultScannerConfig, ["cli"]], ["foo", "bar", "baz"], {
-            helpRequested: false,
-            target: command,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: ["foo", "bar", "baz"],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([command, defaultScannerConfig, ["cli"]], ["--help", "foo", "bar", "baz"], {
-            helpRequested: true,
-            target: command,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: ["foo", "bar", "baz"],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([command, defaultScannerConfig, ["cli"]], ["foo", "--help", "bar", "baz"], {
-            helpRequested: true,
-            target: command,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: ["foo", "bar", "baz"],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([command, defaultScannerConfig, ["cli"]], ["foo", "bar", "--help", "baz"], {
-            helpRequested: true,
-            target: command,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: ["foo", "bar", "baz"],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
+        describe("scans root as target", () => {
+            const commonExpectedResult = {
+                target: command,
+                prefix: ["cli"],
+                rootLevel: true,
+                aliases: { original: [], "convert-camel-to-kebab": [] },
+            } satisfies Partial<RouteScanResult<CommandContext>>;
+
+            it("with no inputs", () => {
+                confirmRouteScanResult([command, defaultScannerConfig, ["cli"]], [], {
+                    ...commonExpectedResult,
+                    helpRequested: false,
+                    unprocessedInputs: [],
+                });
+            });
+
+            it("with help flag", () => {
+                confirmRouteScanResult([command, defaultScannerConfig, ["cli"]], ["--help"], {
+                    ...commonExpectedResult,
+                    helpRequested: true,
+                    unprocessedInputs: [],
+                });
+            });
+
+            it("with help flag (alias)", () => {
+                confirmRouteScanResult([command, defaultScannerConfig, ["cli"]], ["-h"], {
+                    ...commonExpectedResult,
+                    helpRequested: true,
+                    unprocessedInputs: [],
+                });
+            });
+
+            it("with help flag (extraneous help flags provided)", () => {
+                confirmRouteScanResult([command, defaultScannerConfig, ["cli"]], ["--help", "--help"], {
+                    ...commonExpectedResult,
+                    helpRequested: true,
+                    unprocessedInputs: [],
+                });
+            });
+
+            it("with helpAll flag", () => {
+                confirmRouteScanResult([command, defaultScannerConfig, ["cli"]], ["--helpAll"], {
+                    ...commonExpectedResult,
+                    helpRequested: "all",
+                    unprocessedInputs: [],
+                });
+            });
+
+            it("with helpAll flag (alias)", () => {
+                confirmRouteScanResult([command, defaultScannerConfig, ["cli"]], ["-H"], {
+                    ...commonExpectedResult,
+                    helpRequested: "all",
+                    unprocessedInputs: [],
+                });
+            });
+
+            it("with helpAll flag (both help and helpAll provided)", () => {
+                confirmRouteScanResult([command, defaultScannerConfig, ["cli"]], ["--help", "--helpAll"], {
+                    ...commonExpectedResult,
+                    helpRequested: "all",
+                    unprocessedInputs: [],
+                });
+            });
+
+            it("with unprocessed inputs", () => {
+                confirmRouteScanResult([command, defaultScannerConfig, ["cli"]], ["foo", "bar", "baz"], {
+                    ...commonExpectedResult,
+                    helpRequested: false,
+                    unprocessedInputs: ["foo", "bar", "baz"],
+                });
+            });
+
+            it("with unprocessed inputs containing other flags", () => {
+                confirmRouteScanResult([command, defaultScannerConfig, ["cli"]], ["--foo", "--bar", "--baz"], {
+                    ...commonExpectedResult,
+                    helpRequested: false,
+                    unprocessedInputs: ["--foo", "--bar", "--baz"],
+                });
+            });
+
+            it("with unprocessed inputs containing other flags (aliases)", () => {
+                confirmRouteScanResult([command, defaultScannerConfig, ["cli"]], ["-f", "-b", "-B"], {
+                    ...commonExpectedResult,
+                    helpRequested: false,
+                    unprocessedInputs: ["-f", "-b", "-B"],
+                });
+            });
+
+            it("with unprocessed inputs containing other flags (combined aliases)", () => {
+                confirmRouteScanResult([command, defaultScannerConfig, ["cli"]], ["-fbB"], {
+                    ...commonExpectedResult,
+                    helpRequested: false,
+                    unprocessedInputs: ["-fbB"],
+                });
+            });
+
+            it("with unprocessed inputs containing other flags and values", () => {
+                confirmRouteScanResult([command, defaultScannerConfig, ["cli"]], ["--foo", "1", "--bar", "2"], {
+                    ...commonExpectedResult,
+                    helpRequested: false,
+                    unprocessedInputs: ["--foo", "1", "--bar", "2"],
+                });
+            });
+
+            it("with unprocessed inputs containing other flags with values", () => {
+                confirmRouteScanResult([command, defaultScannerConfig, ["cli"]], ["--foo=1", "--bar=2"], {
+                    ...commonExpectedResult,
+                    helpRequested: false,
+                    unprocessedInputs: ["--foo=1", "--bar=2"],
+                });
+            });
+
+            it("with unprocessed inputs containing help flag after argument escape sequence", () => {
+                confirmRouteScanResult(
+                    [
+                        command,
+                        {
+                            ...defaultScannerConfig,
+                            allowArgumentEscapeSequence: true,
+                        },
+                        ["cli"],
+                    ],
+                    ["--", "--help"],
+                    {
+                        ...commonExpectedResult,
+                        helpRequested: false,
+                        unprocessedInputs: ["--", "--help"],
+                    },
+                );
+            });
+
+            it("with unprocessed inputs containing helpAll flag after argument escape sequence", () => {
+                confirmRouteScanResult(
+                    [
+                        command,
+                        {
+                            ...defaultScannerConfig,
+                            allowArgumentEscapeSequence: true,
+                        },
+                        ["cli"],
+                    ],
+                    ["--", "--helpAll"],
+                    {
+                        ...commonExpectedResult,
+                        helpRequested: false,
+                        unprocessedInputs: ["--", "--helpAll"],
+                    },
+                );
+            });
+
+            it("with unprocessed inputs containing help flag before argument escape sequence", () => {
+                confirmRouteScanResult(
+                    [
+                        command,
+                        {
+                            ...defaultScannerConfig,
+                            allowArgumentEscapeSequence: true,
+                        },
+                        ["cli"],
+                    ],
+                    ["--help", "--"],
+                    {
+                        ...commonExpectedResult,
+                        helpRequested: true,
+                        unprocessedInputs: ["--"],
+                    },
+                );
+            });
+
+            it("with help flag and trailing unprocessed inputs", () => {
+                confirmRouteScanResult([command, defaultScannerConfig, ["cli"]], ["--help", "foo", "bar", "baz"], {
+                    ...commonExpectedResult,
+                    helpRequested: true,
+                    unprocessedInputs: ["foo", "bar", "baz"],
+                });
+            });
+
+            it("with help flag in between unprocessed inputs", () => {
+                confirmRouteScanResult([command, defaultScannerConfig, ["cli"]], ["foo", "--help", "bar", "baz"], {
+                    ...commonExpectedResult,
+                    helpRequested: true,
+                    unprocessedInputs: ["foo", "bar", "baz"],
+                });
+            });
         });
     });
 
@@ -213,373 +302,476 @@ describe("RouteScanner", () => {
             },
         });
 
-        testScan([routeMap, defaultScannerConfig, ["cli"]], [], {
-            helpRequested: false,
-            target: routeMap,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["--help"], {
-            helpRequested: true,
-            target: routeMap,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["-h"], {
-            helpRequested: true,
-            target: routeMap,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["--help", "command"], {
-            helpRequested: true,
-            target: routeMap,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: ["command"],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["command"], {
-            helpRequested: false,
-            target: topCommand,
-            prefix: ["cli", "command"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["command", "--help"], {
-            helpRequested: true,
-            target: topCommand,
-            prefix: ["cli", "command"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["command", "foo", "bar", "baz"], {
-            helpRequested: false,
-            target: topCommand,
-            prefix: ["cli", "command"],
-            rootLevel: false,
-            unprocessedInputs: ["foo", "bar", "baz"],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["camelCase"], {
-            helpRequested: false,
-            target: subRouteMap,
-            prefix: ["cli", "camelCase"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["camelCase", "--help"], {
-            helpRequested: true,
-            target: subRouteMap,
-            prefix: ["cli", "camelCase"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["camelCase", "doNothing1"], {
-            helpRequested: false,
-            target: subCommand,
-            prefix: ["cli", "camelCase", "doNothing1"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["camelCase", "do-nothing2"], {
-            helpRequested: false,
-            target: subCommand,
-            prefix: ["cli", "camelCase", "do-nothing2"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["kebab-case"], {
-            helpRequested: false,
-            target: subRouteMap,
-            prefix: ["cli", "kebab-case"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["kebab-case", "--help"], {
-            helpRequested: true,
-            target: subRouteMap,
-            prefix: ["cli", "kebab-case"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["kebab-case", "doNothing1"], {
-            helpRequested: false,
-            target: subCommand,
-            prefix: ["cli", "kebab-case", "doNothing1"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["kebab-case", "do-nothing2"], {
-            helpRequested: false,
-            target: subCommand,
-            prefix: ["cli", "kebab-case", "do-nothing2"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
+        describe("with 'original' case style", () => {
+            describe("scans root as target", () => {
+                it("with no inputs", () => {
+                    confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], [], {
+                        helpRequested: false,
+                        target: routeMap,
+                        prefix: ["cli"],
+                        rootLevel: true,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with help flag", () => {
+                    confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["--help"], {
+                        helpRequested: true,
+                        target: routeMap,
+                        prefix: ["cli"],
+                        rootLevel: true,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with help flag (alias)", () => {
+                    confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["-h"], {
+                        helpRequested: true,
+                        target: routeMap,
+                        prefix: ["cli"],
+                        rootLevel: true,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with help flag, leave post-help inputs unprocessed", () => {
+                    confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["--help", "command"], {
+                        helpRequested: true,
+                        target: routeMap,
+                        prefix: ["cli"],
+                        rootLevel: true,
+                        unprocessedInputs: ["command"],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+            });
+
+            describe("scans nested command as target", () => {
+                it("with simple name", () => {
+                    confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["command"], {
+                        helpRequested: false,
+                        target: topCommand,
+                        prefix: ["cli", "command"],
+                        rootLevel: false,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with simple name and help flag", () => {
+                    confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["command", "--help"], {
+                        helpRequested: true,
+                        target: topCommand,
+                        prefix: ["cli", "command"],
+                        rootLevel: false,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with simple name and unprocessed inputs", () => {
+                    confirmRouteScanResult(
+                        [routeMap, defaultScannerConfig, ["cli"]],
+                        ["command", "foo", "bar", "baz"],
+                        {
+                            helpRequested: false,
+                            target: topCommand,
+                            prefix: ["cli", "command"],
+                            rootLevel: false,
+                            unprocessedInputs: ["foo", "bar", "baz"],
+                            aliases: { original: [], "convert-camel-to-kebab": [] },
+                        },
+                    );
+                });
+
+                it("with camelCase name", () => {
+                    confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["camelCase"], {
+                        helpRequested: false,
+                        target: subRouteMap,
+                        prefix: ["cli", "camelCase"],
+                        rootLevel: false,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with camelCase name and help flag", () => {
+                    confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["camelCase", "--help"], {
+                        helpRequested: true,
+                        target: subRouteMap,
+                        prefix: ["cli", "camelCase"],
+                        rootLevel: false,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with multiple camelCase names", () => {
+                    confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["camelCase", "doNothing1"], {
+                        helpRequested: false,
+                        target: subCommand,
+                        prefix: ["cli", "camelCase", "doNothing1"],
+                        rootLevel: false,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with multiple mixed-case names", () => {
+                    confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["camelCase", "do-nothing2"], {
+                        helpRequested: false,
+                        target: subCommand,
+                        prefix: ["cli", "camelCase", "do-nothing2"],
+                        rootLevel: false,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with kebab-case name", () => {
+                    confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["kebab-case"], {
+                        helpRequested: false,
+                        target: subRouteMap,
+                        prefix: ["cli", "kebab-case"],
+                        rootLevel: false,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with kebab-case name and help flag", () => {
+                    confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["kebab-case", "--help"], {
+                        helpRequested: true,
+                        target: subRouteMap,
+                        prefix: ["cli", "kebab-case"],
+                        rootLevel: false,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with multiple mixed-case names", () => {
+                    confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["kebab-case", "doNothing1"], {
+                        helpRequested: false,
+                        target: subCommand,
+                        prefix: ["cli", "kebab-case", "doNothing1"],
+                        rootLevel: false,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with multiple kebab-case names", () => {
+                    confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["kebab-case", "do-nothing2"], {
+                        helpRequested: false,
+                        target: subCommand,
+                        prefix: ["cli", "kebab-case", "do-nothing2"],
+                        rootLevel: false,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+            });
+
+            it("fails to scan when input does not match routes", () => {
+                confirmRouteScanError([routeMap, defaultScannerConfig, ["cli"]], ["does-not-exist"], {
+                    input: "does-not-exist",
+                    routeMap: routeMap,
+                });
+            });
         });
 
-        testScanError([routeMap, defaultScannerConfig, ["cli"]], ["does-not-exist"], {
-            input: "does-not-exist",
-            routeMap: routeMap,
-        });
+        describe("with allow-kebab-for-camel case style", () => {
+            const configWithAllowKebabForCamel = {
+                ...defaultScannerConfig,
+                caseStyle: "allow-kebab-for-camel",
+            } satisfies ScannerConfiguration;
 
-        testScan([routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]], [], {
-            helpRequested: false,
-            target: routeMap,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]], ["--help"], {
-            helpRequested: true,
-            target: routeMap,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]], ["--help-all"], {
-            helpRequested: "all",
-            target: routeMap,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]], ["-h"], {
-            helpRequested: true,
-            target: routeMap,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["--help", "command"],
-            {
-                helpRequested: true,
-                target: routeMap,
-                prefix: ["cli"],
-                rootLevel: true,
-                unprocessedInputs: ["command"],
-                aliases: { original: [], "convert-camel-to-kebab": [] },
-            },
-        );
-        testScan([routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]], ["command"], {
-            helpRequested: false,
-            target: topCommand,
-            prefix: ["cli", "command"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["command", "--help"],
-            {
-                helpRequested: true,
-                target: topCommand,
-                prefix: ["cli", "command"],
-                rootLevel: false,
-                unprocessedInputs: [],
-                aliases: { original: [], "convert-camel-to-kebab": [] },
-            },
-        );
-        testScan(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["command", "foo", "bar", "baz"],
-            {
-                helpRequested: false,
-                target: topCommand,
-                prefix: ["cli", "command"],
-                rootLevel: false,
-                unprocessedInputs: ["foo", "bar", "baz"],
-                aliases: { original: [], "convert-camel-to-kebab": [] },
-            },
-        );
-        testScan([routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]], ["camelCase"], {
-            helpRequested: false,
-            target: subRouteMap,
-            prefix: ["cli", "camelCase"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]], ["camel-case"], {
-            helpRequested: false,
-            target: subRouteMap,
-            prefix: ["cli", "camel-case"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["camelCase", "--help"],
-            {
-                helpRequested: true,
-                target: subRouteMap,
-                prefix: ["cli", "camelCase"],
-                rootLevel: false,
-                unprocessedInputs: [],
-                aliases: { original: [], "convert-camel-to-kebab": [] },
-            },
-        );
-        testScan(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["camel-case", "--help"],
-            {
-                helpRequested: true,
-                target: subRouteMap,
-                prefix: ["cli", "camel-case"],
-                rootLevel: false,
-                unprocessedInputs: [],
-                aliases: { original: [], "convert-camel-to-kebab": [] },
-            },
-        );
-        testScan(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["camelCase", "doNothing1"],
-            {
-                helpRequested: false,
-                target: subCommand,
-                prefix: ["cli", "camelCase", "doNothing1"],
-                rootLevel: false,
-                unprocessedInputs: [],
-                aliases: { original: [], "convert-camel-to-kebab": [] },
-            },
-        );
-        testScan(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["camel-case", "doNothing1"],
-            {
-                helpRequested: false,
-                target: subCommand,
-                prefix: ["cli", "camel-case", "doNothing1"],
-                rootLevel: false,
-                unprocessedInputs: [],
-                aliases: { original: [], "convert-camel-to-kebab": [] },
-            },
-        );
-        testScan(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["camel-case", "do-nothing-1"],
-            {
-                helpRequested: false,
-                target: subCommand,
-                prefix: ["cli", "camel-case", "do-nothing-1"],
-                rootLevel: false,
-                unprocessedInputs: [],
-                aliases: { original: [], "convert-camel-to-kebab": [] },
-            },
-        );
-        testScan(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["camelCase", "do-nothing2"],
-            {
-                helpRequested: false,
-                target: subCommand,
-                prefix: ["cli", "camelCase", "do-nothing2"],
-                rootLevel: false,
-                unprocessedInputs: [],
-                aliases: { original: [], "convert-camel-to-kebab": [] },
-            },
-        );
-        testScan(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["camel-case", "do-nothing2"],
-            {
-                helpRequested: false,
-                target: subCommand,
-                prefix: ["cli", "camel-case", "do-nothing2"],
-                rootLevel: false,
-                unprocessedInputs: [],
-                aliases: { original: [], "convert-camel-to-kebab": [] },
-            },
-        );
-        testScan([routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]], ["kebab-case"], {
-            helpRequested: false,
-            target: subRouteMap,
-            prefix: ["cli", "kebab-case"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["kebab-case", "--help"],
-            {
-                helpRequested: true,
-                target: subRouteMap,
-                prefix: ["cli", "kebab-case"],
-                rootLevel: false,
-                unprocessedInputs: [],
-                aliases: { original: [], "convert-camel-to-kebab": [] },
-            },
-        );
-        testScan(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["kebab-case", "doNothing1"],
-            {
-                helpRequested: false,
-                target: subCommand,
-                prefix: ["cli", "kebab-case", "doNothing1"],
-                rootLevel: false,
-                unprocessedInputs: [],
-                aliases: { original: [], "convert-camel-to-kebab": [] },
-            },
-        );
-        testScan(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["kebab-case", "do-nothing-1"],
-            {
-                helpRequested: false,
-                target: subCommand,
-                prefix: ["cli", "kebab-case", "do-nothing-1"],
-                rootLevel: false,
-                unprocessedInputs: [],
-                aliases: { original: [], "convert-camel-to-kebab": [] },
-            },
-        );
-        testScan(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["kebab-case", "do-nothing2"],
-            {
-                helpRequested: false,
-                target: subCommand,
-                prefix: ["cli", "kebab-case", "do-nothing2"],
-                rootLevel: false,
-                unprocessedInputs: [],
-                aliases: { original: [], "convert-camel-to-kebab": [] },
-            },
-        );
+            describe("scans root as target", () => {
+                it("with no inputs", () => {
+                    confirmRouteScanResult([routeMap, configWithAllowKebabForCamel, ["cli"]], [], {
+                        helpRequested: false,
+                        target: routeMap,
+                        prefix: ["cli"],
+                        rootLevel: true,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
 
-        testScanError(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["does-not-exist"],
-            {
-                input: "does-not-exist",
-                routeMap: routeMap,
-            },
-        );
+                it("with help flag", () => {
+                    confirmRouteScanResult([routeMap, configWithAllowKebabForCamel, ["cli"]], ["--help"], {
+                        helpRequested: true,
+                        target: routeMap,
+                        prefix: ["cli"],
+                        rootLevel: true,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with help flag (alias)", () => {
+                    confirmRouteScanResult([routeMap, configWithAllowKebabForCamel, ["cli"]], ["-h"], {
+                        helpRequested: true,
+                        target: routeMap,
+                        prefix: ["cli"],
+                        rootLevel: true,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with helpAll flag (as kebab-case)", () => {
+                    confirmRouteScanResult([routeMap, configWithAllowKebabForCamel, ["cli"]], ["--help-all"], {
+                        helpRequested: "all",
+                        target: routeMap,
+                        prefix: ["cli"],
+                        rootLevel: true,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with help flag, leave post-help inputs unprocessed", () => {
+                    confirmRouteScanResult([routeMap, configWithAllowKebabForCamel, ["cli"]], ["--help", "command"], {
+                        helpRequested: true,
+                        target: routeMap,
+                        prefix: ["cli"],
+                        rootLevel: true,
+                        unprocessedInputs: ["command"],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+            });
+
+            describe("scans nested command as target", () => {
+                it("with simple name", () => {
+                    confirmRouteScanResult([routeMap, configWithAllowKebabForCamel, ["cli"]], ["command"], {
+                        helpRequested: false,
+                        target: topCommand,
+                        prefix: ["cli", "command"],
+                        rootLevel: false,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with simple name and help flag", () => {
+                    confirmRouteScanResult([routeMap, configWithAllowKebabForCamel, ["cli"]], ["command", "--help"], {
+                        helpRequested: true,
+                        target: topCommand,
+                        prefix: ["cli", "command"],
+                        rootLevel: false,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with simple name and unprocessed inputs", () => {
+                    confirmRouteScanResult(
+                        [routeMap, configWithAllowKebabForCamel, ["cli"]],
+                        ["command", "foo", "bar", "baz"],
+                        {
+                            helpRequested: false,
+                            target: topCommand,
+                            prefix: ["cli", "command"],
+                            rootLevel: false,
+                            unprocessedInputs: ["foo", "bar", "baz"],
+                            aliases: { original: [], "convert-camel-to-kebab": [] },
+                        },
+                    );
+                });
+
+                it("with camelCase name", () => {
+                    confirmRouteScanResult([routeMap, configWithAllowKebabForCamel, ["cli"]], ["camelCase"], {
+                        helpRequested: false,
+                        target: subRouteMap,
+                        prefix: ["cli", "camelCase"],
+                        rootLevel: false,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with camelCase name (as kebab-case)", () => {
+                    confirmRouteScanResult([routeMap, configWithAllowKebabForCamel, ["cli"]], ["camel-case"], {
+                        helpRequested: false,
+                        target: subRouteMap,
+                        prefix: ["cli", "camel-case"],
+                        rootLevel: false,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with camelCase name and help flag", () => {
+                    confirmRouteScanResult([routeMap, configWithAllowKebabForCamel, ["cli"]], ["camelCase", "--help"], {
+                        helpRequested: true,
+                        target: subRouteMap,
+                        prefix: ["cli", "camelCase"],
+                        rootLevel: false,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with camelCase name (as kebab-case) and help flag", () => {
+                    confirmRouteScanResult(
+                        [routeMap, configWithAllowKebabForCamel, ["cli"]],
+                        ["camel-case", "--help"],
+                        {
+                            helpRequested: true,
+                            target: subRouteMap,
+                            prefix: ["cli", "camel-case"],
+                            rootLevel: false,
+                            unprocessedInputs: [],
+                            aliases: { original: [], "convert-camel-to-kebab": [] },
+                        },
+                    );
+                });
+
+                it("with multiple camelCase names", () => {
+                    confirmRouteScanResult(
+                        [routeMap, configWithAllowKebabForCamel, ["cli"]],
+                        ["camelCase", "doNothing1"],
+                        {
+                            helpRequested: false,
+                            target: subCommand,
+                            prefix: ["cli", "camelCase", "doNothing1"],
+                            rootLevel: false,
+                            unprocessedInputs: [],
+                            aliases: { original: [], "convert-camel-to-kebab": [] },
+                        },
+                    );
+                });
+
+                it("with multiple camelCase names (as kebab-case)", () => {
+                    confirmRouteScanResult(
+                        [routeMap, configWithAllowKebabForCamel, ["cli"]],
+                        ["camel-case", "do-nothing1"],
+                        {
+                            helpRequested: false,
+                            target: subCommand,
+                            prefix: ["cli", "camel-case", "do-nothing1"],
+                            rootLevel: false,
+                            unprocessedInputs: [],
+                            aliases: { original: [], "convert-camel-to-kebab": [] },
+                        },
+                    );
+                });
+
+                it("with multiple mixed-case names", () => {
+                    confirmRouteScanResult(
+                        [routeMap, configWithAllowKebabForCamel, ["cli"]],
+                        ["camelCase", "do-nothing2"],
+                        {
+                            helpRequested: false,
+                            target: subCommand,
+                            prefix: ["cli", "camelCase", "do-nothing2"],
+                            rootLevel: false,
+                            unprocessedInputs: [],
+                            aliases: { original: [], "convert-camel-to-kebab": [] },
+                        },
+                    );
+                });
+
+                it("with multiple mixed-case names (as kebab-case)", () => {
+                    confirmRouteScanResult(
+                        [routeMap, configWithAllowKebabForCamel, ["cli"]],
+                        ["camel-case", "do-nothing2"],
+                        {
+                            helpRequested: false,
+                            target: subCommand,
+                            prefix: ["cli", "camel-case", "do-nothing2"],
+                            rootLevel: false,
+                            unprocessedInputs: [],
+                            aliases: { original: [], "convert-camel-to-kebab": [] },
+                        },
+                    );
+                });
+
+                it("with kebab-case name", () => {
+                    confirmRouteScanResult([routeMap, configWithAllowKebabForCamel, ["cli"]], ["kebab-case"], {
+                        helpRequested: false,
+                        target: subRouteMap,
+                        prefix: ["cli", "kebab-case"],
+                        rootLevel: false,
+                        unprocessedInputs: [],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    });
+                });
+
+                it("with kebab-case name and help flag", () => {
+                    confirmRouteScanResult(
+                        [routeMap, configWithAllowKebabForCamel, ["cli"]],
+                        ["kebab-case", "--help"],
+                        {
+                            helpRequested: true,
+                            target: subRouteMap,
+                            prefix: ["cli", "kebab-case"],
+                            rootLevel: false,
+                            unprocessedInputs: [],
+                            aliases: { original: [], "convert-camel-to-kebab": [] },
+                        },
+                    );
+                });
+
+                it("with multiple mixed-case names", () => {
+                    confirmRouteScanResult(
+                        [routeMap, configWithAllowKebabForCamel, ["cli"]],
+                        ["kebab-case", "doNothing1"],
+                        {
+                            helpRequested: false,
+                            target: subCommand,
+                            prefix: ["cli", "kebab-case", "doNothing1"],
+                            rootLevel: false,
+                            unprocessedInputs: [],
+                            aliases: { original: [], "convert-camel-to-kebab": [] },
+                        },
+                    );
+                });
+
+                it("with multiple mixed-case names (as kebab-case)", () => {
+                    confirmRouteScanResult(
+                        [routeMap, configWithAllowKebabForCamel, ["cli"]],
+                        ["kebab-case", "do-nothing1"],
+                        {
+                            helpRequested: false,
+                            target: subCommand,
+                            prefix: ["cli", "kebab-case", "do-nothing1"],
+                            rootLevel: false,
+                            unprocessedInputs: [],
+                            aliases: { original: [], "convert-camel-to-kebab": [] },
+                        },
+                    );
+                });
+
+                it("with multiple kebab-case names", () => {
+                    confirmRouteScanResult(
+                        [routeMap, configWithAllowKebabForCamel, ["cli"]],
+                        ["kebab-case", "do-nothing2"],
+                        {
+                            helpRequested: false,
+                            target: subCommand,
+                            prefix: ["cli", "kebab-case", "do-nothing2"],
+                            rootLevel: false,
+                            unprocessedInputs: [],
+                            aliases: { original: [], "convert-camel-to-kebab": [] },
+                        },
+                    );
+                });
+            });
+
+            it("fails to scan when input does not match routes", () => {
+                confirmRouteScanError([routeMap, configWithAllowKebabForCamel, ["cli"]], ["does-not-exist"], {
+                    input: "does-not-exist",
+                    routeMap: routeMap,
+                });
+            });
+        });
     });
 
     describe("route map at root with route collision", () => {
@@ -617,119 +809,154 @@ describe("RouteScanner", () => {
             },
         });
 
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["routeName"], {
-            helpRequested: false,
-            target: camelCaseCommand,
-            prefix: ["cli", "routeName"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["routeName", "--help"], {
-            helpRequested: true,
-            target: camelCaseCommand,
-            prefix: ["cli", "routeName"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["routeName", "foo", "bar", "baz"], {
-            helpRequested: false,
-            target: camelCaseCommand,
-            prefix: ["cli", "routeName"],
-            rootLevel: false,
-            unprocessedInputs: ["foo", "bar", "baz"],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["route-name"], {
-            helpRequested: false,
-            target: kebabCaseCommand,
-            prefix: ["cli", "route-name"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["route-name", "--help"], {
-            helpRequested: true,
-            target: kebabCaseCommand,
-            prefix: ["cli", "route-name"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["route-name", "foo", "bar", "baz"], {
-            helpRequested: false,
-            target: kebabCaseCommand,
-            prefix: ["cli", "route-name"],
-            rootLevel: false,
-            unprocessedInputs: ["foo", "bar", "baz"],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
+        describe("with 'original' case style", () => {
+            it("scans camelCase route with exact name", () => {
+                confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["routeName"], {
+                    helpRequested: false,
+                    target: camelCaseCommand,
+                    prefix: ["cli", "routeName"],
+                    rootLevel: false,
+                    unprocessedInputs: [],
+                    aliases: { original: [], "convert-camel-to-kebab": [] },
+                });
+            });
+
+            it("scans camelCase route with exact name and help text", () => {
+                confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["routeName", "--help"], {
+                    helpRequested: true,
+                    target: camelCaseCommand,
+                    prefix: ["cli", "routeName"],
+                    rootLevel: false,
+                    unprocessedInputs: [],
+                    aliases: { original: [], "convert-camel-to-kebab": [] },
+                });
+            });
+
+            it("scans camelCase route with exact name and unprocessed inputs", () => {
+                confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["routeName", "foo", "bar", "baz"], {
+                    helpRequested: false,
+                    target: camelCaseCommand,
+                    prefix: ["cli", "routeName"],
+                    rootLevel: false,
+                    unprocessedInputs: ["foo", "bar", "baz"],
+                    aliases: { original: [], "convert-camel-to-kebab": [] },
+                });
+            });
+
+            it("scans kebab-case route with exact name", () => {
+                confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["route-name"], {
+                    helpRequested: false,
+                    target: kebabCaseCommand,
+                    prefix: ["cli", "route-name"],
+                    rootLevel: false,
+                    unprocessedInputs: [],
+                    aliases: { original: [], "convert-camel-to-kebab": [] },
+                });
+            });
+
+            it("scans kebab-case route with exact name and help flag", () => {
+                confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["route-name", "--help"], {
+                    helpRequested: true,
+                    target: kebabCaseCommand,
+                    prefix: ["cli", "route-name"],
+                    rootLevel: false,
+                    unprocessedInputs: [],
+                    aliases: { original: [], "convert-camel-to-kebab": [] },
+                });
+            });
+
+            it("scans kebab-case route with exact name and unprocessed inputs", () => {
+                confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["route-name", "foo", "bar", "baz"], {
+                    helpRequested: false,
+                    target: kebabCaseCommand,
+                    prefix: ["cli", "route-name"],
+                    rootLevel: false,
+                    unprocessedInputs: ["foo", "bar", "baz"],
+                    aliases: { original: [], "convert-camel-to-kebab": [] },
+                });
+            });
         });
 
-        testScan([routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]], ["routeName"], {
-            helpRequested: false,
-            target: camelCaseCommand,
-            prefix: ["cli", "routeName"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
+        describe("with 'allow-kebab-for-camel' case style", () => {
+            const configWithAllowKebabForCamel = {
+                ...defaultScannerConfig,
+                caseStyle: "allow-kebab-for-camel",
+            } satisfies ScannerConfiguration;
+
+            it("scans camelCase route with exact name", () => {
+                confirmRouteScanResult([routeMap, configWithAllowKebabForCamel, ["cli"]], ["routeName"], {
+                    helpRequested: false,
+                    target: camelCaseCommand,
+                    prefix: ["cli", "routeName"],
+                    rootLevel: false,
+                    unprocessedInputs: [],
+                    aliases: { original: [], "convert-camel-to-kebab": [] },
+                });
+            });
+
+            it("scans camelCase route with exact name and help flag", () => {
+                confirmRouteScanResult([routeMap, configWithAllowKebabForCamel, ["cli"]], ["routeName", "--help"], {
+                    helpRequested: true,
+                    target: camelCaseCommand,
+                    prefix: ["cli", "routeName"],
+                    rootLevel: false,
+                    unprocessedInputs: [],
+                    aliases: { original: [], "convert-camel-to-kebab": [] },
+                });
+            });
+
+            it("scans camelCase route with exact name and unprocessed inputs", () => {
+                confirmRouteScanResult(
+                    [routeMap, configWithAllowKebabForCamel, ["cli"]],
+                    ["routeName", "foo", "bar", "baz"],
+                    {
+                        helpRequested: false,
+                        target: camelCaseCommand,
+                        prefix: ["cli", "routeName"],
+                        rootLevel: false,
+                        unprocessedInputs: ["foo", "bar", "baz"],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    },
+                );
+            });
+
+            it("scans kebab-case route with exact name", () => {
+                confirmRouteScanResult([routeMap, configWithAllowKebabForCamel, ["cli"]], ["route-name"], {
+                    helpRequested: false,
+                    target: kebabCaseCommand,
+                    prefix: ["cli", "route-name"],
+                    rootLevel: false,
+                    unprocessedInputs: [],
+                    aliases: { original: [], "convert-camel-to-kebab": [] },
+                });
+            });
+
+            it("scans kebab-case route with exact name and help flag", () => {
+                confirmRouteScanResult([routeMap, configWithAllowKebabForCamel, ["cli"]], ["route-name", "--help"], {
+                    helpRequested: true,
+                    target: kebabCaseCommand,
+                    prefix: ["cli", "route-name"],
+                    rootLevel: false,
+                    unprocessedInputs: [],
+                    aliases: { original: [], "convert-camel-to-kebab": [] },
+                });
+            });
+
+            it("scans kebab-case route with exact name and unprocessed inputs", () => {
+                confirmRouteScanResult(
+                    [routeMap, configWithAllowKebabForCamel, ["cli"]],
+                    ["route-name", "foo", "bar", "baz"],
+                    {
+                        helpRequested: false,
+                        target: kebabCaseCommand,
+                        prefix: ["cli", "route-name"],
+                        rootLevel: false,
+                        unprocessedInputs: ["foo", "bar", "baz"],
+                        aliases: { original: [], "convert-camel-to-kebab": [] },
+                    },
+                );
+            });
         });
-        testScan(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["routeName", "--help"],
-            {
-                helpRequested: true,
-                target: camelCaseCommand,
-                prefix: ["cli", "routeName"],
-                rootLevel: false,
-                unprocessedInputs: [],
-                aliases: { original: [], "convert-camel-to-kebab": [] },
-            },
-        );
-        testScan(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["routeName", "foo", "bar", "baz"],
-            {
-                helpRequested: false,
-                target: camelCaseCommand,
-                prefix: ["cli", "routeName"],
-                rootLevel: false,
-                unprocessedInputs: ["foo", "bar", "baz"],
-                aliases: { original: [], "convert-camel-to-kebab": [] },
-            },
-        );
-        testScan([routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]], ["route-name"], {
-            helpRequested: false,
-            target: kebabCaseCommand,
-            prefix: ["cli", "route-name"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
-        });
-        testScan(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["route-name", "--help"],
-            {
-                helpRequested: true,
-                target: kebabCaseCommand,
-                prefix: ["cli", "route-name"],
-                rootLevel: false,
-                unprocessedInputs: [],
-                aliases: { original: [], "convert-camel-to-kebab": [] },
-            },
-        );
-        testScan(
-            [routeMap, { ...defaultScannerConfig, caseStyle: "allow-kebab-for-camel" }, ["cli"]],
-            ["route-name", "foo", "bar", "baz"],
-            {
-                helpRequested: false,
-                target: kebabCaseCommand,
-                prefix: ["cli", "route-name"],
-                rootLevel: false,
-                unprocessedInputs: ["foo", "bar", "baz"],
-                aliases: { original: [], "convert-camel-to-kebab": [] },
-            },
-        );
     });
 
     describe("route map with default command", () => {
@@ -768,77 +995,95 @@ describe("RouteScanner", () => {
             },
         });
 
-        testScan([routeMap, defaultScannerConfig, ["cli"]], [], {
-            helpRequested: false,
-            target: defaultCommand,
-            prefix: ["cli"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: ["default"], "convert-camel-to-kebab": ["default"] },
+        it("scans default command as target with no inputs", () => {
+            confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], [], {
+                helpRequested: false,
+                target: defaultCommand,
+                prefix: ["cli"],
+                rootLevel: false,
+                unprocessedInputs: [],
+                aliases: { original: ["default"], "convert-camel-to-kebab": ["default"] },
+            });
         });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["--help"], {
-            helpRequested: true,
-            target: routeMap,
-            prefix: ["cli"],
-            rootLevel: true,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
+        it("scans root as target with help flag", () => {
+            confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["--help"], {
+                helpRequested: true,
+                target: routeMap,
+                prefix: ["cli"],
+                rootLevel: true,
+                unprocessedInputs: [],
+                aliases: { original: [], "convert-camel-to-kebab": [] },
+            });
         });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["arg"], {
-            helpRequested: false,
-            target: defaultCommand,
-            prefix: ["cli"],
-            rootLevel: false,
-            unprocessedInputs: ["arg"],
-            aliases: { original: ["default"], "convert-camel-to-kebab": ["default"] },
+        it("scans default command as target with unprocessed inputs (value)", () => {
+            confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["arg"], {
+                helpRequested: false,
+                target: defaultCommand,
+                prefix: ["cli"],
+                rootLevel: false,
+                unprocessedInputs: ["arg"],
+                aliases: { original: ["default"], "convert-camel-to-kebab": ["default"] },
+            });
         });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["--flag"], {
-            helpRequested: false,
-            target: defaultCommand,
-            prefix: ["cli"],
-            rootLevel: false,
-            unprocessedInputs: ["--flag"],
-            aliases: { original: ["default"], "convert-camel-to-kebab": ["default"] },
+        it("scans default command as target with unprocessed inputs (flag)", () => {
+            confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["--flag"], {
+                helpRequested: false,
+                target: defaultCommand,
+                prefix: ["cli"],
+                rootLevel: false,
+                unprocessedInputs: ["--flag"],
+                aliases: { original: ["default"], "convert-camel-to-kebab": ["default"] },
+            });
         });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["default"], {
-            helpRequested: false,
-            target: defaultCommand,
-            prefix: ["cli", "default"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [""], "convert-camel-to-kebab": [""] },
+        it("scans default command as target with explicit default route", () => {
+            confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["default"], {
+                helpRequested: false,
+                target: defaultCommand,
+                prefix: ["cli", "default"],
+                rootLevel: false,
+                unprocessedInputs: [],
+                aliases: { original: [""], "convert-camel-to-kebab": [""] },
+            });
         });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["default", "--help"], {
-            helpRequested: true,
-            target: defaultCommand,
-            prefix: ["cli", "default"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [""], "convert-camel-to-kebab": [""] },
+        it("scans default command as target with explicit default route with help flag", () => {
+            confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["default", "--help"], {
+                helpRequested: true,
+                target: defaultCommand,
+                prefix: ["cli", "default"],
+                rootLevel: false,
+                unprocessedInputs: [],
+                aliases: { original: [""], "convert-camel-to-kebab": [""] },
+            });
         });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["defaultx"], {
-            helpRequested: false,
-            target: defaultCommand,
-            prefix: ["cli"],
-            rootLevel: false,
-            unprocessedInputs: ["defaultx"],
-            aliases: { original: ["default"], "convert-camel-to-kebab": ["default"] },
+        it("scans default command as target with input that is adjacent to the default rotue", () => {
+            confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["defaultx"], {
+                helpRequested: false,
+                target: defaultCommand,
+                prefix: ["cli"],
+                rootLevel: false,
+                unprocessedInputs: ["defaultx"],
+                aliases: { original: ["default"], "convert-camel-to-kebab": ["default"] },
+            });
         });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["alternate"], {
-            helpRequested: false,
-            target: alternateCommand,
-            prefix: ["cli", "alternate"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
+        it("scans non-default command as target with exact route", () => {
+            confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["alternate"], {
+                helpRequested: false,
+                target: alternateCommand,
+                prefix: ["cli", "alternate"],
+                rootLevel: false,
+                unprocessedInputs: [],
+                aliases: { original: [], "convert-camel-to-kebab": [] },
+            });
         });
-        testScan([routeMap, defaultScannerConfig, ["cli"]], ["alternate", "--help"], {
-            helpRequested: true,
-            target: alternateCommand,
-            prefix: ["cli", "alternate"],
-            rootLevel: false,
-            unprocessedInputs: [],
-            aliases: { original: [], "convert-camel-to-kebab": [] },
+        it("scans non-default command as target with exact route and help flag", () => {
+            confirmRouteScanResult([routeMap, defaultScannerConfig, ["cli"]], ["alternate", "--help"], {
+                helpRequested: true,
+                target: alternateCommand,
+                prefix: ["cli", "alternate"],
+                rootLevel: false,
+                unprocessedInputs: [],
+                aliases: { original: [], "convert-camel-to-kebab": [] },
+            });
         });
     });
 });


### PR DESCRIPTION
**Describe your changes**
The "argument escape sequence" is an optional feature that can be configured with `scanner.allowArgumentEscapeSequence`. When enabled and the inputs contain `--`, everything after that input should be treated as a string value. This means anything that would otherwise be considered a flag is now just a `string` positional parameter argument.

This feature already works as intended with the majority of use cases, but because `--help`/`--helpAll` are handled by the route scanner it wasn't being accounted for properly. After this change `cli -- --help` will parse as `["--help"]` rather than invoking the help text.

**Testing performed**
There's only a few new test cases for this new logic since it's so specific. However, I initially discovered this bug when doing a refactor of the route scanner's tests and that refactor is included in this PR.
