### PR TITLE
ci(create_release): set origin as upstream of release branch

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -55,6 +55,7 @@ jobs:
                 git config user.name "github-actions[bot]"
                 git config user.email "github-actions[bot]@users.noreply.github.com"
                 git checkout -b "release-$GITHUB_RUN_NUMBER"
+                git push -u origin HEAD
                 npx nx release ${{ inputs.version_bump }} --skip-publish
                 RELEASE_VERSION=$(npm pkg get version --workspaces | jq -r '.["@stricli/core"]')
                 gh release edit "v$RELEASE_VERSION" --prerelease=true


### PR DESCRIPTION
**Describe your changes**
Error on last run: https://github.com/bloomberg/stricli/actions/runs/27762925530/job/82141839547

Just need to `push -u origin` before running the Nx release steps as those assume upstream is already sey.
