### PR TITLE
feat(auto-complete): add shell script output command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8609,7 +8609,7 @@
             "version": "6.7.14",
             "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
             "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=8"
             }
@@ -25614,6 +25614,7 @@
             "version": "1.2.7",
             "license": "Apache-2.0",
             "dependencies": {
+                "@bomb.sh/tab": "https://pkg.pr.new/@bomb.sh/tab@077881b",
                 "@stricli/core": "^1.2.7"
             },
             "bin": {
@@ -25628,6 +25629,31 @@
                 "prettier": "^3.0.0",
                 "tsup": "^6.7.0",
                 "typescript": "5.6.x"
+            }
+        },
+        "packages/auto-complete/node_modules/@bomb.sh/tab": {
+            "version": "0.0.17",
+            "resolved": "https://pkg.pr.new/@bomb.sh/tab@077881b",
+            "integrity": "sha512-0Kn8o1OcKZ0i/b7TPOf9xWR3InSIJIzZW7OTHAPudkbrElIl81oFYzmBySLuaCmdg9rbkHtpn1AkHAhuKd0LsQ==",
+            "license": "MIT",
+            "bin": {
+                "tab": "dist/bin/cli.mjs"
+            },
+            "peerDependencies": {
+                "cac": "^6.7.14",
+                "citty": "^0.1.6 || ^0.2.0",
+                "commander": "^13.1.0"
+            },
+            "peerDependenciesMeta": {
+                "cac": {
+                    "optional": true
+                },
+                "citty": {
+                    "optional": true
+                },
+                "commander": {
+                    "optional": true
+                }
             }
         },
         "packages/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9142,7 +9142,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
             "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">= 6"
             }

--- a/packages/auto-complete/package.json
+++ b/packages/auto-complete/package.json
@@ -52,6 +52,7 @@
         "typescript": "5.6.x"
     },
     "dependencies": {
+        "@bomb.sh/tab": "https://pkg.pr.new/@bomb.sh/tab@077881b",
         "@stricli/core": "^1.2.7"
     }
 }

--- a/packages/auto-complete/src/app.ts
+++ b/packages/auto-complete/src/app.ts
@@ -1,13 +1,14 @@
 // Copyright 2024 Bloomberg Finance L.P.
 // Distributed under the terms of the Apache 2.0 license.
 import { buildApplication, buildRouteMap } from "@stricli/core";
-import { installCommand, uninstallCommand } from "./commands";
+import { installCommand, uninstallCommand, scriptCommand } from "./commands";
 import pkg from "../package.json";
 
 const root = buildRouteMap({
     routes: {
         install: installCommand,
         uninstall: uninstallCommand,
+        script: scriptCommand,
     },
     aliases: {
         i: "install",

--- a/packages/auto-complete/src/commands.ts
+++ b/packages/auto-complete/src/commands.ts
@@ -4,6 +4,7 @@ import { buildCommand, type Command, type TypedPositionalParameter } from "@stri
 import type { StricliAutoCompleteContext } from "./context";
 import type { ActiveShells, ShellAutoCompleteCommands } from "./impl";
 import { joinWithGrammar } from "./formatting";
+import type { TabShell } from "./script";
 
 const targetCommandParameter: TypedPositionalParameter<string> = {
     parse: String,
@@ -99,3 +100,51 @@ export function buildUninstallCommand<CONTEXT extends StricliAutoCompleteContext
         },
     });
 }
+
+export const scriptCommand = buildCommand({
+    loader: async () => {
+      const { printScript } = await import("./script");
+      return printScript;
+    },
+  
+    parameters: {
+      flags: {
+        shell: {
+          kind: "parsed",
+          brief: "Shell to generate autocomplete script for",
+          parse: (value: string): TabShell => {
+            if (
+              value !== "bash" &&
+              value !== "zsh" &&
+              value !== "fish" &&
+              value !== "powershell"
+            ) {
+              throw new Error(
+                `Unsupported shell "${value}". Expected bash, zsh, fish, or powershell.`,
+              );
+            }
+  
+            return value;
+          },
+          placeholder: "shell",
+        },
+  
+        command: {
+          kind: "parsed",
+          brief: "Command executed by the shell script to generate completions",
+          parse: String,
+          optional: true,
+          placeholder: "command",
+        },
+      },
+  
+      positional: {
+        kind: "tuple",
+        parameters: [targetCommandParameter],
+      },
+    },
+  
+    docs: {
+      brief: "Prints an autocomplete shell script",
+    },
+  });

--- a/packages/auto-complete/src/script.ts
+++ b/packages/auto-complete/src/script.ts
@@ -1,0 +1,29 @@
+import { script as tabScript } from "@bomb.sh/tab";
+
+export type TabShell = "bash" | "zsh" | "fish" | "powershell";
+
+const shells = new Set(["bash", "zsh", "fish", "powershell"]);
+
+export interface ScriptFlags {
+  readonly shell: TabShell;
+  readonly command?: string;
+}
+
+export function parseShell(value: string): TabShell {
+  if (!shells.has(value)) {
+    throw new Error(
+      `Unsupported shell "${value}". Expected bash, zsh, fish, or powershell.`,
+    );
+  }
+
+  return value as TabShell;
+}
+
+export function printScript(
+  flags: ScriptFlags,
+  targetCommand: string,
+): void {
+  const completionCommand = flags.command ?? targetCommand;
+
+  tabScript(flags.shell, targetCommand, completionCommand);
+}


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #137 and #112 *

**Describe your changes**
adding a script command to `@stricli/auto-complete`. 
The new command prints a shell completion script to stdout instead of installing it directly into a shell configuration file.

**Testing performed**

simply run `node packages/auto-complete/dist/bin/cli.js script --shell zsh --command "my-cli" my-cli` 
supports `zsh`, `powershell`, `fish` and `bash`

**Additional context**
This is intentionally scoped to script generation only. It does not change stricli's completion proposal logic and does not modify `@stricli/core` and uses `@bomb.sh/tab` only for shell script generation.

I havent added the `install --zsh`
let me know what you think @molisani 