### PR TITLE
 fix: consolidate ansi color logic for both streams

### DIFF
--- a/packages/core/src/application/run.ts
+++ b/packages/core/src/application/run.ts
@@ -6,7 +6,7 @@ import { listAllRouteNamesAndAliasesForScan } from "../parameter/scanner";
 import { runCommand } from "../routing/command/run";
 import { RouteMapSymbol } from "../routing/route-map/types";
 import { buildRouteScanner, type RouteNotFoundError } from "../routing/scanner";
-import { shouldUseAnsiColor } from "../text";
+import { shouldUseAnsiColorForStreams } from "../text";
 import { filterClosestAlternatives } from "../util/distance";
 import type { Application } from "./types";
 
@@ -18,20 +18,20 @@ export async function runApplication<CONTEXT extends CommandContext>(
     rawInputs: readonly string[],
     context: StricliDynamicCommandContext<CONTEXT>,
 ): Promise<number> {
+    const ansiColorByStream = shouldUseAnsiColorForStreams(context.process, config.documentation);
     let text = defaultText;
     if (context.locale && "loadText" in config.localization) {
         const localeText = config.localization.loadText(context.locale);
         if (localeText) {
             text = localeText;
         } else {
-            const ansiColor = shouldUseAnsiColor(context.process, context.process.stderr, config.documentation);
             const warningMessage = text.noTextAvailableForLocale({
                 requestedLocale: context.locale,
                 defaultLocale: config.localization.defaultLocale,
-                ansiColor,
+                ansiColor: ansiColorByStream.stderr,
             });
             context.process.stderr.write(
-                ansiColor ? `\x1B[1m\x1B[33m${warningMessage}\x1B[39m\x1B[22m\n` : `${warningMessage}\n`,
+                ansiColorByStream.stderr ? `\x1B[1m\x1B[33m${warningMessage}\x1B[39m\x1B[22m\n` : `${warningMessage}\n`,
             );
         }
     }
@@ -48,15 +48,14 @@ export async function runApplication<CONTEXT extends CommandContext>(
         }
         const latestVersion = await config.versionInfo.getLatestVersion.call(context, currentVersion);
         if (latestVersion && currentVersion !== latestVersion) {
-            const ansiColor = shouldUseAnsiColor(context.process, context.process.stderr, config.documentation);
             const warningMessage = text.currentVersionIsNotLatest({
                 currentVersion,
                 latestVersion,
                 upgradeCommand: config.versionInfo.upgradeCommand,
-                ansiColor,
+                ansiColor: ansiColorByStream.stderr,
             });
             context.process.stderr.write(
-                ansiColor ? `\x1B[1m\x1B[33m${warningMessage}\x1B[39m\x1B[22m\n` : `${warningMessage}\n`,
+                ansiColorByStream.stderr ? `\x1B[1m\x1B[33m${warningMessage}\x1B[39m\x1B[22m\n` : `${warningMessage}\n`,
             );
         }
     }
@@ -89,17 +88,19 @@ export async function runApplication<CONTEXT extends CommandContext>(
         const corrections = filterClosestAlternatives(error.input, routeNames, config.scanner.distanceOptions).map(
             (str) => `\`${str}\``,
         );
-        const ansiColor = shouldUseAnsiColor(context.process, context.process.stderr, config.documentation);
-        const errorMessage = text.noCommandRegisteredForInput({ input: error.input, corrections, ansiColor });
+        const errorMessage = text.noCommandRegisteredForInput({
+            input: error.input,
+            corrections,
+            ansiColor: ansiColorByStream.stderr,
+        });
         context.process.stderr.write(
-            ansiColor ? `\x1B[1m\x1B[31m${errorMessage}\x1B[39m\x1B[22m\n` : `${errorMessage}\n`,
+            ansiColorByStream.stderr ? `\x1B[1m\x1B[31m${errorMessage}\x1B[39m\x1B[22m\n` : `${errorMessage}\n`,
         );
         return ExitCode.UnknownCommand;
     }
     const result = scanner.finish();
 
     if (result.helpRequested || result.target.kind === RouteMapSymbol) {
-        const ansiColor = shouldUseAnsiColor(context.process, context.process.stdout, config.documentation);
         context.process.stdout.write(
             result.target.formatHelp({
                 prefix: result.prefix,
@@ -110,7 +111,7 @@ export async function runApplication<CONTEXT extends CommandContext>(
                 config: config.documentation,
                 aliases: result.aliases[config.documentation.caseStyle],
                 text,
-                ansiColor,
+                ansiColor: ansiColorByStream.stdout,
             }),
         );
         return ExitCode.Success;
@@ -121,9 +122,10 @@ export async function runApplication<CONTEXT extends CommandContext>(
         try {
             commandContext = await context.forCommand({ prefix: result.prefix });
         } catch (exc) {
-            const ansiColor = shouldUseAnsiColor(context.process, context.process.stderr, config.documentation);
-            const errorMessage = text.exceptionWhileLoadingCommandContext(exc, ansiColor);
-            context.process.stderr.write(ansiColor ? `\x1B[1m\x1B[31m${errorMessage}\x1B[39m\x1B[22m` : errorMessage);
+            const errorMessage = text.exceptionWhileLoadingCommandContext(exc, ansiColorByStream.stderr);
+            context.process.stderr.write(
+                ansiColorByStream.stderr ? `\x1B[1m\x1B[31m${errorMessage}\x1B[39m\x1B[22m` : errorMessage,
+            );
             return ExitCode.ContextLoadError;
         }
     } else {
@@ -133,8 +135,8 @@ export async function runApplication<CONTEXT extends CommandContext>(
         context: commandContext,
         inputs: result.unprocessedInputs,
         scannerConfig: config.scanner,
-        documentationConfig: config.documentation,
         errorFormatting: text,
         determineExitCode: config.determineExitCode,
+        ansiColorByStream,
     });
 }

--- a/packages/core/src/routing/command/run.ts
+++ b/packages/core/src/routing/command/run.ts
@@ -1,21 +1,21 @@
 // Copyright 2024 Bloomberg Finance L.P.
 // Distributed under the terms of the Apache 2.0 license.
-import type { DocumentationConfiguration, ScannerConfiguration } from "../../config";
-import { shouldUseAnsiColor, type CommandErrorFormatting } from "../../text";
+import type { ScannerConfiguration } from "../../config";
 import type { CommandContext } from "../../context";
 import { ExitCode } from "../../exit-code";
-import { buildArgumentScanner, type ParsedArguments } from "../../parameter/scanner";
-import type { Command, CommandFunction } from "./types";
-import type { BaseFlags } from "../../parameter/types";
 import type { BaseArgs } from "../../parameter/positional/types";
+import { buildArgumentScanner, type ParsedArguments } from "../../parameter/scanner";
+import type { BaseFlags } from "../../parameter/types";
+import type { CommandErrorFormatting } from "../../text";
+import type { Command, CommandFunction } from "./types";
 
 export interface CommandRunArguments<CONTEXT extends CommandContext> {
     readonly context: CONTEXT;
     readonly inputs: readonly string[];
     readonly errorFormatting: CommandErrorFormatting;
     readonly scannerConfig: ScannerConfiguration;
-    readonly documentationConfig: DocumentationConfiguration;
     readonly determineExitCode?: (exc: unknown) => number;
+    readonly ansiColorByStream: Record<"stdout" | "stderr", boolean>;
 }
 
 export async function runCommand<CONTEXT extends CommandContext>(
@@ -25,8 +25,8 @@ export async function runCommand<CONTEXT extends CommandContext>(
         inputs,
         scannerConfig,
         errorFormatting,
-        documentationConfig,
         determineExitCode,
+        ansiColorByStream,
     }: CommandRunArguments<CONTEXT>,
 ): Promise<number> {
     let parsedArguments: ParsedArguments<BaseFlags, BaseArgs>;
@@ -39,20 +39,18 @@ export async function runCommand<CONTEXT extends CommandContext>(
         if (result.success) {
             parsedArguments = result.arguments;
         } else {
-            const ansiColor = shouldUseAnsiColor(context.process, context.process.stderr, documentationConfig);
             for (const error of result.errors) {
-                const errorMessage = errorFormatting.exceptionWhileParsingArguments(error, ansiColor);
+                const errorMessage = errorFormatting.exceptionWhileParsingArguments(error, ansiColorByStream.stderr);
                 context.process.stderr.write(
-                    ansiColor ? `\x1B[1m\x1B[31m${errorMessage}\x1B[39m\x1B[22m\n` : `${errorMessage}\n`,
+                    ansiColorByStream.stderr ? `\x1B[1m\x1B[31m${errorMessage}\x1B[39m\x1B[22m\n` : `${errorMessage}\n`,
                 );
             }
             return ExitCode.InvalidArgument;
         }
     } catch (exc) {
-        const ansiColor = shouldUseAnsiColor(context.process, context.process.stderr, documentationConfig);
-        const errorMessage = errorFormatting.exceptionWhileParsingArguments(exc, ansiColor);
+        const errorMessage = errorFormatting.exceptionWhileParsingArguments(exc, ansiColorByStream.stderr);
         context.process.stderr.write(
-            ansiColor ? `\x1B[1m\x1B[31m${errorMessage}\x1B[39m\x1B[22m\n` : `${errorMessage}\n`,
+            ansiColorByStream.stderr ? `\x1B[1m\x1B[31m${errorMessage}\x1B[39m\x1B[22m\n` : `${errorMessage}\n`,
         );
         return ExitCode.InvalidArgument;
     }
@@ -66,10 +64,9 @@ export async function runCommand<CONTEXT extends CommandContext>(
             commandFunction = loaded.default;
         }
     } catch (exc) {
-        const ansiColor = shouldUseAnsiColor(context.process, context.process.stderr, documentationConfig);
-        const errorMessage = errorFormatting.exceptionWhileLoadingCommandFunction(exc, ansiColor);
+        const errorMessage = errorFormatting.exceptionWhileLoadingCommandFunction(exc, ansiColorByStream.stderr);
         context.process.stderr.write(
-            ansiColor ? `\x1B[1m\x1B[31m${errorMessage}\x1B[39m\x1B[22m\n` : `${errorMessage}\n`,
+            ansiColorByStream.stderr ? `\x1B[1m\x1B[31m${errorMessage}\x1B[39m\x1B[22m\n` : `${errorMessage}\n`,
         );
         return ExitCode.CommandLoadError;
     }
@@ -77,10 +74,9 @@ export async function runCommand<CONTEXT extends CommandContext>(
     try {
         const result = await commandFunction.call(context, ...parsedArguments);
         if (result instanceof Error) {
-            const ansiColor = shouldUseAnsiColor(context.process, context.process.stderr, documentationConfig);
-            const errorMessage = errorFormatting.commandErrorResult(result, ansiColor);
+            const errorMessage = errorFormatting.commandErrorResult(result, ansiColorByStream.stderr);
             context.process.stderr.write(
-                ansiColor ? `\x1B[1m\x1B[31m${errorMessage}\x1B[39m\x1B[22m\n` : `${errorMessage}\n`,
+                ansiColorByStream.stderr ? `\x1B[1m\x1B[31m${errorMessage}\x1B[39m\x1B[22m\n` : `${errorMessage}\n`,
             );
             if (determineExitCode) {
                 return determineExitCode(result);
@@ -88,10 +84,9 @@ export async function runCommand<CONTEXT extends CommandContext>(
             return ExitCode.CommandRunError;
         }
     } catch (exc) {
-        const ansiColor = shouldUseAnsiColor(context.process, context.process.stderr, documentationConfig);
-        const errorMessage = errorFormatting.exceptionWhileRunningCommand(exc, ansiColor);
+        const errorMessage = errorFormatting.exceptionWhileRunningCommand(exc, ansiColorByStream.stderr);
         context.process.stderr.write(
-            ansiColor ? `\x1B[1m\x1B[31m${errorMessage}\x1B[39m\x1B[22m\n` : `${errorMessage}\n`,
+            ansiColorByStream.stderr ? `\x1B[1m\x1B[31m${errorMessage}\x1B[39m\x1B[22m\n` : `${errorMessage}\n`,
         );
         if (determineExitCode) {
             return determineExitCode(exc);

--- a/packages/core/src/text.ts
+++ b/packages/core/src/text.ts
@@ -297,14 +297,23 @@ export function defaultTextLoader(locale: string): ApplicationText | undefined {
     }
 }
 
-export function shouldUseAnsiColor(
-    process: StricliProcess,
-    stream: Writable,
-    config: DocumentationConfiguration,
-): boolean {
+function shouldUseAnsiColor(process: StricliProcess, stream: Writable, config: DocumentationConfiguration): boolean {
     return (
         !config.disableAnsiColor &&
         !checkEnvironmentVariable(process, "STRICLI_NO_COLOR") &&
         (stream.getColorDepth?.(process.env) ?? 1) >= 4
     );
+}
+
+/**
+ * @internal
+ */
+export function shouldUseAnsiColorForStreams(
+    process: StricliProcess,
+    config: DocumentationConfiguration,
+): Record<"stdout" | "stderr", boolean> {
+    return {
+        stdout: shouldUseAnsiColor(process, process.stdout, config),
+        stderr: shouldUseAnsiColor(process, process.stderr, config),
+    };
 }

--- a/packages/core/tests/routing/command.spec.ts
+++ b/packages/core/tests/routing/command.spec.ts
@@ -1875,13 +1875,7 @@ describe("Command", () => {
                     },
                 },
             },
-            documentationConfig: {
-                alwaysShowHelpAllFlag: false,
-                caseStyle: "original",
-                onlyRequiredInUsageLine: false,
-                useAliasInUsageLine: false,
-                disableAnsiColor: true,
-            },
+            ansiColorByStream: { stdout: false, stderr: false },
         };
 
         describe("doNothing (loader returns function)", () => {
@@ -1939,10 +1933,7 @@ describe("Command", () => {
             it("unexpected input argument, with ansi color", async () => {
                 const result = await runWithInputs(command, {
                     ...defaultArgs,
-                    documentationConfig: {
-                        ...defaultArgs.documentationConfig,
-                        disableAnsiColor: false,
-                    },
+                    ansiColorByStream: { stdout: true, stderr: true },
                     inputs: ["foo"],
                 });
                 expect(result).toMatchSnapshot();
@@ -1956,10 +1947,7 @@ describe("Command", () => {
             it("unexpected input flag, with ansi color", async () => {
                 const result = await runWithInputs(command, {
                     ...defaultArgs,
-                    documentationConfig: {
-                        ...defaultArgs.documentationConfig,
-                        disableAnsiColor: false,
-                    },
+                    ansiColorByStream: { stdout: true, stderr: true },
                     inputs: ["--foo"],
                 });
                 expect(result).toMatchSnapshot();
@@ -2020,10 +2008,7 @@ describe("Command", () => {
             it("unexpected error, with ansi color", async () => {
                 const result = await runWithInputs(command, {
                     ...defaultArgs,
-                    documentationConfig: {
-                        ...defaultArgs.documentationConfig,
-                        disableAnsiColor: false,
-                    },
+                    ansiColorByStream: { stdout: true, stderr: true },
                     inputs: [
                         {
                             toString() {
@@ -2043,10 +2028,7 @@ describe("Command", () => {
                 };
                 const result = await runWithInputs(command, {
                     ...defaultArgs,
-                    documentationConfig: {
-                        ...defaultArgs.documentationConfig,
-                        disableAnsiColor: false,
-                    },
+                    ansiColorByStream: { stdout: true, stderr: true },
                     errorFormatting: {
                         ...defaultArgs.errorFormatting,
                         formatException() {
@@ -2109,10 +2091,7 @@ describe("Command", () => {
 
             const result = await runWithInputs(command, {
                 ...defaultArgs,
-                documentationConfig: {
-                    ...defaultArgs.documentationConfig,
-                    disableAnsiColor: false,
-                },
+                ansiColorByStream: { stdout: true, stderr: true },
                 inputs: [],
             });
             expect(result).toMatchSnapshot();
@@ -2172,10 +2151,7 @@ describe("Command", () => {
 
             const result = await runWithInputs(command, {
                 ...defaultArgs,
-                documentationConfig: {
-                    ...defaultArgs.documentationConfig,
-                    disableAnsiColor: false,
-                },
+                ansiColorByStream: { stdout: true, stderr: true },
                 inputs: [],
             });
             expect(result).toMatchSnapshot();
@@ -2195,10 +2171,7 @@ describe("Command", () => {
 
             const result = await runWithInputs(command, {
                 ...defaultArgs,
-                documentationConfig: {
-                    ...defaultArgs.documentationConfig,
-                    disableAnsiColor: false,
-                },
+                ansiColorByStream: { stdout: true, stderr: true },
                 errorFormatting: {
                     ...defaultArgs.errorFormatting,
                     formatException() {
@@ -2237,10 +2210,7 @@ describe("Command", () => {
             it("with default exit code, ansi color", async () => {
                 const result = await runWithInputs(command, {
                     ...defaultArgs,
-                    documentationConfig: {
-                        ...defaultArgs.documentationConfig,
-                        disableAnsiColor: false,
-                    },
+                    ansiColorByStream: { stdout: true, stderr: true },
                     inputs: [],
                 });
                 expect(result).toMatchSnapshot();
@@ -2249,10 +2219,7 @@ describe("Command", () => {
             it("with default exit code, custom exception formatting", async () => {
                 const result = await runWithInputs(command, {
                     ...defaultArgs,
-                    documentationConfig: {
-                        ...defaultArgs.documentationConfig,
-                        disableAnsiColor: false,
-                    },
+                    ansiColorByStream: { stdout: true, stderr: true },
                     errorFormatting: {
                         ...defaultArgs.errorFormatting,
                         formatException() {
@@ -2298,10 +2265,7 @@ describe("Command", () => {
             it("with default exit code, ansi color", async () => {
                 const result = await runWithInputs(command, {
                     ...defaultArgs,
-                    documentationConfig: {
-                        ...defaultArgs.documentationConfig,
-                        disableAnsiColor: false,
-                    },
+                    ansiColorByStream: { stdout: true, stderr: true },
                     inputs: [],
                 });
                 expect(result).toMatchSnapshot();


### PR DESCRIPTION
**Describe your changes**
Calculate whether ANSI color codes should be used for both stdout and stderr once at the start of an application run, and then pass that information through to the necessary functions. This also simplifies the signature for `runCommand` as the resolved ANSI flags can be passed in directly and don't need to be recalculated.

**Testing performed**
Updated the tests to match the new signature from `runCommand` but the behavior is still identical and the tests are functionally unchanged.

**Additional context**
This change was prompted by an incoming enhancement that necessitates passing the ANSI color flag for both streams at once. Practically, it is unlikely for stdout and stderr to have misaligned color depths but this is a direct consequence of how the node API is structured so might as well follow-through.
