### PR TITLE
ci: upgrade actions to deploy docs via pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
               run: npx nx run @stricli/docs:build-docs
 
             - name: Upload Build Artifact
-              uses: actions/upload-pages-artifact@v3
+              uses: actions/upload-pages-artifact@v5
               with:
                   path: docs/build
 
@@ -49,4 +49,4 @@ jobs:
         steps:
             - name: Deploy to GitHub Pages
               id: deployment
-              uses: actions/deploy-pages@v4
+              uses: actions/deploy-pages@v5


### PR DESCRIPTION
**Describe your changes**
Latest run failed: https://github.com/bloomberg/stricli/actions/runs/28611444864

It looks like the deprecations were just warnings, and shouldn't have contributed to the failure but no reason not to upgrade anyway.

**Testing performed**
Unable to test manually due to setup. Double-checked major version changelog for both actions.

