### PR TITLE
ci(publish): explicitly set prerelease=false when making latest release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,4 +39,4 @@ jobs:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                 npx nx release publish
-                gh release edit "v$RELEASE_VERSION" --latest
+                gh release edit "v$RELEASE_VERSION" --prerelease=false --latest


### PR DESCRIPTION
**Describe your changes**
Misinterpreted help text on CLI command. Only non-`prerelease` releases can become `latest`, but setting a release to `latest` does not make it stop being a `prerelease` automatically.
